### PR TITLE
Make the cache size configurable

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -59,6 +59,7 @@ type (
 		ResizeVolume(id int, maxSectors uint64, result chan<- error) error
 		SetReadOnly(id int, readOnly bool) error
 		RemoveSector(root types.Hash256) error
+		ResizeCache(size uint32)
 	}
 
 	// A ContractManager manages the host's contracts

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -151,8 +151,7 @@ func (a *api) handlePATCHSettings(c jape.Context) {
 	}
 
 	// Resize the cache based on the updated settings
-	cacheSize := settings.SectorCacheSize
-	a.volumes.ResizeCache(cacheSize)
+	a.volumes.ResizeCache(settings.SectorCacheSize)
 
 	c.Encode(a.settings.Settings())
 }

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -149,6 +149,11 @@ func (a *api) handlePATCHSettings(c jape.Context) {
 	if !a.checkServerError(c, "failed to update settings", err) {
 		return
 	}
+
+	// Resize the cache based on the updated settings
+	cacheSize := settings.SectorCacheSize
+	a.volumes.ResizeCache(cacheSize)
+
 	c.Encode(a.settings.Settings())
 }
 

--- a/cmd/hostd/node.go
+++ b/cmd/hostd/node.go
@@ -248,7 +248,7 @@ func newNode(gatewayAddr, rhp2Addr, rhp3Addr, dir string, bootstrap bool, wallet
 
 	accountManager := accounts.NewManager(db, sr)
 	am := alerts.NewManager()
-	sm, err := storage.NewVolumeManager(db, am, cm, logger.Named("volumes"))
+	sm, err := storage.NewVolumeManager(db, am, cm, logger.Named("volumes"), sr.Settings().SectorCacheSize)
 	if err != nil {
 		return nil, types.PrivateKey{}, fmt.Errorf("failed to create storage manager: %w", err)
 	}

--- a/host/contracts/integrity_test.go
+++ b/host/contracts/integrity_test.go
@@ -80,14 +80,11 @@ func TestCheckIntegrity(t *testing.T) {
 	defer node.Close()
 
 	am := alerts.NewManager()
-	s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"))
+	s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer s.Close()
-
-	// Resize cache to 0 sectors
-	s.ResizeCache(0)
 
 	result := make(chan error, 1)
 	if _, err := s.AddVolume(filepath.Join(dir, "data.dat"), 10, result); err != nil {

--- a/host/contracts/manager_test.go
+++ b/host/contracts/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/host/alerts"
 	"go.sia.tech/hostd/host/contracts"
+	"go.sia.tech/hostd/host/settings"
 	"go.sia.tech/hostd/host/storage"
 	"go.sia.tech/hostd/internal/test"
 	"go.sia.tech/hostd/persist/sqlite"
@@ -20,6 +21,10 @@ import (
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
+
+var DefaultSettings = settings.Settings{
+	SectorCacheSize: 64,
+}
 
 func hashRevision(rev types.FileContractRevision) types.Hash256 {
 	h := types.NewHasher()
@@ -103,7 +108,7 @@ func TestContractLockUnlock(t *testing.T) {
 	defer node.Close()
 
 	am := alerts.NewManager()
-	s, err := storage.NewVolumeManager(db, am, node.ChainManager(), log.Named("storage"))
+	s, err := storage.NewVolumeManager(db, am, node.ChainManager(), log.Named("storage"), DefaultSettings.SectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +187,7 @@ func TestContractLifecycle(t *testing.T) {
 		defer node.Close()
 
 		am := alerts.NewManager()
-		s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"))
+		s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"), DefaultSettings.SectorCacheSize)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -340,7 +345,7 @@ func TestContractLifecycle(t *testing.T) {
 		defer node.Close()
 
 		am := alerts.NewManager()
-		s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"))
+		s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"), DefaultSettings.SectorCacheSize)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/host/contracts/manager_test.go
+++ b/host/contracts/manager_test.go
@@ -13,7 +13,6 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/host/alerts"
 	"go.sia.tech/hostd/host/contracts"
-	"go.sia.tech/hostd/host/settings"
 	"go.sia.tech/hostd/host/storage"
 	"go.sia.tech/hostd/internal/test"
 	"go.sia.tech/hostd/persist/sqlite"
@@ -22,9 +21,7 @@ import (
 	"lukechampine.com/frand"
 )
 
-var DefaultSettings = settings.Settings{
-	SectorCacheSize: 64,
-}
+const sectorCacheSize = 64
 
 func hashRevision(rev types.FileContractRevision) types.Hash256 {
 	h := types.NewHasher()
@@ -108,7 +105,7 @@ func TestContractLockUnlock(t *testing.T) {
 	defer node.Close()
 
 	am := alerts.NewManager()
-	s, err := storage.NewVolumeManager(db, am, node.ChainManager(), log.Named("storage"), DefaultSettings.SectorCacheSize)
+	s, err := storage.NewVolumeManager(db, am, node.ChainManager(), log.Named("storage"), sectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +184,7 @@ func TestContractLifecycle(t *testing.T) {
 		defer node.Close()
 
 		am := alerts.NewManager()
-		s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"), DefaultSettings.SectorCacheSize)
+		s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"), sectorCacheSize)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -345,7 +342,7 @@ func TestContractLifecycle(t *testing.T) {
 		defer node.Close()
 
 		am := alerts.NewManager()
-		s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"), DefaultSettings.SectorCacheSize)
+		s, err := storage.NewVolumeManager(node.Store(), am, node.ChainManager(), log.Named("storage"), sectorCacheSize)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/host/settings/settings.go
+++ b/host/settings/settings.go
@@ -72,6 +72,9 @@ type (
 		// DNS settings
 		DDNS DNSSettings `json:"ddns"`
 
+		// New setting for number of sectors to cache
+		SectorCacheSize uint32 `json:"sectorCacheSize"`
+
 		Revision uint64 `json:"revision"`
 	}
 

--- a/host/settings/settings.go
+++ b/host/settings/settings.go
@@ -72,7 +72,6 @@ type (
 		// DNS settings
 		DDNS DNSSettings `json:"ddns"`
 
-		// New setting for number of sectors to cache
 		SectorCacheSize uint32 `json:"sectorCacheSize"`
 
 		Revision uint64 `json:"revision"`

--- a/host/storage/storage.go
+++ b/host/storage/storage.go
@@ -984,10 +984,14 @@ func (vm *VolumeManager) ResizeCache(size uint32) {
 // NewVolumeManager creates a new VolumeManager.
 func NewVolumeManager(vs VolumeStore, a Alerts, cm ChainManager, log *zap.Logger, sectorCacheSize uint32) (*VolumeManager, error) {
 	// Initialize cache with LRU eviction and a max capacity of 64
-	cache, err := lru.New[types.Hash256, *[rhpv2.SectorSize]byte](int(sectorCacheSize))
+	cache, err := lru.New[types.Hash256, *[rhpv2.SectorSize]byte](64)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize cache: %w", err)
 	}
+	// resize the cache, prevents an error in lru.New when initializing the
+	// cache to 0
+	cache.Resize(int(sectorCacheSize))
+
 	vm := &VolumeManager{
 		vs:  vs,
 		a:   a,

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -11,7 +11,6 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/chain"
 	"go.sia.tech/hostd/host/alerts"
-	"go.sia.tech/hostd/host/settings"
 	"go.sia.tech/hostd/host/storage"
 	"go.sia.tech/hostd/persist/sqlite"
 	"go.sia.tech/siad/modules/consensus"
@@ -20,9 +19,7 @@ import (
 	"lukechampine.com/frand"
 )
 
-var DefaultSettings = settings.Settings{
-	SectorCacheSize: 64,
-}
+const sectorCacheSize = 64
 
 func checkFileSize(fp string, expectedSize int64) error {
 	stat, err := os.Stat(fp)
@@ -67,7 +64,7 @@ func TestVolumeLoad(t *testing.T) {
 	defer cm.Close()
 
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +94,7 @@ func TestVolumeLoad(t *testing.T) {
 	}
 
 	// reopen the volume manager
-	vm, err = storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err = storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +166,7 @@ func TestAddVolume(t *testing.T) {
 	defer cm.Close()
 
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +235,7 @@ func TestRemoveVolume(t *testing.T) {
 
 	// initialize the storage manager
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +437,7 @@ func TestRemoveMissing(t *testing.T) {
 
 	// initialize the storage manager
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,7 +494,7 @@ func TestRemoveMissing(t *testing.T) {
 	}
 
 	// reload the volume manager
-	vm, err = storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err = storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -559,7 +556,7 @@ func TestVolumeGrow(t *testing.T) {
 
 	// initialize the storage manager
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -648,7 +645,7 @@ func TestVolumeShrink(t *testing.T) {
 
 	// initialize the storage manager
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -810,7 +807,7 @@ func TestVolumeManagerReadWrite(t *testing.T) {
 
 	// initialize the storage manager
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -910,7 +907,7 @@ func BenchmarkVolumeManagerWrite(b *testing.B) {
 
 	// initialize the storage manager
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -979,7 +976,7 @@ func BenchmarkNewVolume(b *testing.B) {
 
 	// initialize the storage manager
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1030,7 +1027,7 @@ func BenchmarkVolumeManagerRead(b *testing.B) {
 
 	// initialize the storage manager
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1102,7 +1099,7 @@ func BenchmarkVolumeRemove(b *testing.B) {
 
 	// initialize the storage manager
 	am := alerts.NewManager()
-	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), DefaultSettings.SectorCacheSize)
+	vm, err := storage.NewVolumeManager(db, am, cm, log.Named("volumes"), sectorCacheSize)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/test/host.go
+++ b/internal/test/host.go
@@ -74,6 +74,7 @@ var DefaultSettings = settings.Settings{
 
 	AccountExpiry:     30 * 24 * time.Hour, // 1 month
 	MaxAccountBalance: types.Siacoins(10),
+	SectorCacheSize:   64,
 }
 
 // Close shutsdown the host
@@ -163,7 +164,7 @@ func NewHost(privKey types.PrivateKey, dir string, node *Node, log *zap.Logger) 
 	}
 
 	am := alerts.NewManager()
-	storage, err := storage.NewVolumeManager(db, am, node.cm, log.Named("storage"))
+	storage, err := storage.NewVolumeManager(db, am, node.cm, log.Named("storage"), DefaultSettings.SectorCacheSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage manager: %w", err)
 	}

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -205,7 +205,8 @@ CREATE TABLE host_settings (
 	ddns_update_v4 BOOLEAN NOT NULL,
 	ddns_update_v6 BOOLEAN NOT NULL,
 	ddns_opts BLOB,
-	registry_limit INTEGER NOT NULL
+	registry_limit INTEGER NOT NULL,
+	sector_cache_size INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE log_lines (
@@ -234,4 +235,4 @@ CREATE TABLE global_settings (
 	contracts_height INTEGER -- height of the contract manager as of the last processed change
 );
 
-INSERT INTO global_settings (id, db_version) VALUES (0, 6); -- version must be updated when the schema changes
+INSERT INTO global_settings (id, db_version) VALUES (0, 7); -- version must be updated when the schema changes

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+// migrateVersion7 adds the sector_cache_size column to the host_settings table
+func migrateVersion7(tx txn) error {
+	_, err := tx.Exec(`ALTER TABLE host_settings ADD COLUMN sector_cache_size INTEGER NOT NULL DEFAULT 0;`)
+	return err
+}
+
 // migrateVersion6 fixes a bug where the physical sectors metric was not being
 // properly decreased when a volume is force removed.
 func migrateVersion6(tx txn) error {
@@ -123,7 +129,7 @@ func migrateVersion2(tx txn) error {
 		migrateSettings = `INSERT INTO host_settings (id, settings_revision, accepting_contracts, net_address, 
 contract_price, base_rpc_price, sector_access_price, collateral, max_collateral, storage_price, egress_price, 
 ingress_price, max_account_balance, max_account_age, price_table_validity, max_contract_duration, window_size, 
-ingress_limit, egress_limit, ddns_provider, ddns_update_v4, ddns_update_v6, ddns_opts, registry_limit)
+ingress_limit, egress_limit, ddns_provider, ddns_update_v4, ddns_update_v6, ddns_opts, registry_limit, sector_cache_size)
 SELECT 0, settings_revision, accepting_contracts, net_address, contract_price, base_rpc_price, 
 sector_access_price, collateral, max_collateral, min_storage_price, min_egress_price, min_ingress_price, 
 max_account_balance, max_account_age, price_table_validity, max_contract_duration, window_size, ingress_limit, 
@@ -153,4 +159,5 @@ var migrations = []func(tx txn) error{
 	migrateVersion4,
 	migrateVersion5,
 	migrateVersion6,
+	migrateVersion7,
 }

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -129,7 +129,7 @@ func migrateVersion2(tx txn) error {
 		migrateSettings = `INSERT INTO host_settings (id, settings_revision, accepting_contracts, net_address, 
 contract_price, base_rpc_price, sector_access_price, collateral, max_collateral, storage_price, egress_price, 
 ingress_price, max_account_balance, max_account_age, price_table_validity, max_contract_duration, window_size, 
-ingress_limit, egress_limit, ddns_provider, ddns_update_v4, ddns_update_v6, ddns_opts, registry_limit, sector_cache_size)
+ingress_limit, egress_limit, ddns_provider, ddns_update_v4, ddns_update_v6, ddns_opts, registry_limit)
 SELECT 0, settings_revision, accepting_contracts, net_address, contract_price, base_rpc_price, 
 sector_access_price, collateral, max_collateral, min_storage_price, min_egress_price, min_ingress_price, 
 max_account_balance, max_account_age, price_table_validity, max_contract_duration, window_size, ingress_limit, 

--- a/persist/sqlite/settings.go
+++ b/persist/sqlite/settings.go
@@ -83,7 +83,7 @@ ON CONFLICT (id) DO UPDATE SET (settings_revision,
 			sqlCurrency(settings.IngressPrice), sqlCurrency(settings.MaxAccountBalance),
 			settings.AccountExpiry, settings.PriceTableValidity, settings.MaxContractDuration, settings.WindowSize,
 			settings.IngressLimit, settings.EgressLimit, settings.MaxRegistryEntries,
-			settings.DDNS.Provider, settings.DDNS.IPv4, settings.DDNS.IPv6, dnsOptsBuf, settings.SectorCacheSize) //Update the parameter for the new column
+			settings.DDNS.Provider, settings.DDNS.IPv4, settings.DDNS.IPv6, dnsOptsBuf, settings.SectorCacheSize)
 		if err != nil {
 			return fmt.Errorf("failed to update settings: %w", err)
 		}

--- a/persist/sqlite/settings.go
+++ b/persist/sqlite/settings.go
@@ -20,7 +20,7 @@ func (s *Store) Settings() (config settings.Settings, err error) {
 	contract_price, base_rpc_price, sector_access_price, collateral_multiplier, 
 	max_collateral, storage_price, egress_price, ingress_price, 
 	max_account_balance, max_account_age, price_table_validity, max_contract_duration, window_size, 
-	ingress_limit, egress_limit, registry_limit, ddns_provider, ddns_update_v4, ddns_update_v6, ddns_opts
+	ingress_limit, egress_limit, registry_limit, ddns_provider, ddns_update_v4, ddns_update_v6, ddns_opts, sector_cache_size
 FROM host_settings;`
 	err = s.queryRow(query).Scan(&config.Revision, &config.AcceptingContracts,
 		&config.NetAddress, (*sqlCurrency)(&config.ContractPrice),
@@ -30,7 +30,7 @@ FROM host_settings;`
 		(*sqlCurrency)(&config.IngressPrice), (*sqlCurrency)(&config.MaxAccountBalance),
 		&config.AccountExpiry, &config.PriceTableValidity, &config.MaxContractDuration, &config.WindowSize,
 		&config.IngressLimit, &config.EgressLimit, &config.MaxRegistryEntries,
-		&config.DDNS.Provider, &config.DDNS.IPv4, &config.DDNS.IPv6, &dyndnsBuf)
+		&config.DDNS.Provider, &config.DDNS.IPv4, &config.DDNS.IPv6, &dyndnsBuf, &config.SectorCacheSize)
 	if errors.Is(err, sql.ErrNoRows) {
 		return settings.Settings{}, settings.ErrNoSettings
 	}
@@ -50,21 +50,21 @@ func (s *Store) UpdateSettings(settings settings.Settings) error {
 		sector_access_price, collateral_multiplier, max_collateral, storage_price, 
 		egress_price, ingress_price, max_account_balance, 
 		max_account_age, price_table_validity, max_contract_duration, window_size, ingress_limit, 
-		egress_limit, registry_limit, ddns_provider, ddns_update_v4, ddns_update_v6, ddns_opts) 
-		VALUES (0, 0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22) 
+		egress_limit, registry_limit, ddns_provider, ddns_update_v4, ddns_update_v6, ddns_opts, sector_cache_size) 
+		VALUES (0, 0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23) 
 ON CONFLICT (id) DO UPDATE SET (settings_revision, 
 	accepting_contracts, net_address, contract_price, base_rpc_price, 
 	sector_access_price, collateral_multiplier, max_collateral, storage_price, 
 	egress_price, ingress_price, max_account_balance, 
 	max_account_age, price_table_validity, max_contract_duration, window_size, ingress_limit, 
-	egress_limit, registry_limit, ddns_provider, ddns_update_v4, ddns_update_v6, ddns_opts) = (
+	egress_limit, registry_limit, ddns_provider, ddns_update_v4, ddns_update_v6, ddns_opts, sector_cache_size) = (
 	settings_revision + 1, EXCLUDED.accepting_contracts, EXCLUDED.net_address,
 	EXCLUDED.contract_price, EXCLUDED.base_rpc_price, EXCLUDED.sector_access_price,
 	EXCLUDED.collateral_multiplier, EXCLUDED.max_collateral, EXCLUDED.storage_price,
 	EXCLUDED.egress_price, EXCLUDED.ingress_price, EXCLUDED.max_account_balance,
 	EXCLUDED.max_account_age, EXCLUDED.price_table_validity, EXCLUDED.max_contract_duration, EXCLUDED.window_size, 
 	EXCLUDED.ingress_limit, EXCLUDED.egress_limit, EXCLUDED.registry_limit, EXCLUDED.ddns_provider, 
-	EXCLUDED.ddns_update_v4, EXCLUDED.ddns_update_v6, EXCLUDED.ddns_opts);`
+	EXCLUDED.ddns_update_v4, EXCLUDED.ddns_update_v6, EXCLUDED.ddns_opts, EXCLUDED.sector_cache_size);`
 	var dnsOptsBuf []byte
 	if len(settings.DDNS.Provider) > 0 {
 		var err error
@@ -83,7 +83,7 @@ ON CONFLICT (id) DO UPDATE SET (settings_revision,
 			sqlCurrency(settings.IngressPrice), sqlCurrency(settings.MaxAccountBalance),
 			settings.AccountExpiry, settings.PriceTableValidity, settings.MaxContractDuration, settings.WindowSize,
 			settings.IngressLimit, settings.EgressLimit, settings.MaxRegistryEntries,
-			settings.DDNS.Provider, settings.DDNS.IPv4, settings.DDNS.IPv6, dnsOptsBuf)
+			settings.DDNS.Provider, settings.DDNS.IPv4, settings.DDNS.IPv6, dnsOptsBuf, settings.SectorCacheSize) //Update the parameter for the new column
 		if err != nil {
 			return fmt.Errorf("failed to update settings: %w", err)
 		}


### PR DESCRIPTION
See issue https://github.com/SiaFoundation/hostd/issues/18 Part 2:

- [X] Add a new setting for the number of sectors to cache. An int or uint32 is fine. Each sector is 4MiB.
- [X] Add the new setting to the database
- [X] Add a migration to add the new column https://github.com/SiaFoundation/hostd/blob/master/persist/sqlite/migrations.go
- [X] Change the store methods to read and update the new column
- [X] Pass the initial cache setting into the volume manager and initialize the cache
- [X] Resize the cache when the setting changes. There are a few ways to do this. The least invasive is probably to add a 
- [X] ResizeCache(sectors int) error func to the volume manager and call it from the settings API handler.