### PR TITLE
Add alerts

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -53,10 +53,10 @@ type (
 		Usage() (usedSectors uint64, totalSectors uint64, err error)
 		Volumes() ([]storage.VolumeMeta, error)
 		Volume(id int) (storage.VolumeMeta, error)
-		AddVolume(localPath string, maxSectors uint64) (storage.Volume, error)
+		AddVolume(localPath string, maxSectors uint64, result chan<- error) (storage.Volume, error)
+		RemoveVolume(id int, force bool, result chan<- error) error
+		ResizeVolume(id int, maxSectors uint64, result chan<- error) error
 		SetReadOnly(id int, readOnly bool) error
-		RemoveVolume(id int, force bool) error
-		ResizeVolume(id int, maxSectors uint64) error
 		RemoveSector(root types.Hash256) error
 	}
 

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -324,7 +324,7 @@ func (a *api) handlePOSTVolume(c jape.Context) {
 		return
 	}
 
-	volume, err := a.volumes.AddVolume(req.LocalPath, req.MaxSectors)
+	volume, err := a.volumes.AddVolume(req.LocalPath, req.MaxSectors, nil)
 	if !a.checkServerError(c, "failed to add volume", err) {
 		return
 	}
@@ -342,7 +342,7 @@ func (a *api) handleDeleteVolume(c jape.Context) {
 	} else if err := c.DecodeForm("force", &force); err != nil {
 		return
 	}
-	err := a.volumes.RemoveVolume(id, force)
+	err := a.volumes.RemoveVolume(id, force, nil)
 	a.checkServerError(c, "failed to remove volume", err)
 }
 
@@ -360,7 +360,7 @@ func (a *api) handlePUTVolumeResize(c jape.Context) {
 		return
 	}
 
-	err := a.volumes.ResizeVolume(id, req.MaxSectors)
+	err := a.volumes.ResizeVolume(id, req.MaxSectors, nil)
 	a.checkServerError(c, "failed to resize volume", err)
 }
 

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -97,6 +97,9 @@ func (a *api) handleDELETEAlerts(c jape.Context) {
 	var req DismissAlertsRequest
 	if err := c.Decode(&req); err != nil {
 		return
+	} else if len(req.IDs) == 0 {
+		c.Error(errors.New("no alerts to dismiss"), http.StatusBadRequest)
+		return
 	}
 	a.alerts.Dismiss(req.IDs...)
 }

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -89,6 +89,18 @@ func (a *api) handleDeleteSyncerPeer(c jape.Context) {
 	a.checkServerError(c, "failed to disconnect from peer", err)
 }
 
+func (a *api) handleGETAlerts(c jape.Context) {
+	c.Encode(a.alerts.Active())
+}
+
+func (a *api) handleDELETEAlerts(c jape.Context) {
+	var req DismissAlertsRequest
+	if err := c.Decode(&req); err != nil {
+		return
+	}
+	a.alerts.Dismiss(req.IDs...)
+}
+
 func (a *api) handlePOSTAnnounce(c jape.Context) {
 	err := a.settings.Announce()
 	a.checkServerError(c, "failed to announce", err)

--- a/api/types.go
+++ b/api/types.go
@@ -56,6 +56,11 @@ type (
 		BuildState
 	}
 
+	// A DismissAlertsRequest is the request body for the [DELETE] /alerts endpoint.
+	DismissAlertsRequest struct {
+		IDs []types.Hash256 `json:"alertIDs"`
+	}
+
 	// ConsensusState is the response body for the [GET] /consensus endpoint.
 	ConsensusState struct {
 		Synced     bool             `json:"synced"`

--- a/cmd/hostd/main.go
+++ b/cmd/hostd/main.go
@@ -171,7 +171,7 @@ func main() {
 	auth := jape.BasicAuth(apiPassword)
 	web := http.Server{
 		Handler: webRouter{
-			api: auth(api.NewServer(hostKey.PublicKey(), node.g, node.cm, node.tp, node.contracts, node.storage, node.metrics, node.store, node.settings, node.w, logger.Named("api"))),
+			api: auth(api.NewServer(hostKey.PublicKey(), node.a, node.g, node.cm, node.tp, node.contracts, node.storage, node.metrics, node.store, node.settings, node.w, logger.Named("api"))),
 			ui:  createUIHandler(),
 		},
 		ReadTimeout: 30 * time.Second,

--- a/cmd/hostd/node.go
+++ b/cmd/hostd/node.go
@@ -12,6 +12,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/chain"
 	"go.sia.tech/hostd/host/accounts"
+	"go.sia.tech/hostd/host/alerts"
 	"go.sia.tech/hostd/host/contracts"
 	"go.sia.tech/hostd/host/metrics"
 	"go.sia.tech/hostd/host/registry"
@@ -245,8 +246,8 @@ func newNode(gatewayAddr, rhp2Addr, rhp3Addr, dir string, bootstrap bool, wallet
 	}
 
 	accountManager := accounts.NewManager(db, sr)
-
-	sm, err := storage.NewVolumeManager(db, cm, logger.Named("volumes"))
+	am := alerts.NewManager()
+	sm, err := storage.NewVolumeManager(db, am, cm, logger.Named("volumes"))
 	if err != nil {
 		return nil, types.PrivateKey{}, fmt.Errorf("failed to create storage manager: %w", err)
 	}

--- a/cmd/hostd/node.go
+++ b/cmd/hostd/node.go
@@ -253,7 +253,7 @@ func newNode(gatewayAddr, rhp2Addr, rhp3Addr, dir string, bootstrap bool, wallet
 		return nil, types.PrivateKey{}, fmt.Errorf("failed to create storage manager: %w", err)
 	}
 
-	contractManager, err := contracts.NewManager(db, sm, cm, tp, w, logger.Named("contracts"))
+	contractManager, err := contracts.NewManager(db, am, sm, cm, tp, w, logger.Named("contracts"))
 	if err != nil {
 		return nil, types.PrivateKey{}, fmt.Errorf("failed to create contract manager: %w", err)
 	}

--- a/cmd/hostd/node.go
+++ b/cmd/hostd/node.go
@@ -111,6 +111,7 @@ func (tp txpool) Close() error {
 
 type node struct {
 	g     modules.Gateway
+	a     *alerts.Manager
 	cm    *chain.Manager
 	tp    *txpool
 	w     *wallet.SingleAddressWallet
@@ -272,6 +273,7 @@ func newNode(gatewayAddr, rhp2Addr, rhp3Addr, dir string, bootstrap bool, wallet
 
 	return &node{
 		g:     g,
+		a:     am,
 		cm:    cm,
 		tp:    tp,
 		w:     w,

--- a/host/alerts/alerts.go
+++ b/host/alerts/alerts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"go.sia.tech/core/types"
 )
@@ -38,7 +39,8 @@ type (
 		Message string `json:"message"`
 		// Data is a map of arbitrary data that can be used to provide
 		// additional context to the alert.
-		Data map[string]any `json:"data,omitempty"`
+		Data      map[string]any `json:"data,omitempty"`
+		Timestamp time.Time      `json:"timestamp"`
 	}
 
 	// A Manager manages the host's alerts.
@@ -92,6 +94,8 @@ func (s *Severity) UnmarshalJSON(b []byte) error {
 func (m *Manager) Register(a Alert) {
 	if a.ID == (types.Hash256{}) {
 		panic("cannot register alert with empty ID") // developer error
+	} else if a.Timestamp.IsZero() {
+		a.Timestamp = time.Now() // set timestamp to now if not set
 	}
 
 	m.mu.Lock()

--- a/host/alerts/alerts.go
+++ b/host/alerts/alerts.go
@@ -25,6 +25,7 @@ const (
 )
 
 type (
+	// Severity indicates the severity of an alert.
 	Severity uint8
 
 	// An Alert is a dismissible message that is displayed to the user.
@@ -107,8 +108,8 @@ func (m *Manager) Dismiss(ids ...types.Hash256) {
 	m.mu.Unlock()
 }
 
-// Alerts returns the host's current alerts.
-func (m *Manager) Alerts() []Alert {
+// Active returns the host's active alerts.
+func (m *Manager) Active() []Alert {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/host/alerts/alerts.go
+++ b/host/alerts/alerts.go
@@ -2,6 +2,7 @@ package alerts
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -95,7 +96,7 @@ func (m *Manager) Register(a Alert) {
 	if a.ID == (types.Hash256{}) {
 		panic("cannot register alert with empty ID") // developer error
 	} else if a.Timestamp.IsZero() {
-		a.Timestamp = time.Now() // set timestamp to now if not set
+		panic("cannot register alert with zero timestamp") // developer error
 	}
 
 	m.mu.Lock()
@@ -121,6 +122,9 @@ func (m *Manager) Active() []Alert {
 	for _, a := range m.alerts {
 		alerts = append(alerts, a)
 	}
+	sort.Slice(alerts, func(i, j int) bool {
+		return alerts[i].Timestamp.After(alerts[j].Timestamp)
+	})
 	return alerts
 }
 

--- a/host/alerts/alerts.go
+++ b/host/alerts/alerts.go
@@ -1,0 +1,127 @@
+package alerts
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"go.sia.tech/core/types"
+)
+
+const (
+	// SeverityInfo indicates that the alert is informational.
+	SeverityInfo Severity = iota + 1
+	// SeverityWarning indicates that the alert is a warning.
+	SeverityWarning
+	// SeverityError indicates that the alert is an error.
+	SeverityError
+	// SeverityCritical indicates that the alert is critical.
+	SeverityCritical
+
+	severityInfoStr     = "info"
+	severityWarningStr  = "warning"
+	severityErrorStr    = "error"
+	severityCriticalStr = "critical"
+)
+
+type (
+	Severity uint8
+
+	// An Alert is a dismissible message that is displayed to the user.
+	Alert struct {
+		// ID is a unique identifier for the alert.
+		ID types.Hash256 `json:"id"`
+		// Severity is the severity of the alert.
+		Severity Severity `json:"severity"`
+		// Message is a human-readable message describing the alert.
+		Message string `json:"message"`
+		// Data is a map of arbitrary data that can be used to provide
+		// additional context to the alert.
+		Data map[string]any `json:"data,omitempty"`
+	}
+
+	// A Manager manages the host's alerts.
+	Manager struct {
+		mu sync.Mutex
+		// alerts is a map of alert IDs to their current alert.
+		alerts map[types.Hash256]Alert
+	}
+)
+
+// String implements the fmt.Stringer interface.
+func (s Severity) String() string {
+	switch s {
+	case SeverityInfo:
+		return severityInfoStr
+	case SeverityWarning:
+		return severityWarningStr
+	case SeverityError:
+		return severityErrorStr
+	case SeverityCritical:
+		return severityCriticalStr
+	default:
+		panic(fmt.Sprintf("unrecognized severity %d", s))
+	}
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (s Severity) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`%q`, s.String())), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (s *Severity) UnmarshalJSON(b []byte) error {
+	status := strings.Trim(string(b), `"`)
+	switch status {
+	case severityInfoStr:
+		*s = SeverityInfo
+	case severityWarningStr:
+		*s = SeverityWarning
+	case severityErrorStr:
+		*s = SeverityError
+	case severityCriticalStr:
+		*s = SeverityCritical
+	default:
+		return fmt.Errorf("unrecognized severity: %v", status)
+	}
+	return nil
+}
+
+// Register registers a new alert with the manager
+func (m *Manager) Register(a Alert) {
+	if a.ID == (types.Hash256{}) {
+		panic("cannot register alert with empty ID") // developer error
+	}
+
+	m.mu.Lock()
+	m.alerts[a.ID] = a
+	m.mu.Unlock()
+}
+
+// Dismiss removes the alerts with the given IDs.
+func (m *Manager) Dismiss(ids ...types.Hash256) {
+	m.mu.Lock()
+	for _, id := range ids {
+		delete(m.alerts, id)
+	}
+	m.mu.Unlock()
+}
+
+// Alerts returns the host's current alerts.
+func (m *Manager) Alerts() []Alert {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	alerts := make([]Alert, 0, len(m.alerts))
+	for _, a := range m.alerts {
+		alerts = append(alerts, a)
+	}
+	return alerts
+}
+
+// NewManager initializes a new alerts manager.
+func NewManager() *Manager {
+	return &Manager{
+		alerts: make(map[types.Hash256]Alert),
+	}
+}

--- a/host/contracts/integrity_test.go
+++ b/host/contracts/integrity_test.go
@@ -44,7 +44,7 @@ func TestCheckIntegrity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err := contracts.NewManager(node.Store(), s, node.ChainManager(), node.TPool(), node, log.Named("contracts"))
+	c, err := contracts.NewManager(node.Store(), am, s, node.ChainManager(), node.TPool(), node, log.Named("contracts"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/host/contracts/manager_test.go
+++ b/host/contracts/manager_test.go
@@ -11,6 +11,7 @@ import (
 
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
+	"go.sia.tech/hostd/host/alerts"
 	"go.sia.tech/hostd/host/contracts"
 	"go.sia.tech/hostd/host/storage"
 	"go.sia.tech/hostd/internal/test"
@@ -101,7 +102,8 @@ func TestContractLockUnlock(t *testing.T) {
 	}
 	defer node.Close()
 
-	s, err := storage.NewVolumeManager(db, node.ChainManager(), log.Named("storage"))
+	am := alerts.NewManager()
+	s, err := storage.NewVolumeManager(db, am, node.ChainManager(), log.Named("storage"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,13 +180,17 @@ func TestContractLifecycle(t *testing.T) {
 	}
 	defer node.Close()
 
-	s, err := storage.NewVolumeManager(node.Store(), node.ChainManager(), log.Named("storage"))
+	am := alerts.NewManager()
+	s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer s.Close()
 
-	if _, err := s.AddVolume(filepath.Join(dir, "data.dat"), 10); err != nil {
+	result := make(chan error, 1)
+	if _, err := s.AddVolume(filepath.Join(dir, "data.dat"), 10, result); err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
 

--- a/host/contracts/manager_test.go
+++ b/host/contracts/manager_test.go
@@ -109,7 +109,7 @@ func TestContractLockUnlock(t *testing.T) {
 	}
 	defer s.Close()
 
-	c, err := contracts.NewManager(db, s, node.ChainManager(), node.TPool(), node, log.Named("contracts"))
+	c, err := contracts.NewManager(db, am, s, node.ChainManager(), node.TPool(), node, log.Named("contracts"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +194,7 @@ func TestContractLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err := contracts.NewManager(node.Store(), s, node.ChainManager(), node.TPool(), node, log.Named("contracts"))
+	c, err := contracts.NewManager(node.Store(), am, s, node.ChainManager(), node.TPool(), node, log.Named("contracts"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/host/storage/storage.go
+++ b/host/storage/storage.go
@@ -385,7 +385,7 @@ func (vm *VolumeManager) setVolumeStatus(id int, status string) {
 	v.stats.Status = status
 }
 
-func (vm *VolumeManager) resizeVolume(volumeID int, current, target uint64) error {
+func (vm *VolumeManager) doResize(volumeID int, current, target uint64) error {
 	ctx, cancel, err := vm.tg.AddContext(context.Background())
 	if err != nil {
 		return err
@@ -582,7 +582,7 @@ func (vm *VolumeManager) AddVolume(localPath string, maxSectors uint64, result c
 
 		log := vm.log.Named("initialize").With(zap.Int("volumeID", volumeID), zap.Uint64("maxSectors", maxSectors))
 		start := time.Now()
-		err := vm.resizeVolume(volumeID, 0, maxSectors)
+		err := vm.doResize(volumeID, 0, maxSectors)
 		if err != nil {
 			vm.a.Register(alerts.Alert{
 				ID:       frand.Entropy256(),
@@ -787,7 +787,7 @@ func (vm *VolumeManager) ResizeVolume(id int, maxSectors uint64, result chan<- e
 		defer release()
 
 		start := time.Now()
-		if err := vm.resizeVolume(id, vol.TotalSectors, maxSectors); err != nil {
+		if err := vm.doResize(id, vol.TotalSectors, maxSectors); err != nil {
 			log.Error("failed to resize volume", zap.Error(err))
 			vm.a.Register(alerts.Alert{
 				ID:       frand.Entropy256(),

--- a/host/storage/storage.go
+++ b/host/storage/storage.go
@@ -244,6 +244,7 @@ func (vm *VolumeManager) growVolume(ctx context.Context, id int, oldMaxSectors, 
 			"currentSectors": oldMaxSectors,
 			"targetSectors":  newMaxSectors,
 		},
+		Timestamp: time.Now(),
 	}
 	vm.a.Register(alert)
 	// dismiss the alert when the function returns. It is the caller's
@@ -304,6 +305,7 @@ func (vm *VolumeManager) shrinkVolume(ctx context.Context, id int, oldMaxSectors
 			"targetSectors":   newMaxSectors,
 			"migratedSectors": 0,
 		},
+		Timestamp: time.Now(),
 	}
 	vm.a.Register(a)
 	// dismiss the alert when the function returns. It is the caller's
@@ -420,6 +422,7 @@ func (vm *VolumeManager) migrateForRemoval(id int, localPath string, force bool,
 			"migrated": 0,
 			"force":    force,
 		},
+		Timestamp: time.Now(),
 	}
 	vm.a.Register(a)
 	// dismiss the alert when the function returns. It is the caller's
@@ -593,6 +596,7 @@ func (vm *VolumeManager) AddVolume(localPath string, maxSectors uint64, result c
 					"error":    err.Error(),
 					"elapsed":  time.Since(start),
 				},
+				Timestamp: time.Now(),
 			})
 			log.Error("failed to initialize volume", zap.Error(err))
 			select {
@@ -610,6 +614,7 @@ func (vm *VolumeManager) AddVolume(localPath string, maxSectors uint64, result c
 				"volumeID": volumeID,
 				"elapsed":  time.Since(start),
 			},
+			Timestamp: time.Now(),
 		})
 		log.Info("volume initialized")
 		select {
@@ -688,6 +693,7 @@ func (vm *VolumeManager) RemoveVolume(id int, force bool, result chan<- error) e
 						"error":    err.Error(),
 						"elapsed":  time.Since(start),
 					},
+					Timestamp: time.Now(),
 				})
 				select {
 				case result <- err:
@@ -714,6 +720,7 @@ func (vm *VolumeManager) RemoveVolume(id int, force bool, result chan<- error) e
 					"error":    err.Error(),
 					"elapsed":  time.Since(start),
 				},
+				Timestamp: time.Now(),
 			})
 			select {
 			case result <- err:
@@ -732,6 +739,7 @@ func (vm *VolumeManager) RemoveVolume(id int, force bool, result chan<- error) e
 					"error":    err.Error(),
 					"elapsed":  time.Since(start),
 				},
+				Timestamp: time.Now(),
 			})
 			log.Error("failed to remove volume", zap.Error(err))
 			select {
@@ -800,6 +808,7 @@ func (vm *VolumeManager) ResizeVolume(id int, maxSectors uint64, result chan<- e
 					"targetSectors":  maxSectors,
 					"currentSectors": vol.TotalSectors,
 				},
+				Timestamp: time.Now(),
 			})
 			select {
 			case result <- err:
@@ -818,6 +827,7 @@ func (vm *VolumeManager) ResizeVolume(id int, maxSectors uint64, result chan<- e
 				"targetSectors":  maxSectors,
 				"currentSectors": vol.TotalSectors,
 			},
+			Timestamp: time.Now(),
 		})
 		select {
 		case result <- nil:

--- a/host/storage/storage.go
+++ b/host/storage/storage.go
@@ -11,8 +11,10 @@ import (
 	"go.sia.tech/core/consensus"
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
+	"go.sia.tech/hostd/host/alerts"
 	"go.sia.tech/hostd/internal/threadgroup"
 	"go.uber.org/zap"
+	"lukechampine.com/frand"
 )
 
 const (
@@ -31,6 +33,12 @@ const (
 )
 
 type (
+	// Alerts can be used to register alerts.
+	Alerts interface {
+		Register(alerts.Alert)
+		Dismiss(...types.Hash256)
+	}
+
 	// A ChainManager is used to get the current consensus state.
 	ChainManager interface {
 		TipState() consensus.State
@@ -54,6 +62,7 @@ type (
 
 	// A VolumeManager manages storage using local volumes.
 	VolumeManager struct {
+		a        Alerts
 		vs       VolumeStore
 		cm       ChainManager
 		log      *zap.Logger
@@ -224,6 +233,23 @@ func (vm *VolumeManager) growVolume(ctx context.Context, id int, oldMaxSectors, 
 		return fmt.Errorf("failed to get volume: %w", err)
 	}
 
+	// register an alert
+	alert := alerts.Alert{
+		ID:       frand.Entropy256(),
+		Message:  "Growing volume",
+		Severity: alerts.SeverityInfo,
+		Data: map[string]any{
+			"volumeID":       id,
+			"oldSectors":     oldMaxSectors,
+			"currentSectors": oldMaxSectors,
+			"targetSectors":  newMaxSectors,
+		},
+	}
+	vm.a.Register(alert)
+	// dismiss the alert when the function returns. It is the caller's
+	// responsibility to register a completion alert
+	defer vm.a.Dismiss(alert.ID)
+
 	for current := oldMaxSectors; current < newMaxSectors; current += resizeBatchSize {
 		// stop early if the context is cancelled
 		select {
@@ -244,6 +270,11 @@ func (vm *VolumeManager) growVolume(ctx context.Context, id int, oldMaxSectors, 
 		} else if err := vm.vs.GrowVolume(id, target); err != nil {
 			return fmt.Errorf("failed to expand volume metadata: %w", err)
 		}
+
+		// update the alert
+		alert.Data["currentSectors"] = target
+		vm.a.Register(alert)
+		// sleep to allow other operations to run
 		time.Sleep(time.Millisecond)
 	}
 	return nil
@@ -261,8 +292,26 @@ func (vm *VolumeManager) shrinkVolume(ctx context.Context, id int, oldMaxSectors
 		return fmt.Errorf("failed to get volume: %w", err)
 	}
 
+	// register the alert
+	a := alerts.Alert{
+		ID:       frand.Entropy256(),
+		Message:  "Shrinking volume",
+		Severity: alerts.SeverityInfo,
+		Data: map[string]any{
+			"volumeID":        id,
+			"oldSectors":      oldMaxSectors,
+			"currentSectors":  oldMaxSectors,
+			"targetSectors":   newMaxSectors,
+			"migratedSectors": 0,
+		},
+	}
+	vm.a.Register(a)
+	// dismiss the alert when the function returns. It is the caller's
+	// responsibility to register a completion alert
+	defer vm.a.Dismiss(a.ID)
+
 	// migrate any sectors outside of the target range. migrateSectors will be
-	// called on chunks of 256 sectors
+	// called on chunks of 64 sectors
 	var migrated int
 	err = vm.vs.MigrateSectors(id, newMaxSectors, func(newLocations []SectorLocation) error {
 		select {
@@ -273,6 +322,9 @@ func (vm *VolumeManager) shrinkVolume(ctx context.Context, id int, oldMaxSectors
 
 		n, err := vm.migrateSectors(newLocations, false, log.Named("migrateSectors"))
 		migrated += n
+		// update the alert
+		a.Data["migratedSectors"] = migrated
+		vm.a.Register(a)
 		return err
 	})
 	log.Info("migrated sectors", zap.Int("count", migrated))
@@ -303,6 +355,10 @@ func (vm *VolumeManager) shrinkVolume(ctx context.Context, id int, oldMaxSectors
 		} else if err := volume.Resize(target); err != nil {
 			return fmt.Errorf("failed to shrink volume data to %v sectors: %w", target, err)
 		}
+		// update the alert
+		a.Data["currentSectors"] = target
+		vm.a.Register(a)
+		// sleep to allow other operations to run
 		time.Sleep(time.Millisecond)
 	}
 	return nil
@@ -327,6 +383,70 @@ func (vm *VolumeManager) setVolumeStatus(id int, status string) {
 		return
 	}
 	v.stats.Status = status
+}
+
+func (vm *VolumeManager) resizeVolume(volumeID int, current, target uint64) error {
+	ctx, cancel, err := vm.tg.AddContext(context.Background())
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	switch {
+	case current > target:
+		// volume is shrinking
+		return vm.shrinkVolume(ctx, volumeID, current, target)
+	case current < target:
+		// volume is growing
+		return vm.growVolume(ctx, volumeID, current, target)
+	}
+	return nil
+}
+
+func (vm *VolumeManager) migrateForRemoval(id int, localPath string, force bool, log *zap.Logger) (int, error) {
+	ctx, cancel, err := vm.tg.AddContext(context.Background())
+	if err != nil {
+		return 0, err
+	}
+	defer cancel()
+
+	// add an alert for the migration
+	a := alerts.Alert{
+		ID:       frand.Entropy256(),
+		Message:  "Migrating sectors",
+		Severity: alerts.SeverityInfo,
+		Data: map[string]interface{}{
+			"volumeID": id,
+			"migrated": 0,
+			"force":    force,
+		},
+	}
+	vm.a.Register(a)
+	// dismiss the alert when the function returns. It is the caller's
+	// responsibility to register a completion alert
+	defer vm.a.Dismiss(a.ID)
+
+	// migrate sectors to other volumes
+	var migrated int
+	err = vm.vs.MigrateSectors(id, 0, func(locations []SectorLocation) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		n, err := vm.migrateSectors(locations, force, log.Named("migrateSectors"))
+		migrated += n
+		// update the alert
+		a.Data["migrated"] = migrated
+		vm.a.Register(a)
+		return err
+	})
+	if err != nil && !force {
+		return migrated, fmt.Errorf("failed to migrate sector data: %w", err)
+	} else if err := vm.vs.RemoveVolume(id, force); err != nil {
+		return migrated, fmt.Errorf("failed to remove volume: %w", err)
+	}
+	return migrated, nil
 }
 
 // Close gracefully shutsdown the volume manager.
@@ -410,16 +530,16 @@ func (vm *VolumeManager) Volume(id int) (VolumeMeta, error) {
 }
 
 // AddVolume adds a new volume to the storage manager
-func (vm *VolumeManager) AddVolume(localPath string, maxSectors uint64) (Volume, error) {
+func (vm *VolumeManager) AddVolume(localPath string, maxSectors uint64, result chan<- error) (Volume, error) {
 	if maxSectors == 0 {
 		return Volume{}, errors.New("max sectors must be greater than 0")
 	}
 
-	ctx, cancel, err := vm.tg.AddContext(context.Background())
+	done, err := vm.tg.Add()
 	if err != nil {
 		return Volume{}, err
 	}
-	defer cancel()
+	defer done()
 
 	// check that the volume file does not already exist
 	if _, err := os.Stat(localPath); !errors.Is(err, os.ErrNotExist) {
@@ -448,21 +568,55 @@ func (vm *VolumeManager) AddVolume(localPath string, maxSectors uint64) (Volume,
 		},
 	}
 	vm.mu.Unlock()
-	defer vm.setVolumeStatus(volumeID, VolumeStatusReady)
 
 	// lock the volume during grow operation
 	release, err := vm.lockVolume(volumeID)
 	if err != nil {
 		return Volume{}, fmt.Errorf("failed to lock volume: %w", err)
 	}
-	defer release()
 
-	// grow the volume to the desired size
-	if err := vm.growVolume(ctx, volumeID, 0, maxSectors); err != nil {
-		return Volume{}, fmt.Errorf("failed to grow volume: %w", err)
-	} else if err := vm.vs.SetAvailable(volumeID, true); err != nil {
-		return Volume{}, fmt.Errorf("failed to set volume available: %w", err)
-	}
+	go func() {
+		defer vm.vs.SetAvailable(volumeID, true)
+		defer vm.setVolumeStatus(volumeID, VolumeStatusReady)
+		defer release()
+
+		log := vm.log.Named("initialize").With(zap.Int("volumeID", volumeID), zap.Uint64("maxSectors", maxSectors))
+		start := time.Now()
+		err := vm.resizeVolume(volumeID, 0, maxSectors)
+		if err != nil {
+			vm.a.Register(alerts.Alert{
+				ID:       frand.Entropy256(),
+				Message:  "Unable to initialize volume",
+				Severity: alerts.SeverityError,
+				Data: map[string]interface{}{
+					"volumeID": volumeID,
+					"error":    err.Error(),
+					"elapsed":  time.Since(start),
+				},
+			})
+			log.Error("failed to initialize volume", zap.Error(err))
+			select {
+			case result <- err:
+			default:
+			}
+			return
+		}
+
+		vm.a.Register(alerts.Alert{
+			ID:       frand.Entropy256(),
+			Message:  "Volume initialized",
+			Severity: alerts.SeverityInfo,
+			Data: map[string]interface{}{
+				"volumeID": volumeID,
+				"elapsed":  time.Since(start),
+			},
+		})
+		log.Info("volume initialized")
+		select {
+		case result <- nil:
+		default:
+		}
+	}()
 	return vm.vs.Volume(volumeID)
 }
 
@@ -487,113 +641,190 @@ func (vm *VolumeManager) SetReadOnly(id int, readOnly bool) error {
 }
 
 // RemoveVolume removes a volume from the manager.
-func (vm *VolumeManager) RemoveVolume(id int, force bool) error {
-	log := vm.log.Named("removeVolume").With(zap.Int("volumeID", id))
-	ctx, cancel, err := vm.tg.AddContext(context.Background())
+func (vm *VolumeManager) RemoveVolume(id int, force bool, result chan<- error) error {
+	log := vm.log.Named("remove").With(zap.Int("volumeID", id))
+	done, err := vm.tg.Add()
 	if err != nil {
 		return err
 	}
-	defer cancel()
+	defer done()
 
 	// lock the volume during removal to prevent concurrent operations
 	release, err := vm.lockVolume(id)
 	if err != nil {
 		return fmt.Errorf("failed to lock volume: %w", err)
 	}
-	defer release()
 
 	vol, err := vm.vs.Volume(id)
 	if err != nil {
+		release()
 		return fmt.Errorf("failed to get volume: %w", err)
 	}
 
 	// set the volume to read-only to prevent new sectors from being added
 	if err := vm.vs.SetReadOnly(id, true); err != nil {
+		release()
 		return fmt.Errorf("failed to set volume %v to read-only: %w", id, err)
 	}
-	vm.setVolumeStatus(id, VolumeStatusRemoving)
-	defer vm.setVolumeStatus(id, VolumeStatusUnavailable)
 
-	// migrate sectors to other volumes
-	var migrated int
-	err = vm.vs.MigrateSectors(id, 0, func(locations []SectorLocation) error {
+	go func() {
+		vm.setVolumeStatus(id, VolumeStatusRemoving)
+		defer vm.setVolumeStatus(id, VolumeStatusUnavailable)
+		defer release()
+
+		start := time.Now()
+
+		migrated, err := vm.migrateForRemoval(id, vol.LocalPath, force, log)
+		log.Info("migrated sectors", zap.Int("count", migrated))
+		if err != nil {
+			log.Error("failed to migrate data", zap.Error(err))
+			if !force {
+				vm.a.Register(alerts.Alert{
+					ID:       frand.Entropy256(),
+					Severity: alerts.SeverityError,
+					Message:  "Removal failed, unable to migrate sectors",
+					Data: map[string]interface{}{
+						"volumeID": id,
+						"error":    err.Error(),
+						"elapsed":  time.Since(start),
+					},
+				})
+				select {
+				case result <- err:
+				default:
+				}
+				return
+			}
+		}
+
+		vm.mu.Lock()
+		defer vm.mu.Unlock()
+		// close the volume
+		vm.volumes[id].Close()
+		// delete the volume from memory
+		delete(vm.volumes, id)
+		// remove the volume file, ignore error if the file does not exist
+		if err := os.Remove(vol.LocalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			vm.a.Register(alerts.Alert{
+				ID:       frand.Entropy256(),
+				Severity: alerts.SeverityError,
+				Message:  "Removal failed, unable to remove volume file",
+				Data: map[string]interface{}{
+					"volumeID": id,
+					"error":    err.Error(),
+					"elapsed":  time.Since(start),
+				},
+			})
+			select {
+			case result <- err:
+			default:
+			}
+			log.Error("failed to remove volume file", zap.Error(err))
+		}
+
+		if err := vm.vs.RemoveVolume(id, force); err != nil {
+			vm.a.Register(alerts.Alert{
+				ID:       frand.Entropy256(),
+				Severity: alerts.SeverityError,
+				Message:  "Removal failed, unable to remove volume",
+				Data: map[string]interface{}{
+					"volumeID": id,
+					"error":    err.Error(),
+					"elapsed":  time.Since(start),
+				},
+			})
+			log.Error("failed to remove volume", zap.Error(err))
+			select {
+			case result <- err:
+			default:
+			}
+		}
+
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
+		case result <- nil:
 		default:
 		}
-		n, err := vm.migrateSectors(locations, force, log.Named("migrateSectors"))
-		migrated += n
-		return err
-	})
-	log.Debug("migrated sectors", zap.Int("count", migrated))
-	if err != nil && !force {
-		return fmt.Errorf("failed to migrate sector data: %w", err)
-	} else if err := vm.vs.RemoveVolume(id, force); err != nil {
-		return fmt.Errorf("failed to remove volume: %w", err)
-	}
-	vm.mu.Lock()
-	defer vm.mu.Unlock()
-	// close the volume
-	vm.volumes[id].Close()
-	// delete the volume from memory
-	delete(vm.volumes, id)
-	// remove the volume file, ignore error if the file does not exist
-	if err := os.Remove(vol.LocalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("failed to remove volume file: %w", err)
-	}
+	}()
 	return nil
 }
 
 // ResizeVolume resizes a volume to the specified size.
-func (vm *VolumeManager) ResizeVolume(id int, maxSectors uint64) error {
-	ctx, cancel, err := vm.tg.AddContext(context.Background())
+func (vm *VolumeManager) ResizeVolume(id int, maxSectors uint64, result chan<- error) error {
+	done, err := vm.tg.Add()
 	if err != nil {
 		return err
 	}
-	defer cancel()
+	defer done()
 
 	release, err := vm.lockVolume(id)
 	if err != nil {
 		return fmt.Errorf("failed to lock volume: %w", err)
 	}
-	defer release()
+	vm.setVolumeStatus(id, VolumeStatusResizing)
 
 	vol, err := vm.vs.Volume(id)
 	if err != nil {
+		release()
 		return fmt.Errorf("failed to get volume: %w", err)
 	}
-
-	vm.setVolumeStatus(id, VolumeStatusResizing)
-	defer vm.setVolumeStatus(id, VolumeStatusReady)
 
 	oldReadonly := vol.ReadOnly
 	// set the volume to read-only to prevent new sectors from being added
 	if err := vm.vs.SetReadOnly(id, true); err != nil {
+		release()
 		return fmt.Errorf("failed to set volume %v to read-only: %w", id, err)
 	}
 
-	defer func() {
-		// restore the volume to its original read-only status
-		if err := vm.vs.SetReadOnly(id, oldReadonly); err != nil {
-			vm.log.Named("resize").Error("failed to restore volume read-only status", zap.Error(err), zap.Int("volumeID", id))
+	go func() {
+		log := vm.log.Named("resize").With(zap.Int("volumeID", id))
+		defer func() {
+			// restore the volume to its original read-only status
+			if err := vm.vs.SetReadOnly(id, oldReadonly); err != nil {
+				log.Error("failed to restore volume read-only status", zap.Error(err))
+			}
+			vm.setVolumeStatus(id, VolumeStatusReady)
+		}()
+		defer release()
+
+		start := time.Now()
+		if err := vm.resizeVolume(id, vol.TotalSectors, maxSectors); err != nil {
+			log.Error("failed to resize volume", zap.Error(err))
+			vm.a.Register(alerts.Alert{
+				ID:       frand.Entropy256(),
+				Severity: alerts.SeverityError,
+				Message:  "Unable to resize volume",
+				Data: map[string]any{
+					"volumeID":       id,
+					"error":          err.Error(),
+					"elapsed":        time.Since(start),
+					"targetSectors":  maxSectors,
+					"currentSectors": vol.TotalSectors,
+				},
+			})
+			select {
+			case result <- err:
+			default:
+			}
+			return
+		}
+
+		vm.a.Register(alerts.Alert{
+			ID:       frand.Entropy256(),
+			Severity: alerts.SeverityInfo,
+			Message:  "Volume resized",
+			Data: map[string]any{
+				"volumeID":       id,
+				"elapsed":        time.Since(start),
+				"targetSectors":  maxSectors,
+				"currentSectors": vol.TotalSectors,
+			},
+		})
+		select {
+		case result <- nil:
+		default:
 		}
 	}()
 
-	if vol.TotalSectors == maxSectors {
-		// volume is the same size, nothing to do
-		return nil
-	} else if vol.TotalSectors > maxSectors {
-		// volume is shrinking
-		if err := vm.shrinkVolume(ctx, id, vol.TotalSectors, maxSectors); err != nil {
-			return fmt.Errorf("failed to shrink volume to %v sectors: %w", maxSectors, err)
-		}
-		return nil
-	}
-	// volume is growing
-	if err := vm.growVolume(ctx, id, vol.TotalSectors, maxSectors); err != nil {
-		return fmt.Errorf("failed to grow volume: %w", err)
-	}
 	return nil
 }
 
@@ -764,9 +995,10 @@ func (vm *VolumeManager) PruneSectors() error {
 }
 
 // NewVolumeManager creates a new VolumeManager.
-func NewVolumeManager(vs VolumeStore, cm ChainManager, log *zap.Logger) (*VolumeManager, error) {
+func NewVolumeManager(vs VolumeStore, a Alerts, cm ChainManager, log *zap.Logger) (*VolumeManager, error) {
 	vm := &VolumeManager{
 		vs:  vs,
+		a:   a,
 		cm:  cm,
 		log: log,
 		recorder: &sectorAccessRecorder{

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -656,7 +656,6 @@ func TestVolumeShrink(t *testing.T) {
 		t.Fatal(err)
 	} else if err := <-result; err != nil {
 		t.Fatal(err)
-
 	}
 
 	volume, err := vm.Volume(vol.ID)

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -3,7 +3,6 @@ package storage_test
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/chain"
+	"go.sia.tech/hostd/host/alerts"
 	"go.sia.tech/hostd/host/storage"
 	"go.sia.tech/hostd/persist/sqlite"
 	"go.sia.tech/siad/modules/consensus"
@@ -61,14 +61,18 @@ func TestVolumeLoad(t *testing.T) {
 	defer cm.Close()
 	defer cm.Close()
 
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer vm.Close()
 
-	volume, err := vm.AddVolume(filepath.Join(t.TempDir(), "hostdata.dat"), expectedSectors)
+	result := make(chan error, 1)
+	volume, err := vm.AddVolume(filepath.Join(t.TempDir(), "hostdata.dat"), expectedSectors, result)
 	if err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
 
@@ -88,7 +92,7 @@ func TestVolumeLoad(t *testing.T) {
 	}
 
 	// reopen the volume manager
-	vm, err = storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	vm, err = storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,14 +163,18 @@ func TestAddVolume(t *testing.T) {
 	defer cm.Close()
 	defer cm.Close()
 
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer vm.Close()
 
-	volume, err := vm.AddVolume(filepath.Join(t.TempDir(), "hostdata.dat"), expectedSectors)
+	result := make(chan error, 1)
+	volume, err := vm.AddVolume(filepath.Join(t.TempDir(), "hostdata.dat"), expectedSectors, result)
 	if err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
 
@@ -224,15 +232,19 @@ func TestRemoveVolume(t *testing.T) {
 	defer cm.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer vm.Close()
 
+	result := make(chan error, 1)
 	volumePath := filepath.Join(t.TempDir(), "hostdata.dat")
-	volume, err := vm.AddVolume(volumePath, expectedSectors)
+	volume, err := vm.AddVolume(volumePath, expectedSectors, result)
 	if err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
 
@@ -251,7 +263,11 @@ func TestRemoveVolume(t *testing.T) {
 
 	// attempt to remove the volume. Should return ErrNotEnoughStorage since
 	// there is only one volume.
-	if err := vm.RemoveVolume(volume.ID, false); !errors.Is(err, storage.ErrNotEnoughStorage) {
+	if err := vm.RemoveVolume(volume.ID, false, result); err != nil {
+		// blocking error should be nil
+		t.Fatal(err)
+	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
+		// async error should be ErrNotEnoughStorage
 		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
 
@@ -261,7 +277,9 @@ func TestRemoveVolume(t *testing.T) {
 	}
 
 	// remove the volume
-	if err := vm.RemoveVolume(volume.ID, false); err != nil {
+	if err := vm.RemoveVolume(volume.ID, false, result); err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	} else if _, err := os.Stat(volumePath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatal("volume file still exists", err)
@@ -302,15 +320,19 @@ func TestRemoveCorrupt(t *testing.T) {
 	defer cm.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer vm.Close()
 
+	result := make(chan error, 1)
 	volumePath := filepath.Join(t.TempDir(), "hostdata.dat")
-	volume, err := vm.AddVolume(volumePath, expectedSectors)
+	volume, err := vm.AddVolume(volumePath, expectedSectors, result)
 	if err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
 
@@ -331,13 +353,19 @@ func TestRemoveCorrupt(t *testing.T) {
 
 	// attempt to remove the volume. Should return ErrNotEnoughStorage since
 	// there is only one volume.
-	if err := vm.RemoveVolume(volume.ID, false); !errors.Is(err, storage.ErrNotEnoughStorage) {
+	if err := vm.RemoveVolume(volume.ID, false, result); err != nil {
+		// blocking error should be nil
+		t.Fatal(err)
+	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
+		// async error should be ErrNotEnoughStorage
 		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
 
 	// add a second volume to the manager
-	_, err = vm.AddVolume(filepath.Join(t.TempDir(), "vol2.dat"), expectedSectors)
+	_, err = vm.AddVolume(filepath.Join(t.TempDir(), "vol2.dat"), expectedSectors, result)
 	if err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
 
@@ -357,12 +385,18 @@ func TestRemoveCorrupt(t *testing.T) {
 	}
 
 	// remove the volume
-	if err := vm.RemoveVolume(volume.ID, false); err == nil || errors.Is(err, storage.ErrNotEnoughStorage) {
+	if err := vm.RemoveVolume(volume.ID, false, result); err != nil {
+		t.Fatal(err) // blocking error should be nil
+	} else if err := <-result; err == nil {
 		t.Fatal("expected error when removing corrupt volume", err)
-	} else if err != nil {
-		t.Log("got", err)
-	} else if err := vm.RemoveVolume(volume.ID, true); err != nil {
+	}
+	// force remove the volume
+	if err := vm.RemoveVolume(volume.ID, true, result); err != nil {
 		t.Fatal(err)
+	} else if err := <-result; err != nil {
+		t.Fatal(err)
+	} else if _, err := os.Stat(volumePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("volume file still exists", err)
 	}
 }
 
@@ -400,15 +434,19 @@ func TestRemoveMissing(t *testing.T) {
 	defer cm.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer vm.Close()
 
+	result := make(chan error, 1)
 	volumePath := filepath.Join(t.TempDir(), "hostdata.dat")
-	volume, err := vm.AddVolume(volumePath, expectedSectors)
+	volume, err := vm.AddVolume(volumePath, expectedSectors, result)
 	if err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
 
@@ -429,13 +467,17 @@ func TestRemoveMissing(t *testing.T) {
 
 	// attempt to remove the volume. Should return ErrNotEnoughStorage since
 	// there is only one volume.
-	if err := vm.RemoveVolume(volume.ID, false); !errors.Is(err, storage.ErrNotEnoughStorage) {
+	if err := vm.RemoveVolume(volume.ID, false, result); err != nil {
+		t.Fatal(err)
+	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
 
 	// add a second volume to the manager
-	_, err = vm.AddVolume(filepath.Join(t.TempDir(), "vol2.dat"), expectedSectors)
+	_, err = vm.AddVolume(filepath.Join(t.TempDir(), "vol2.dat"), expectedSectors, result)
 	if err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
 
@@ -450,7 +492,7 @@ func TestRemoveMissing(t *testing.T) {
 	}
 
 	// reload the volume manager
-	vm, err = storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	vm, err = storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,11 +506,15 @@ func TestRemoveMissing(t *testing.T) {
 	}
 
 	// remove the volume
-	if err := vm.RemoveVolume(volume.ID, false); err == nil || errors.Is(err, storage.ErrNotEnoughStorage) {
-		t.Fatal("expected error when removing missing volume", err)
-	} else if err != nil {
-		t.Log("got", err)
-	} else if err := vm.RemoveVolume(volume.ID, true); err != nil {
+	if err := vm.RemoveVolume(volume.ID, false, result); err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err == nil {
+		t.Fatal("expected error when removing missing volume")
+	}
+
+	if err := vm.RemoveVolume(volume.ID, true, result); err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
 }
@@ -507,17 +553,31 @@ func TestVolumeGrow(t *testing.T) {
 	defer cm.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer vm.Close()
 
+	result := make(chan error, 1)
 	volumeFilePath := filepath.Join(t.TempDir(), "hostdata.dat")
-	volume, err := vm.AddVolume(volumeFilePath, initialSectors)
+	volume, err := vm.AddVolume(volumeFilePath, initialSectors, result)
 	if err != nil {
 		t.Fatal(err)
-	} else if err := checkFileSize(volumeFilePath, int64(initialSectors*rhpv2.SectorSize)); err != nil {
+	} else if err := <-result; err != nil {
+		t.Fatal(err)
+	}
+
+	// reload the volume, since the initialization progress will have changed
+	v, err := vm.Volume(volume.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	volume = v.Volume
+
+	// check the volume
+	if err := checkFileSize(volumeFilePath, int64(initialSectors*rhpv2.SectorSize)); err != nil {
 		t.Fatal(err)
 	} else if volume.TotalSectors != initialSectors {
 		t.Fatalf("expected %v total sectors, got %v", initialSectors, volume.TotalSectors)
@@ -527,11 +587,16 @@ func TestVolumeGrow(t *testing.T) {
 
 	// grow the volume
 	const newSectors = 64
-	if err := vm.ResizeVolume(volume.ID, newSectors); err != nil {
+	if err := vm.ResizeVolume(volume.ID, newSectors, result); err != nil {
 		t.Fatal(err)
-	} else if err := checkFileSize(volumeFilePath, int64(newSectors*rhpv2.SectorSize)); err != nil {
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
+
+	if err := checkFileSize(volumeFilePath, int64(newSectors*rhpv2.SectorSize)); err != nil {
+		t.Fatal(err)
+	}
+
 	meta, err := vm.Volume(volume.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -577,17 +642,30 @@ func TestVolumeShrink(t *testing.T) {
 	defer cm.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer vm.Close()
 
+	result := make(chan error, 1)
 	volumeFilePath := filepath.Join(t.TempDir(), "hostdata.dat")
-	volume, err := vm.AddVolume(volumeFilePath, sectors)
+	vol, err := vm.AddVolume(volumeFilePath, sectors, result)
 	if err != nil {
 		t.Fatal(err)
-	} else if err := checkFileSize(volumeFilePath, int64(sectors*rhpv2.SectorSize)); err != nil {
+	} else if err := <-result; err != nil {
+		t.Fatal(err)
+
+	}
+
+	volume, err := vm.Volume(vol.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check the volume
+	if err := checkFileSize(volumeFilePath, int64(sectors*rhpv2.SectorSize)); err != nil {
 		t.Fatal(err)
 	} else if volume.TotalSectors != sectors {
 		t.Fatalf("expected %v total sectors, got %v", sectors, volume.TotalSectors)
@@ -641,7 +719,9 @@ func TestVolumeShrink(t *testing.T) {
 	// try to shrink the volume, should fail since no space is available
 	toRemove := sectors / 4
 	remainingSectors := uint64(sectors - toRemove)
-	if err := vm.ResizeVolume(volume.ID, remainingSectors); !errors.Is(err, storage.ErrNotEnoughStorage) {
+	if err := vm.ResizeVolume(volume.ID, remainingSectors, result); err != nil {
+		t.Fatal(err)
+	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected not enough storage error, got %v", err)
 	}
 
@@ -656,7 +736,9 @@ func TestVolumeShrink(t *testing.T) {
 	roots = append(roots[remainingSectors:], roots[toRemove:remainingSectors]...)
 
 	// shrink the volume by the number of sectors removed, should succeed
-	if err := vm.ResizeVolume(volume.ID, remainingSectors); err != nil {
+	if err := vm.ResizeVolume(volume.ID, remainingSectors, result); err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	} else if err := checkFileSize(volumeFilePath, int64(remainingSectors*rhpv2.SectorSize)); err != nil {
 		t.Fatal(err)
@@ -723,17 +805,28 @@ func TestVolumeManagerReadWrite(t *testing.T) {
 	defer cm.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer vm.Close()
 
+	result := make(chan error, 1)
 	volumeFilePath := filepath.Join(t.TempDir(), "hostdata.dat")
-	volume, err := vm.AddVolume(volumeFilePath, sectors)
+	vol, err := vm.AddVolume(volumeFilePath, sectors, result)
 	if err != nil {
 		t.Fatal(err)
-	} else if err := checkFileSize(volumeFilePath, int64(sectors*rhpv2.SectorSize)); err != nil {
+	} else if err := <-result; err != nil {
+		t.Fatal(err)
+	}
+
+	volume, err := vm.Volume(vol.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkFileSize(volumeFilePath, int64(sectors*rhpv2.SectorSize)); err != nil {
 		t.Fatal(err)
 	} else if volume.TotalSectors != sectors {
 		t.Fatalf("expected %v total sectors, got %v", sectors, volume.TotalSectors)
@@ -812,15 +905,19 @@ func BenchmarkVolumeManagerWrite(b *testing.B) {
 	defer cm.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer vm.Close()
 
+	result := make(chan error, 1)
 	volumeFilePath := filepath.Join(b.TempDir(), "hostdata.dat")
-	_, err = vm.AddVolume(volumeFilePath, uint64(b.N))
+	_, err = vm.AddVolume(volumeFilePath, uint64(b.N), result)
 	if err != nil {
+		b.Fatal(err)
+	} else if err := <-result; err != nil {
 		b.Fatal(err)
 	}
 
@@ -877,7 +974,8 @@ func BenchmarkNewVolume(b *testing.B) {
 	defer cm.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -887,36 +985,13 @@ func BenchmarkNewVolume(b *testing.B) {
 	b.ReportMetric(float64(b.N), "sectors")
 	b.SetBytes(rhpv2.SectorSize)
 
+	result := make(chan error, 1)
 	volumeFilePath := filepath.Join(b.TempDir(), "hostdata.dat")
-	_, err = vm.AddVolume(volumeFilePath, uint64(b.N))
+	_, err = vm.AddVolume(volumeFilePath, uint64(b.N), result)
 	if err != nil {
 		b.Fatal(err)
-	}
-}
-
-func BenchmarkThingy(b *testing.B) {
-	f, err := os.Create(filepath.Join(os.TempDir(), "test.tmp"))
-	if err != nil {
+	} else if err := <-result; err != nil {
 		b.Fatal(err)
-	}
-	defer f.Close()
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	b.SetBytes(1)
-
-	lr := io.LimitReader(frand.Reader, int64(b.N))
-	if _, err := io.Copy(f, lr); err != nil {
-		b.Fatal(err)
-	} else if err := f.Sync(); err != nil {
-		b.Fatal(err)
-	}
-
-	stat, err := f.Stat()
-	if err != nil {
-		b.Fatal(err)
-	} else if stat.Size() != int64(b.N) {
-		b.Fatalf("expected file size %v, got %v", b.N, stat.Size())
 	}
 }
 
@@ -950,15 +1025,19 @@ func BenchmarkVolumeManagerRead(b *testing.B) {
 	defer cm.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer vm.Close()
 
+	result := make(chan error, 1)
 	volumeFilePath := filepath.Join(b.TempDir(), "hostdata.dat")
-	_, err = vm.AddVolume(volumeFilePath, uint64(b.N))
+	_, err = vm.AddVolume(volumeFilePath, uint64(b.N), result)
 	if err != nil {
+		b.Fatal(err)
+	} else if err := <-result; err != nil {
 		b.Fatal(err)
 	}
 
@@ -1018,15 +1097,19 @@ func BenchmarkVolumeRemove(b *testing.B) {
 	defer cm.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, cm, log.Named("volumes"))
+	am := alerts.NewManager()
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"))
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer vm.Close()
 
+	result := make(chan error, 1)
 	volumeFilePath := filepath.Join(b.TempDir(), "hostdata.dat")
-	volume1, err := vm.AddVolume(volumeFilePath, uint64(b.N))
+	volume1, err := vm.AddVolume(volumeFilePath, uint64(b.N), result)
 	if err != nil {
+		b.Fatal(err)
+	} else if err := <-result; err != nil {
 		b.Fatal(err)
 	}
 
@@ -1045,8 +1128,10 @@ func BenchmarkVolumeRemove(b *testing.B) {
 
 	// add a new volume
 	volume2FilePath := filepath.Join(b.TempDir(), "hostdata2.dat")
-	_, err = vm.AddVolume(volume2FilePath, uint64(b.N))
+	_, err = vm.AddVolume(volume2FilePath, uint64(b.N), result)
 	if err != nil {
+		b.Fatal(err)
+	} else if err := <-result; err != nil {
 		b.Fatal(err)
 	}
 
@@ -1055,7 +1140,9 @@ func BenchmarkVolumeRemove(b *testing.B) {
 	b.SetBytes(rhpv2.SectorSize)
 
 	// migrate the sectors
-	if err := vm.RemoveVolume(volume1.ID, false); err != nil {
+	if err := vm.RemoveVolume(volume1.ID, false, result); err != nil {
+		b.Fatal(err)
+	} else if err := <-result; err != nil {
 		b.Fatal(err)
 	}
 }

--- a/internal/test/host.go
+++ b/internal/test/host.go
@@ -163,7 +163,6 @@ func NewHost(privKey types.PrivateKey, dir string, node *Node, log *zap.Logger) 
 	}
 
 	am := alerts.NewManager()
-
 	storage, err := storage.NewVolumeManager(db, am, node.cm, log.Named("storage"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage manager: %w", err)
@@ -175,7 +174,7 @@ func NewHost(privKey types.PrivateKey, dir string, node *Node, log *zap.Logger) 
 		return nil, fmt.Errorf("failed to add storage volume: %w", err)
 	}
 
-	contracts, err := contracts.NewManager(db, storage, node.cm, node.tp, wallet, log.Named("contracts"))
+	contracts, err := contracts.NewManager(db, am, storage, node.cm, node.tp, wallet, log.Named("contracts"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create contract manager: %w", err)
 	}


### PR DESCRIPTION
Adds alerts to the host. Initially these will be focused on background tasks, like volume management and contracts. It may be expanded in the future.

Adds `[GET] /alerts` and `[DELETE] /alerts` endpoints

Changes add, resize, and delete volume actions to complete asynchronously. The blocking portion will return an initial error for permission errors, but background errors, like during migration, will be surfaced through alerts/log messages. An optional channel argument has been added to each function to signal completion.