### PR TITLE
EA settings

### DIFF
--- a/rhp/v2/rhp.go
+++ b/rhp/v2/rhp.go
@@ -250,6 +250,10 @@ func (sh *SessionHandler) Settings() (rhpv2.HostSettings, error) {
 		DownloadBandwidthPrice: settings.MinEgressPrice,
 		UploadBandwidthPrice:   settings.MinIngressPrice,
 
+		// ea settings
+		MaxEphemeralAccountBalance: settings.MaxAccountBalance,
+		EphemeralAccountExpiry:     settings.AccountExpiry,
+
 		RevisionNumber: settings.Revision,
 	}, nil
 }


### PR DESCRIPTION
I noticed the account settings aren't set when converting from the new settings object to the old rhpv2 settings.