### PR TITLE
Fix log path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 .DS_Store
 .vscode
+hostd.yml

--- a/cmd/hostd/main.go
+++ b/cmd/hostd/main.go
@@ -169,10 +169,6 @@ func main() {
 	// attempt to load the config file first, command line flags will override
 	// any values set in the config file
 	mustLoadConfig()
-	// set the log path to the data dir if it is not already set
-	if len(config.Log.Path) == 0 {
-		config.Log.Path = config.DataDir
-	}
 
 	// global
 	flag.StringVar(&config.Name, "name", config.Name, "a friendly name for the host, only used for display")
@@ -214,6 +210,13 @@ func main() {
 	// check that the API password and wallet seed are set
 	mustSetAPIPassword()
 	mustSetWalletkey()
+
+	// set the log path to the data dir if it is not already set note: this
+	// musst happen after CLI flags are parsed so that the data directory can be
+	// specified via the command line
+	if len(config.Log.Path) == 0 {
+		config.Log.Path = config.DataDir
+	}
 
 	var seed [32]byte
 	if err := wallet.SeedFromPhrase(&seed, config.RecoveryPhrase); err != nil {


### PR DESCRIPTION
Adding yaml support broke the log path override. The log would be created in the current directory when not explicitly set instead of in the data directory