### PR TITLE
Increase contract lifecycle buffers

### DIFF
--- a/host/contracts/consts_default.go
+++ b/host/contracts/consts_default.go
@@ -1,0 +1,12 @@
+//go:build !testing
+
+package contracts
+
+const (
+	// RebroadcastBuffer is the number of blocks after the negotiation height to
+	// attempt to rebroadcast the contract.
+	RebroadcastBuffer = 36 // 6 hours
+	// RevisionSubmissionBuffer number of blocks before the proof window to
+	// submit a revision and prevent modification of the contract.
+	RevisionSubmissionBuffer = 144 // 24 hours
+)

--- a/host/contracts/consts_testing.go
+++ b/host/contracts/consts_testing.go
@@ -1,0 +1,12 @@
+//go:build testing
+
+package contracts
+
+const (
+	// RebroadcastBuffer is the number of blocks after the negotiation height to
+	// attempt to rebroadcast the contract.
+	RebroadcastBuffer = 12
+	// RevisionSubmissionBuffer number of blocks before the proof window to
+	// submit a revision and prevent modification of the contract.
+	RevisionSubmissionBuffer = 24
+)

--- a/host/contracts/contracts.go
+++ b/host/contracts/contracts.go
@@ -16,10 +16,10 @@ import (
 const (
 	// RebroadcastBuffer is the number of blocks after the negotiation height to
 	// attempt to rebroadcast the contract.
-	RebroadcastBuffer = 18 // 3 hours
+	RebroadcastBuffer = 36 // 6 hours
 	// RevisionSubmissionBuffer number of blocks before the proof window to
 	// submit a revision and prevent modification of the contract.
-	RevisionSubmissionBuffer = 36 // 6 hours
+	RevisionSubmissionBuffer = 144 // 24 hours
 )
 
 // A SectorAction denotes the type of action to be performed on a

--- a/host/contracts/contracts.go
+++ b/host/contracts/contracts.go
@@ -13,15 +13,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// RebroadcastBuffer is the number of blocks after the negotiation height to
-	// attempt to rebroadcast the contract.
-	RebroadcastBuffer = 36 // 6 hours
-	// RevisionSubmissionBuffer number of blocks before the proof window to
-	// submit a revision and prevent modification of the contract.
-	RevisionSubmissionBuffer = 144 // 24 hours
-)
-
 // A SectorAction denotes the type of action to be performed on a
 // contract sector.
 const (

--- a/host/storage/storage.go
+++ b/host/storage/storage.go
@@ -23,6 +23,10 @@ const (
 	resizeBatchSize = 64 // 256 MiB
 
 	cleanupInterval = 5 * time.Minute
+
+	// MaxTempSectorBlocks is the maximum number of blocks that a temp sector
+	// can be stored for.
+	MaxTempSectorBlocks = 144 * 7 // 7 days
 )
 
 // VolumeStatus is the status of a volume.

--- a/host/storage/volume.go
+++ b/host/storage/volume.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
+	"math/rand"
 	"os"
 	"sync"
 
@@ -154,8 +156,9 @@ func (v *volume) Resize(oldSectors, newSectors uint64) error {
 
 	if newSectors > oldSectors {
 		buf := make([]byte, rhpv2.SectorSize)
+		r := rand.New(rand.NewSource(int64(frand.Intn(math.MaxInt64))))
 		for i := oldSectors; i < newSectors; i++ {
-			frand.Read(buf)
+			r.Read(buf)
 			if _, err := v.data.WriteAt(buf, int64(i*rhpv2.SectorSize)); err != nil {
 				return fmt.Errorf("failed to write sector to index %v: %w", i, err)
 			}

--- a/rhp/v3/execute.go
+++ b/rhp/v3/execute.go
@@ -368,6 +368,12 @@ func (pe *programExecutor) executeStoreSector(instr *rhpv3.InstrStoreSector) ([]
 		return nil, fmt.Errorf("failed to pay for instruction: %w", err)
 	}
 
+	if instr.Duration == 0 {
+		return nil, fmt.Errorf("duration cannot be 0")
+	} else if instr.Duration > storage.MaxTempSectorBlocks {
+		return nil, fmt.Errorf("duration cannot be greater than %d", storage.MaxTempSectorBlocks)
+	}
+
 	// store the sector
 	release, err := pe.storage.Write(root, sector)
 	if err != nil {


### PR DESCRIPTION
This increases the number of blocks before a contract will be considered rejected and when a contract will be locked for further revisions, giving more time to the host to perform lifecycle actions