### PR TITLE
ui: v0.19.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	go.sia.tech/jape v0.9.1-0.20230525021720-ecf031ecbffb
 	go.sia.tech/renterd v0.0.0-20230322105544-b8424a111b76
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca
-	go.sia.tech/web/hostd v0.18.0
+	go.sia.tech/web/hostd v0.19.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/sys v0.7.0
 	golang.org/x/term v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca h1:aZMg2AKevn7jKx+wlusWQf
 go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca/go.mod h1:h/1afFwpxzff6/gG5i1XdAgPK7dEY6FaibhK7N5F86Y=
 go.sia.tech/web v0.0.0-20230616170703-7ed0b639fb22 h1:8R5XuEh1rfWYzWiZ3vWJ6q8be3XoDZ+OD+ryxSKM/w0=
 go.sia.tech/web v0.0.0-20230616170703-7ed0b639fb22/go.mod h1:RKODSdOmR3VtObPAcGwQqm4qnqntDVFylbvOBbWYYBU=
-go.sia.tech/web/hostd v0.18.0 h1:sB6HRSTE+KcPngzqKdDrCl5TqdV9TFQgM2BH+E0RNxs=
-go.sia.tech/web/hostd v0.18.0/go.mod h1:nZf2Ubbd5ecUjEzlZPlwIc7ZIf+iVosgmLDBymQtzTM=
+go.sia.tech/web/hostd v0.19.0 h1:3FSeSoDarYYJbrtCzTTM/YhL4zrwyQhZs6zZL/xVUCA=
+go.sia.tech/web/hostd v0.19.0/go.mod h1:nZf2Ubbd5ecUjEzlZPlwIc7ZIf+iVosgmLDBymQtzTM=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=


### PR DESCRIPTION
- The app now warns the user if it is running on the testnet with a prominent banner.
- The logs view has been removed from the node tab.
- The metrics time range now automatically updates and refreshes the data at a rate equal to the selected data interval.
- Table headers now freeze in view when the table scrolls.
- Metrics datum modes (average, latest, total) selected by the user are now remembered.
- Wallet now warns the user if the wallet is scanning and shows the percent progress.
- The contrast was improved on the syncing progress text in the daemon profile.
- Metrics now support a 1 day time range with 5 minute intervals.
- Context menus now show the entity type and identifier for clarity.
- All dropdown menus now have higher contrast text.