### PR TITLE
Fix underflow when broadcasting storage proof for expired contracts

### DIFF
--- a/host/contracts/actions.go
+++ b/host/contracts/actions.go
@@ -156,9 +156,6 @@ func (cm *ContractManager) handleContractAction(id types.FileContractID, height 
 		validPayout, missedPayout := contract.Revision.ValidHostPayout(), contract.Revision.MissedHostPayout()
 		if missedPayout.Cmp(validPayout) >= 0 {
 			log.Info("skipping storage proof, no benefit to host", zap.String("validPayout", validPayout.ExactString()), zap.String("missedPayout", missedPayout.ExactString()))
-			if err := cm.store.ExpireContract(id, ContractStatusSuccessful); err != nil {
-				log.Error("failed to set contract status", zap.Error(err))
-			}
 			return
 		}
 
@@ -244,11 +241,10 @@ func (cm *ContractManager) handleContractAction(id types.FileContractID, height 
 			log.Error("contract failed, revenue lost", zap.Uint64("windowStart", contract.Revision.WindowStart), zap.Uint64("windowEnd", contract.Revision.WindowEnd), zap.String("validPayout", validPayout.ExactString()), zap.String("missedPayout", missedPayout.ExactString()))
 			return
 		}
-		// note: this should always be a no-op, but it's good to be explicit
 		if err := cm.store.ExpireContract(id, ContractStatusSuccessful); err != nil {
 			log.Error("failed to set contract status", zap.Error(err))
 		}
-		log.Info("contract expired")
+		log.Info("contract successful", zap.String("validPayout", validPayout.ExactString()), zap.String("missedPayout", missedPayout.ExactString()))
 	default:
 		log.Panic("unrecognized contract action", zap.Stack("stack"))
 	}

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -220,4 +220,4 @@ CREATE TABLE global_settings (
 	contracts_height INTEGER -- height of the contract manager as of the last processed change
 );
 
-INSERT INTO global_settings (id, db_version) VALUES (0, 10); -- version must be updated when the schema changes
+INSERT INTO global_settings (id, db_version) VALUES (0, 11); -- version must be updated when the schema changes


### PR DESCRIPTION
Fixes a panic when reducing the collateral metric of a contract that does not need a storage proof.

```
panic: underflow

goroutine 39 [running]:
go.sia.tech/core/types.Currency.Sub(...)
      go.sia.tech/core@v0.1.12-0.20230529164041-6347a98003be/types/currency.go:97
, 0x0?}, 0x1, {0xc12ab85287de76a2, 0x29326ed31, 0x1c593c0})
      go.sia.tech/hostd/persist/sqlite/metrics.go:423 +0x479
go.sia.tech/hostd/persist/sqlite.(*Store).ExpireContract.func1({0x15f3c08, 0xc000592460})
      go.sia.tech/hostd/persist/sqlite/contracts.go:458 +0x212
go.sia.tech/hostd/persist/sqlite.(*Store).transaction(0xc000116360, {0x15f35b0, 0xc0008d4690}, 0xc0000f7ba0)
      go.sia.tech/hostd/persist/sqlite/store.go:108 +0x669
go.sia.tech/hostd/persist/sqlite.(*Store).ExpireContract(0x2?, {0xcb, 0x89, 0x9b, 0x90, 0xf2, 0xde, 0xd9, 0x84, 0x88, ...}, ...)
      go.sia.tech/hostd/persist/sqlite/contracts.go:449 +0xbe
go.sia.tech/hostd/host/contracts.(*ContractManager).handleContractAction(0xc0003a8c60, {0xcb, 0x89, 0x9b, 0x90, 0xf2, 0xde, 0xd9, 0x84, 0x88, ...}, ...)
      go.sia.tech/hostd/host/contracts/actions.go:159 +0x195a
go.sia.tech/hostd/persist/sqlite.(*Store).ContractAction(0xc000116360, 0xc0006ba380?, 0xc000592160)
      go.sia.tech/hostd/persist/sqlite/contracts.go:417 +0x423
go.sia.tech/hostd/host/contracts.(*ContractManager).processActions.func1(0xc0003a8c60, 0xc0000f9e80?)
      go.sia.tech/hostd/host/contracts/actions.go:66 +0xaa
go.sia.tech/hostd/host/contracts.(*ContractManager).processActions(0xc0003a8c60)
      go.sia.tech/hostd/host/contracts/actions.go:73 +0xa5
created by go.sia.tech/hostd/host/contracts.NewManager
      go.sia.tech/hostd/host/contracts/manager.go:484 +0x38a
```