### PR TITLE
ui: v0.18.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	go.sia.tech/jape v0.9.1-0.20230525021720-ecf031ecbffb
 	go.sia.tech/renterd v0.0.0-20230322105544-b8424a111b76
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca
-	go.sia.tech/web/hostd v0.16.0
+	go.sia.tech/web/hostd v0.18.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/sys v0.7.0
 	golang.org/x/term v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca h1:aZMg2AKevn7jKx+wlusWQf
 go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca/go.mod h1:h/1afFwpxzff6/gG5i1XdAgPK7dEY6FaibhK7N5F86Y=
 go.sia.tech/web v0.0.0-20230616170703-7ed0b639fb22 h1:8R5XuEh1rfWYzWiZ3vWJ6q8be3XoDZ+OD+ryxSKM/w0=
 go.sia.tech/web v0.0.0-20230616170703-7ed0b639fb22/go.mod h1:RKODSdOmR3VtObPAcGwQqm4qnqntDVFylbvOBbWYYBU=
-go.sia.tech/web/hostd v0.16.0 h1:shR3quR3QqLCey5Nh0QxhxQiWyA5wrx4d5dlCRwaZek=
-go.sia.tech/web/hostd v0.16.0/go.mod h1:nZf2Ubbd5ecUjEzlZPlwIc7ZIf+iVosgmLDBymQtzTM=
+go.sia.tech/web/hostd v0.18.0 h1:sB6HRSTE+KcPngzqKdDrCl5TqdV9TFQgM2BH+E0RNxs=
+go.sia.tech/web/hostd v0.18.0/go.mod h1:nZf2Ubbd5ecUjEzlZPlwIc7ZIf+iVosgmLDBymQtzTM=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=


### PR DESCRIPTION
- Currency options now include AUD. Closes https://github.com/SiaFoundation/hostd/issues/103
- Accepting contracts option can be disabled.
- Metrics now include locked and risked collateral. Closes https://github.com/SiaFoundation/hostd/issues/111
- Contract data integrity checks can now be triggered from the contract action menu. Status updates are published to the alerts feeds. Closes https://github.com/SiaFoundation/hostd/issues/93
- Bandwidth and operation metric graph colors have been revised for clarity.
- Contract timeline now always shows contract duration dates, on user interaction the specific labels will activate. Closes https://github.com/SiaFoundation/hostd/issues/72
- Contracts columns now have a time category.
- Fixed a metrics issue where the data time range would stay fixed between page loads until explicitly changed.
- The Settings dialog is now called App preferences.
- Contract columns now include start date, expiration date, and payout date - start and expiration are sortable.
- Dates are now properly localized based on the user's system. Closes https://github.com/SiaFoundation/hostd/issues/105
- Fixed an issue where some metrics graphs and totals were including an incorrect large first datum. Closes https://github.com/SiaFoundation/hostd/issues/102
- Storage stat cards no longer include total as an option.
- Collateral metric is now based on multiplier and properly shows in stats and on graph. Closes https://github.com/SiaFoundation/hostd/issues/100
- The app now includes an auto-lock feature that can be enabled or disabled from the App Preferences menu. The locking inactivity period can also be configured.
- Contract timeline dates are now localized.
- Paginators now properly show loading state when fetching a new page or previous results when revalidating a cached page.
- Inactive sortable table columns now show a subtle caret to signify that they are sortable.
- The login screen now has an option to show the custom API field.
- The login screen timeout for an unresponsive daemon is now 10 seconds.