### PR TITLE
api,metrics: performance and usability fixes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -42,8 +42,8 @@ type (
 
 	// Metrics retrieves metrics related to the host
 	Metrics interface {
-		// PeriodMetrics returns aggregated metrics for the period between start and end.
-		PeriodMetrics(start, end time.Time, interval metrics.Interval) (period []metrics.Metrics, err error)
+		// PeriodMetrics returns metrics for n periods starting at start.
+		PeriodMetrics(start time.Time, periods int, interval metrics.Interval) (period []metrics.Metrics, err error)
 		// Metrics returns aggregated metrics for the host as of the timestamp.
 		Metrics(time.Time) (m metrics.Metrics, err error)
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -87,11 +88,11 @@ func (c *Client) Metrics(at time.Time) (metrics metrics.Metrics, err error) {
 	return
 }
 
-// PeriodMetrics returns the metrics of the host for the specified period
-func (c *Client) PeriodMetrics(start, end time.Time, interval metrics.Interval) (periods []metrics.Metrics, err error) {
+// PeriodMetrics returns the metrics of the host for n periods starting at start.
+func (c *Client) PeriodMetrics(start time.Time, n int, interval metrics.Interval) (periods []metrics.Metrics, err error) {
 	v := url.Values{
-		"start": []string{start.Format(time.RFC3339)},
-		"end":   []string{end.Format(time.RFC3339)},
+		"start":   []string{start.Format(time.RFC3339)},
+		"periods": []string{strconv.Itoa(n)},
 	}
 	err = c.c.GET("/metrics/"+interval.String()+"?"+v.Encode(), &periods)
 	return

--- a/host/metrics/metrics.go
+++ b/host/metrics/metrics.go
@@ -7,8 +7,8 @@ import (
 type (
 	// A Store retrieves metrics
 	Store interface {
-		// PeriodMetrics returns aggregated metrics for the period between start and end.
-		PeriodMetrics(start, end time.Time, interval Interval) (period []Metrics, err error)
+		// PeriodMetrics returns metrics for n periods starting at start.
+		PeriodMetrics(start time.Time, n int, interval Interval) (period []Metrics, err error)
 		// Metrics returns aggregated metrics for the host as of the timestamp.
 		Metrics(time.Time) (m Metrics, err error)
 	}
@@ -19,9 +19,9 @@ type (
 	}
 )
 
-// PeriodMetrics returns aggregated PeriodMetrics for the period between start and end.
-func (mm *MetricManager) PeriodMetrics(start, end time.Time, interval Interval) (period []Metrics, err error) {
-	return mm.store.PeriodMetrics(start, end, interval)
+// PeriodMetrics returns metrics for n periods starting at start.
+func (mm *MetricManager) PeriodMetrics(start time.Time, periods int, interval Interval) ([]Metrics, error) {
+	return mm.store.PeriodMetrics(start, periods, interval)
 }
 
 // Metrics returns the current metrics for the host.


### PR DESCRIPTION
+ Significantly improves performance of the metrics endpoint when dealing with many periods.
+ Changes usage from `/api/metrics/monthly?start=2023-01-01T00:00:00-06:00&end=2024-01-01T00:00:00-06:00` to `/api/metrics/monthly?start=2023-01-01T00:00:00-06:00&periods=12`