### PR TITLE
ui: v0.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	go.sia.tech/jape v0.9.1-0.20230525021720-ecf031ecbffb
 	go.sia.tech/renterd v0.0.0-20230322105544-b8424a111b76
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca
-	go.sia.tech/web/hostd v0.21.0
+	go.sia.tech/web/hostd v0.23.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/sys v0.7.0
 	golang.org/x/term v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca h1:aZMg2AKevn7jKx+wlusWQf
 go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca/go.mod h1:h/1afFwpxzff6/gG5i1XdAgPK7dEY6FaibhK7N5F86Y=
 go.sia.tech/web v0.0.0-20230616170703-7ed0b639fb22 h1:8R5XuEh1rfWYzWiZ3vWJ6q8be3XoDZ+OD+ryxSKM/w0=
 go.sia.tech/web v0.0.0-20230616170703-7ed0b639fb22/go.mod h1:RKODSdOmR3VtObPAcGwQqm4qnqntDVFylbvOBbWYYBU=
-go.sia.tech/web/hostd v0.21.0 h1:x3F+iaz5RjQFSAco0O8dc9WH6PeJQecpKeucUrFpwX8=
-go.sia.tech/web/hostd v0.21.0/go.mod h1:nZf2Ubbd5ecUjEzlZPlwIc7ZIf+iVosgmLDBymQtzTM=
+go.sia.tech/web/hostd v0.23.0 h1:XAXMgBHv4ukuXYTcjeshMhwA7PBRiJZ6tTcKDlinVck=
+go.sia.tech/web/hostd v0.23.0/go.mod h1:nZf2Ubbd5ecUjEzlZPlwIc7ZIf+iVosgmLDBymQtzTM=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=


### PR DESCRIPTION
- The volume status icon now shows in progress operations more clearly.
- The contracts table now has a column for "remaining renter funds".
- Alerts can now be filtered and dismissed by type.
- The alert dialog now has a fixed height, so it stays in the same position when an alert is dismissed.
- In-progress volume operations can now be canceled from the volume context menu.
- Bandwidth metrics are no longer broken out by protocol.
- Volume operations are now disabled when one is already in progress.
- The node block height now shows the estimated network height when syncing.
- Fixed an issue with the alert dismiss button overflowing.
- The GPU setting now displays the correct device support text.