### PR TITLE
Reset wallet metrics when resetting wallet

### DIFF
--- a/persist/sqlite/wallet.go
+++ b/persist/sqlite/wallet.go
@@ -189,6 +189,8 @@ func (s *Store) ResetWallet(seedHash types.Hash256) error {
 			return fmt.Errorf("failed to delete wallet utxos: %w", err)
 		} else if _, err := tx.Exec(`DELETE FROM wallet_transactions`); err != nil {
 			return fmt.Errorf("failed to delete wallet transactions: %w", err)
+		} else if _, err := tx.Exec(`DELETE FROM host_stats WHERE stat=$1`, metricWalletBalance); err != nil {
+			return fmt.Errorf("failed to delete wallet metrics: %w", err)
 		} else if _, err := tx.Exec(`UPDATE global_settings SET wallet_last_processed_change=NULL, wallet_height=NULL,  wallet_hash=?`, sqlHash256(seedHash)); err != nil {
 			return fmt.Errorf("failed to reset wallet settings: %w", err)
 		}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -279,6 +279,13 @@ func TestWalletReset(t *testing.T) {
 		t.Fatal("expected transactions")
 	}
 
+	m, err := w.Store().Metrics(time.Now())
+	if err != nil {
+		t.Fatal(err)
+	} else if m.Balance.IsZero() {
+		t.Fatal("expected non-zero balance")
+	}
+
 	// close the wallet and trigger a reset by using a different private key
 	w.Close()
 
@@ -309,5 +316,12 @@ func TestWalletReset(t *testing.T) {
 		t.Fatal(err)
 	} else if len(txns) != 0 {
 		t.Fatal("expected no transactions")
+	}
+
+	m, err = w.Store().Metrics(time.Now())
+	if err != nil {
+		t.Fatal(err)
+	} else if !m.Balance.IsZero() {
+		t.Fatal("expected zero balance")
 	}
 }


### PR DESCRIPTION
When the wallet needs to rescan, the wallet metrics are not currently reset. This will reset the wallet metrics so the balance graph shows correctly.