### PR TITLE
Fix volume migration

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -55,11 +55,11 @@ type (
 	VolumeManager interface {
 		Usage() (usedSectors uint64, totalSectors uint64, err error)
 		Volumes() ([]storage.VolumeMeta, error)
-		Volume(id int) (storage.VolumeMeta, error)
+		Volume(id int64) (storage.VolumeMeta, error)
 		AddVolume(ctx context.Context, localPath string, maxSectors uint64, result chan<- error) (storage.Volume, error)
-		RemoveVolume(ctx context.Context, id int, force bool, result chan<- error) error
-		ResizeVolume(ctx context.Context, id int, maxSectors uint64, result chan<- error) error
-		SetReadOnly(id int, readOnly bool) error
+		RemoveVolume(ctx context.Context, id int64, force bool, result chan<- error) error
+		ResizeVolume(ctx context.Context, id int64, maxSectors uint64, result chan<- error) error
+		SetReadOnly(id int64, readOnly bool) error
 		RemoveSector(root types.Hash256) error
 		ResizeCache(size uint32)
 	}
@@ -164,7 +164,7 @@ func NewServer(name string, hostKey types.PublicKey, a Alerts, g Syncer, chain C
 		},
 		volumeJobs: volumeJobs{
 			volumes: vm,
-			jobs:    make(map[int]context.CancelFunc),
+			jobs:    make(map[int64]context.CancelFunc),
 		},
 	}
 	return jape.Mux(map[string]jape.Handler{

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -285,7 +285,7 @@ func (a *api) handleGETVolume(c jape.Context) {
 		return
 	}
 
-	volume, err := a.volumes.Volume(id)
+	volume, err := a.volumes.Volume(int64(id))
 	if errors.Is(err, storage.ErrVolumeNotFound) {
 		c.Error(err, http.StatusNotFound)
 		return
@@ -309,7 +309,7 @@ func (a *api) handlePUTVolume(c jape.Context) {
 		return
 	}
 
-	err := a.volumes.SetReadOnly(id, req.ReadOnly)
+	err := a.volumes.SetReadOnly(int64(id), req.ReadOnly)
 	if errors.Is(err, storage.ErrVolumeNotFound) {
 		c.Error(err, http.StatusNotFound)
 		return

--- a/host/contracts/contracts.go
+++ b/host/contracts/contracts.go
@@ -331,7 +331,7 @@ func (cu *ContractUpdater) Commit(revision SignedRevision, usage Usage) error {
 
 	start := time.Now()
 	// revise the contract
-	err := cu.store.ReviseContract(revision, usage, cu.sectors, cu.sectorActions)
+	err := cu.store.ReviseContract(revision, usage, cu.sectorActions)
 	if err == nil {
 		// clear the committed sector actions
 		cu.sectorActions = cu.sectorActions[:0]

--- a/host/contracts/manager_test.go
+++ b/host/contracts/manager_test.go
@@ -1013,7 +1013,7 @@ func TestSectorRoots(t *testing.T) {
 		defer release()
 
 		// use the database method directly to avoid the sector cache
-		err = db.ReviseContract(rev, contracts.Usage{}, uint64(i), []contracts.SectorChange{
+		err = db.ReviseContract(rev, contracts.Usage{}, []contracts.SectorChange{
 			{Action: contracts.SectorActionAppend, Root: root},
 		})
 		if err != nil {

--- a/host/contracts/persist.go
+++ b/host/contracts/persist.go
@@ -6,24 +6,6 @@ import (
 )
 
 type (
-	// UpdateContractTransaction atomically updates a single contract and its
-	// associated sector roots.
-	UpdateContractTransaction interface {
-		// AppendSector appends a sector root to the end of the contract
-		AppendSector(root types.Hash256) error
-		// SwapSectors swaps the sector roots at the given indices.
-		SwapSectors(i, j uint64) error
-		// TrimSectors removes the last n sector roots from the contract.
-		TrimSectors(n int) error
-		// UpdateSector updates the sector root at the given index.
-		UpdateSector(index uint64, newRoot types.Hash256) error
-
-		// AddUsage adds the additional usage costs to the contract.
-		AddUsage(Usage) error
-		// ReviseContract updates the current revision associated with a contract.
-		ReviseContract(SignedRevision) error
-	}
-
 	// UpdateStateTransaction atomically updates the contract manager's state.
 	UpdateStateTransaction interface {
 		ContractRelevant(types.FileContractID) (bool, error)
@@ -66,7 +48,7 @@ type (
 		ContractAction(height uint64, contractFn func(types.FileContractID, uint64, string)) error
 		// ReviseContract atomically updates a contract and its associated
 		// sector roots.
-		ReviseContract(revision SignedRevision, usage Usage, oldSectors uint64, sectorChanges []SectorChange) error
+		ReviseContract(revision SignedRevision, usage Usage, sectorChanges []SectorChange) error
 		// UpdateContractState atomically updates the contract manager's state.
 		UpdateContractState(modules.ConsensusChangeID, uint64, func(UpdateStateTransaction) error) error
 		// ExpireContractSectors removes sector roots for any contracts that are

--- a/host/storage/persist.go
+++ b/host/storage/persist.go
@@ -23,7 +23,7 @@ type (
 		// RemoveVolume removes a storage volume from the volume store. If there
 		// are used sectors in the volume, ErrVolumeNotEmpty is returned. If
 		// force is true, the volume is removed even if it is not empty.
-		RemoveVolume(volumeID int64, force bool) error
+		RemoveVolume(volumeID int64) error
 		// GrowVolume grows a storage volume's metadata to maxSectors. If the
 		// number of sectors in the volume is already greater than maxSectors,
 		// nil is returned.

--- a/host/storage/persist.go
+++ b/host/storage/persist.go
@@ -37,11 +37,11 @@ type (
 		// SetAvailable sets the available flag on a volume.
 		SetAvailable(volumeID int, available bool) error
 
-		// MigrateSectors returns a new location for each occupied sector of a volume
-		// starting at min. The sector data should be copied to the new volume and
-		// synced to disk during migrateFn. Iteration is stopped if migrateFn returns an
-		// error.
-		MigrateSectors(volumeID int, min uint64, migrateFn func(newLocations []SectorLocation) error) error
+		// MigrateSectors returns a new location for each occupied sector of a
+		// volume starting at min. The sector data should be copied to the new
+		// location and synced to disk during migrateFn. Iteration is stopped if
+		// migrateFn returns an error.
+		MigrateSectors(volumeID int, min uint64, migrateFn func(SectorLocation) error) error
 		// StoreSector calls fn with an empty location in a writable volume. If
 		// the sector root already exists, fn is called with the existing
 		// location and exists is true. Unless exists is true, The sector must

--- a/host/storage/persist.go
+++ b/host/storage/persist.go
@@ -15,33 +15,33 @@ type (
 		// Volumes returns a list of all volumes in the volume store.
 		Volumes() ([]Volume, error)
 		// Volume returns a volume in the store by its id
-		Volume(id int) (Volume, error)
+		Volume(id int64) (Volume, error)
 		// AddVolume initializes a new storage volume and adds it to the volume
 		// store. GrowVolume must be called afterwards to initialize the volume
 		// to its desired size.
-		AddVolume(localPath string, readOnly bool) (int, error)
+		AddVolume(localPath string, readOnly bool) (int64, error)
 		// RemoveVolume removes a storage volume from the volume store. If there
 		// are used sectors in the volume, ErrVolumeNotEmpty is returned. If
 		// force is true, the volume is removed even if it is not empty.
-		RemoveVolume(volumeID int, force bool) error
+		RemoveVolume(volumeID int64, force bool) error
 		// GrowVolume grows a storage volume's metadata to maxSectors. If the
 		// number of sectors in the volume is already greater than maxSectors,
 		// nil is returned.
-		GrowVolume(volumeID int, maxSectors uint64) error
+		GrowVolume(volumeID int64, maxSectors uint64) error
 		// ShrinkVolume shrinks a storage volume's metadata to maxSectors. If
 		// there are used sectors in the shrink range, an error is returned.
-		ShrinkVolume(volumeID int, maxSectors uint64) error
+		ShrinkVolume(volumeID int64, maxSectors uint64) error
 
 		// SetReadOnly sets the read-only flag on a volume.
-		SetReadOnly(volumeID int, readOnly bool) error
+		SetReadOnly(volumeID int64, readOnly bool) error
 		// SetAvailable sets the available flag on a volume.
-		SetAvailable(volumeID int, available bool) error
+		SetAvailable(volumeID int64, available bool) error
 
 		// MigrateSectors returns a new location for each occupied sector of a
 		// volume starting at min. The sector data should be copied to the new
 		// location and synced to disk during migrateFn. Iteration is stopped if
 		// migrateFn returns an error.
-		MigrateSectors(volumeID int, min uint64, migrateFn func(SectorLocation) error) error
+		MigrateSectors(volumeID int64, min uint64, migrateFn func(SectorLocation) error) error
 		// StoreSector calls fn with an empty location in a writable volume. If
 		// the sector root already exists, fn is called with the existing
 		// location and exists is true. Unless exists is true, The sector must

--- a/host/storage/storage.go
+++ b/host/storage/storage.go
@@ -928,11 +928,8 @@ func (vm *VolumeManager) Write(root types.Hash256, data *[rhp2.SectorSize]byte) 
 			return nil
 		}
 		start := time.Now()
-		vol, err := vm.getVolume(loc.Volume)
-		if err != nil {
-			return fmt.Errorf("failed to get volume %v: %w", loc.Volume, err)
-		} else if err := vol.WriteSector(data, loc.Index); err != nil {
-			return fmt.Errorf("failed to write sector %v: %w", root, err)
+		if err := vm.writeSector(data, loc, false); err != nil {
+			return err
 		}
 		vm.log.Debug("wrote sector", zap.String("root", root.String()), zap.Int64("volume", loc.Volume), zap.Uint64("index", loc.Index), zap.Duration("elapsed", time.Since(start)))
 		// Add newly written sector to cache

--- a/host/storage/storage.go
+++ b/host/storage/storage.go
@@ -435,8 +435,8 @@ func (vm *VolumeManager) migrateForRemoval(ctx context.Context, id int64, localP
 		}
 
 		if err := vm.migrateSector(newLoc, log.Named("migrate")); err != nil {
+			log.Error("failed to migrate sector", zap.Stringer("sectorRoot", newLoc.Root), zap.Error(err))
 			if force {
-				log.Error("failed to migrate sector", zap.Stringer("sectorRoot", newLoc.Root), zap.Error(err))
 				failed++
 				a.Data["failed"] = failed
 				return nil
@@ -449,9 +449,9 @@ func (vm *VolumeManager) migrateForRemoval(ctx context.Context, id int64, localP
 		vm.a.Register(a)
 		return nil
 	})
-	if err != nil && !force {
+	if err != nil {
 		return migrated, fmt.Errorf("failed to migrate sector data: %w", err)
-	} else if err := vm.vs.RemoveVolume(id, force); err != nil {
+	} else if err := vm.vs.RemoveVolume(id); err != nil {
 		return migrated, fmt.Errorf("failed to remove volume: %w", err)
 	}
 

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -567,7 +567,7 @@ func TestVolumeDistribution(t *testing.T) {
 	}
 	defer vm.Close()
 
-	volumeIDs := make([]int, 5)
+	volumeIDs := make([]int64, 5)
 	volumeDir := t.TempDir()
 	for i := range volumeIDs {
 		result := make(chan error, 1)

--- a/host/storage/volume.go
+++ b/host/storage/volume.go
@@ -49,7 +49,7 @@ type (
 
 	// A Volume stores and retrieves sector data
 	Volume struct {
-		ID           int    `json:"ID"`
+		ID           int64  `json:"ID"`
 		LocalPath    string `json:"localPath"`
 		UsedSectors  uint64 `json:"usedSectors"`
 		TotalSectors uint64 `json:"totalSectors"`

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -313,6 +313,10 @@ func (s *Store) ReviseContract(revision contracts.SignedRevision, usage contract
 				sectors++
 				delta++
 			case contracts.SectorActionTrim:
+				if sectors < change.A {
+					return fmt.Errorf("cannot trim %v sectors from contract with %v sectors", change.A, sectors)
+				}
+
 				if err := trimSectors(tx, contractID, change.A); err != nil {
 					return fmt.Errorf("failed to trim sectors: %w", err)
 				}
@@ -576,7 +580,7 @@ func swapSectors(tx txn, contractID int64, i, j uint64) error {
 	}
 
 	var records []contractSectorRootRef
-	rows, err := tx.Query(`SELECT id, sector_id FROM contract_sector_roots WHERE contract_id=$1 AND root_index IN ($2, $3) ORDER BY root_index ASC;`, contractID, i, j)
+	rows, err := tx.Query(`SELECT id, sector_id FROM contract_sector_roots WHERE contract_id=$1 AND root_index IN ($2, $3);`, contractID, i, j)
 	if err != nil {
 		return fmt.Errorf("failed to query sector IDs: %w", err)
 	}

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -137,8 +137,8 @@ func (u *updateContractsTxn) ContractRelevant(id types.FileContractID) (bool, er
 }
 
 func (s *Store) batchExpireContractSectors(height uint64) (removed []contractSectorRef, pruned int, err error) {
-	err = s.transaction(func(tx txn) error {
-		removed, err := expiredContractSectors(tx, height, sqlSectorBatchSize)
+	err = s.transaction(func(tx txn) (err error) {
+		removed, err = expiredContractSectors(tx, height, sqlSectorBatchSize)
 		if err != nil {
 			return fmt.Errorf("failed to select sectors: %w", err)
 		}
@@ -146,7 +146,8 @@ func (s *Store) batchExpireContractSectors(height uint64) (removed []contractSec
 		refs := make([]contractSectorRootRef, 0, len(removed))
 		for _, sector := range removed {
 			refs = append(refs, contractSectorRootRef{
-				dbID: sector.ID,
+				dbID:     sector.ID,
+				sectorID: sector.SectorID,
 			})
 		}
 

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -89,7 +89,7 @@ func TestReviseContract(t *testing.T) {
 		roots = append(roots, root)
 	}
 
-	err = db.ReviseContract(contract, contracts.Usage{}, 0, changes)
+	err = db.ReviseContract(contract, contracts.Usage{}, changes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestReviseContract(t *testing.T) {
 	changes = []contracts.SectorChange{
 		{Action: contracts.SectorActionSwap, A: uint64(i), B: uint64(j)},
 	}
-	err = db.ReviseContract(contract, contracts.Usage{}, uint64(len(roots)), changes)
+	err = db.ReviseContract(contract, contracts.Usage{}, changes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestReviseContract(t *testing.T) {
 	changes = []contracts.SectorChange{
 		{Action: contracts.SectorActionTrim, A: uint64(toRemove)},
 	}
-	err = db.ReviseContract(contract, contracts.Usage{}, uint64(len(roots)), changes)
+	err = db.ReviseContract(contract, contracts.Usage{}, changes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestReviseContract(t *testing.T) {
 	changes = []contracts.SectorChange{
 		{Action: contracts.SectorActionSwap, A: 0, B: 15},
 	}
-	err = db.ReviseContract(contract, contracts.Usage{}, uint64(len(roots)), changes)
+	err = db.ReviseContract(contract, contracts.Usage{}, changes)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -171,7 +171,7 @@ func TestReviseContract(t *testing.T) {
 	changes = []contracts.SectorChange{
 		{Action: contracts.SectorActionTrim, A: uint64(toTrim)},
 	}
-	err = db.ReviseContract(contract, contracts.Usage{}, uint64(len(roots)), changes)
+	err = db.ReviseContract(contract, contracts.Usage{}, changes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestReviseContract(t *testing.T) {
 		A:      uint64(toTrim),
 	})
 
-	err = db.ReviseContract(contract, contracts.Usage{}, 0, changes)
+	err = db.ReviseContract(contract, contracts.Usage{}, changes)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -313,7 +313,6 @@ func TestReviseContract(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
-
 	}
 }
 

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -14,6 +14,17 @@ import (
 	"lukechampine.com/frand"
 )
 
+func (s *Store) rootAtIndex(contractID types.FileContractID, rootIndex int64) (root types.Hash256, err error) {
+	err = s.transaction(func(tx txn) error {
+		const query = `SELECT s.sector_root FROM contract_sector_roots csr
+INNER JOIN stored_sectors s ON (csr.sector_id = s.id)
+INNER JOIN contracts c ON (csr.contract_id = c.id)
+WHERE c.contract_id=$1 AND csr.root_index=$2;`
+		return tx.QueryRow(query, sqlHash256(contractID), rootIndex).Scan((*sqlHash256)(&root))
+	})
+	return
+}
+
 func rootsEqual(a, b []types.Hash256) error {
 	if len(a) != len(b) {
 		return errors.New("length mismatch")
@@ -24,6 +35,24 @@ func rootsEqual(a, b []types.Hash256) error {
 		}
 	}
 	return nil
+}
+
+func runRevision(db *Store, revision contracts.SignedRevision, changes []contracts.SectorChange) error {
+	for _, change := range changes {
+		switch change.Action {
+		// store a sector in the database for the append or update actions
+		case contracts.SectorActionAppend, contracts.SectorActionUpdate:
+			root := frand.Entropy256()
+			release, err := db.StoreSector(root, func(loc storage.SectorLocation, exists bool) error { return nil })
+			if err != nil {
+				return fmt.Errorf("failed to store sector: %w", err)
+			}
+			defer release()
+			change.Root = root
+		}
+	}
+
+	return db.ReviseContract(revision, contracts.Usage{}, changes)
 }
 
 func TestReviseContract(t *testing.T) {
@@ -72,37 +101,28 @@ func TestReviseContract(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// add some sector roots
-	var changes []contracts.SectorChange
-	var roots []types.Hash256
-	for i := 0; i < 10; i++ {
-		root := frand.Entropy256()
-		release, err := db.StoreSector(root, func(loc storage.SectorLocation, exists bool) error { return nil })
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer release()
-		changes = append(changes, contracts.SectorChange{
-			Root:   root,
-			Action: contracts.SectorActionAppend,
-		})
-		roots = append(roots, root)
-	}
-
-	err = db.ReviseContract(contract, contracts.Usage{}, changes)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// checkConsistency is a helper function that verifies the expected sector
 	// roots are consistent with the database
-	checkConsistency := func() error {
-		// verify the roots were added in the correct order
-		dbRoots, err := db.SectorRoots(contract.Revision.ParentID)
+	checkConsistency := func(roots []types.Hash256, expected int) error {
+		dbRoot, err := db.SectorRoots(contract.Revision.ParentID)
 		if err != nil {
 			return fmt.Errorf("failed to get sector roots: %w", err)
-		} else if err = rootsEqual(roots, dbRoots); err != nil {
+		} else if len(dbRoot) != expected {
+			return fmt.Errorf("expected %v sector roots, got %v", expected, len(dbRoot))
+		} else if len(roots) != expected {
+			return fmt.Errorf("expected %v sector roots, got %v", expected, len(roots))
+		} else if err = rootsEqual(roots, dbRoot); err != nil {
 			return fmt.Errorf("sector roots mismatch: %w", err)
+		}
+
+		// verify the roots were added in the correct order
+		for i := range roots {
+			root, err := db.rootAtIndex(contract.Revision.ParentID, int64(i))
+			if err != nil {
+				return fmt.Errorf("failed to get sector root %d: %w", i, err)
+			} else if root != roots[i] {
+				return fmt.Errorf("sector root mismatch: expected %v, got %v", roots[i], root)
+			}
 		}
 
 		m, err := db.Metrics(time.Now())
@@ -114,128 +134,184 @@ func TestReviseContract(t *testing.T) {
 		return nil
 	}
 
-	// verify the roots were added
-	if err = checkConsistency(); err != nil {
-		t.Fatal(err)
+	var roots []types.Hash256
+	tests := []struct {
+		name    string
+		changes []contracts.SectorChange
+		sectors int
+		errors  bool
+	}{
+		{
+			name: "append 10 roots",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+			},
+			sectors: 10,
+		},
+		{
+			name: "swap 4 roots",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionSwap, A: 0, B: 1},
+				{Action: contracts.SectorActionSwap, A: 6, B: 4},
+			},
+			sectors: 10,
+		},
+		{
+			name: "update root",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionUpdate, A: 3},
+			},
+			sectors: 10,
+		},
+		{
+			name: "trim 5 roots",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionTrim, A: 5},
+			},
+			sectors: 5,
+		},
+		{
+			name: "swap outside range",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionSwap, A: 0, B: 10},
+			},
+			errors:  true,
+			sectors: 5,
+		},
+		{
+			name: "append swap trim",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionSwap, A: 5, B: 2},
+				{Action: contracts.SectorActionTrim, A: 1},
+			},
+			sectors: 5,
+		},
+		{
+			name: "trim append swap",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionTrim, A: 1},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionSwap, A: 4, B: 1},
+			},
+			sectors: 5,
+		},
+		{
+			name: "swap 2 roots",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionSwap, A: 3, B: 1},
+			},
+			sectors: 5,
+		},
+		{
+			name: "trim append",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionTrim, A: 5},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+			},
+			sectors: 3,
+		},
+		{
+			name: "trim more",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionTrim, A: 5},
+			},
+			sectors: 3,
+			errors:  true,
+		},
+		{
+			name: "update outside range",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionUpdate, A: 6},
+			},
+			sectors: 3,
+			errors:  true,
+		},
+		{
+			name: "trim all",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionTrim, A: 3},
+			},
+			sectors: 0,
+		},
+		{
+			name: "append 5",
+			changes: []contracts.SectorChange{
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+				{Action: contracts.SectorActionAppend},
+			},
+			sectors: 5,
+		},
 	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// update the expected roots
+			for i, change := range test.changes {
+				switch change.Action {
+				case contracts.SectorActionAppend:
+					// add a random sector root
+					root := frand.Entropy256()
+					release, err := db.StoreSector(root, func(loc storage.SectorLocation, exists bool) error { return nil })
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer release()
+					test.changes[i].Root = root
+					roots = append(roots, root)
+				case contracts.SectorActionUpdate:
+					// replace with a random sector root
+					root := frand.Entropy256()
+					release, err := db.StoreSector(root, func(loc storage.SectorLocation, exists bool) error { return nil })
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer release()
+					test.changes[i].Root = root
 
-	// swap two roots
-	i, j := 5, 8
-	changes = []contracts.SectorChange{
-		{Action: contracts.SectorActionSwap, A: uint64(i), B: uint64(j)},
-	}
-	err = db.ReviseContract(contract, contracts.Usage{}, changes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	roots[i], roots[j] = roots[j], roots[i]
+					if test.errors && change.A >= uint64(len(roots)) { // test failure
+						continue
+					}
+					roots[change.A] = root
+				case contracts.SectorActionSwap:
+					if test.errors && (change.A >= uint64(len(roots)) || change.B >= uint64(len(roots))) { // test failure
+						continue
+					}
+					roots[change.A], roots[change.B] = roots[change.B], roots[change.A]
+				case contracts.SectorActionTrim:
+					if test.errors && change.A >= uint64(len(roots)) { // test failure
+						continue
+					}
+					roots = roots[:len(roots)-int(change.A)]
+				}
+			}
 
-	// verify the roots were swapped
-	if err = checkConsistency(); err != nil {
-		t.Fatal(err)
-	}
-
-	// trim the last 3 roots
-	toRemove := 3
-	changes = []contracts.SectorChange{
-		{Action: contracts.SectorActionTrim, A: uint64(toRemove)},
-	}
-	err = db.ReviseContract(contract, contracts.Usage{}, changes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	roots = roots[:len(roots)-toRemove]
-
-	// verify the roots were removed
-	if err = checkConsistency(); err != nil {
-		t.Fatal(err)
-	}
-
-	// swap a root outside of the range, should fail
-	changes = []contracts.SectorChange{
-		{Action: contracts.SectorActionSwap, A: 0, B: 15},
-	}
-	err = db.ReviseContract(contract, contracts.Usage{}, changes)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-
-	// verify the roots stayed the same
-	if err = checkConsistency(); err != nil {
-		t.Fatal(err)
-	}
-
-	// trim everything
-	toTrim := len(roots)
-	// swap a root outside of the range, should fail
-	changes = []contracts.SectorChange{
-		{Action: contracts.SectorActionTrim, A: uint64(toTrim)},
-	}
-	err = db.ReviseContract(contract, contracts.Usage{}, changes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	roots = roots[:0]
-
-	// verify the roots are gone
-	if err = checkConsistency(); err != nil {
-		t.Fatal(err)
-	}
-
-	// test multiple operations in the same transaction
-	// add some sector roots
-	changes = changes[:0]
-	for i := 0; i < 10; i++ {
-		root := frand.Entropy256()
-		release, err := db.StoreSector(root, func(loc storage.SectorLocation, exists bool) error { return nil })
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer release()
-		changes = append(changes, contracts.SectorChange{
-			Root:   root,
-			Action: contracts.SectorActionAppend,
+			if err := runRevision(db, contract, test.changes); err != nil {
+				if test.errors {
+					t.Log("received error:", err)
+					return
+				}
+				t.Fatal(err)
+			} else if err == nil && test.errors {
+				t.Fatal("expected error")
+			} else if err := checkConsistency(roots, test.sectors); err != nil {
+				t.Fatal(err)
+			}
 		})
-		roots = append(roots, root)
-	}
 
-	// store a sector root to update the contract
-	updateRoot := frand.Entropy256()
-	release, err := db.StoreSector(updateRoot, func(loc storage.SectorLocation, exists bool) error { return nil })
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer release()
-
-	i, j = 3, 6
-	toUpdate := 8
-	toTrim = 3
-	changes = append(changes, contracts.SectorChange{
-		Action: contracts.SectorActionSwap,
-		A:      uint64(i),
-		B:      uint64(j),
-	}, contracts.SectorChange{
-		Action: contracts.SectorActionUpdate,
-		A:      uint64(toUpdate),
-		Root:   updateRoot,
-	}, contracts.SectorChange{
-		Action: contracts.SectorActionTrim,
-		A:      uint64(toTrim),
-	})
-
-	err = db.ReviseContract(contract, contracts.Usage{}, changes)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// update the roots
-	roots[i], roots[j] = roots[j], roots[i]
-	roots[toUpdate] = updateRoot
-	roots = roots[:len(roots)-toTrim]
-
-	// verify the roots match
-	if err = checkConsistency(); err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -130,6 +130,8 @@ func TestReviseContract(t *testing.T) {
 			return fmt.Errorf("failed to get metrics: %w", err)
 		} else if m.Storage.ContractSectors != uint64(len(roots)) {
 			return fmt.Errorf("expected %v contract sectors, got %v", len(roots), m.Storage.ContractSectors)
+		} else if m.Storage.PhysicalSectors != uint64(len(roots)) {
+			return fmt.Errorf("expected %v physical sectors, got %v", len(roots), m.Storage.PhysicalSectors)
 		}
 		return nil
 	}

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -57,8 +57,7 @@ CREATE TABLE volume_sectors (
 	sector_id INTEGER UNIQUE REFERENCES stored_sectors (id),
 	UNIQUE (volume_id, volume_index)
 );
--- careful with these indices, the empty sector query is fragile and relies on
--- the volume_index indice for performance.
+CREATE INDEX volume_sectors_volume_id_sector_id ON volume_sectors(volume_id, sector_id);
 CREATE INDEX volume_sectors_volume_id ON volume_sectors(volume_id);
 CREATE INDEX volume_sectors_volume_index ON volume_sectors(volume_index ASC);
 CREATE INDEX volume_sectors_sector_id ON volume_sectors(sector_id);

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -9,6 +9,14 @@ import (
 	"go.sia.tech/hostd/host/contracts"
 )
 
+// migrateVersion18 adds an index to the volume_sectors table to speed up
+// empty sector selection.
+func migrateVersion18(tx txn) error {
+	const query = `CREATE INDEX volume_sectors_volume_id_sector_id ON volume_sectors(volume_id, sector_id);`
+	_, err := tx.Exec(query)
+	return err
+}
+
 // migrateVersion17 recalculates the indices of all contract sector roots.
 // Fixes a bug where the indices were not being properly updated if more than
 // one root was trimmed.
@@ -484,4 +492,5 @@ var migrations = []func(tx txn) error{
 	migrateVersion15,
 	migrateVersion16,
 	migrateVersion17,
+	migrateVersion18,
 }

--- a/persist/sqlite/volumes.go
+++ b/persist/sqlite/volumes.go
@@ -19,6 +19,8 @@ type volumeSectorRef struct {
 var errNoSectorsToMigrate = errors.New("no sectors to migrate")
 
 func (s *Store) migrateSector(volumeID int64, startIndex uint64, migrateFn func(location storage.SectorLocation) error, log *zap.Logger) error {
+	start := time.Now()
+
 	var locks []int64
 	var oldLoc, newLoc storage.SectorLocation
 	err := s.transaction(func(tx txn) (err error) {
@@ -94,7 +96,7 @@ func (s *Store) migrateSector(volumeID int64, startIndex uint64, migrateFn func(
 		}
 		return nil
 	})
-	log.Debug("migrated sector", zap.Uint64("oldIndex", oldLoc.Index), zap.Stringer("root", newLoc.Root), zap.Int64("newVolume", newLoc.Volume), zap.Uint64("newIndex", newLoc.Index))
+	log.Debug("migrated sector", zap.Uint64("oldIndex", oldLoc.Index), zap.Stringer("root", newLoc.Root), zap.Int64("newVolume", newLoc.Volume), zap.Uint64("newIndex", newLoc.Index), zap.Duration("elapsed", time.Since(start)))
 	return err
 }
 

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -721,9 +721,9 @@ func TestPrune(t *testing.T) {
 			}
 		}
 
-		for _, root := range deleted {
+		for i, root := range deleted {
 			if _, _, err := db.SectorLocation(root); !errors.Is(err, storage.ErrSectorNotFound) {
-				return fmt.Errorf("expected ErrSectorNotFound, got %v", err)
+				return fmt.Errorf("expected ErrSectorNotFound for sector %d %q, got %v", i, root, err)
 			}
 		}
 
@@ -784,7 +784,7 @@ func TestPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// expire the contract sectors
+	// expire the rest of the contract sectors
 	if err := db.ExpireContractSectors(c.Revision.WindowEnd + 1); err != nil {
 		t.Fatal(err)
 	}

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -188,7 +188,7 @@ func TestVolumeAdd(t *testing.T) {
 		volume, err := db.Volume(volumeID)
 		if err != nil {
 			t.Fatal(err)
-		} else if volume.ID != i {
+		} else if volume.ID != int64(i) {
 			t.Fatalf("expected volume ID to be %v, got %v", i, volume.ID)
 		} else if volume.LocalPath != localPath {
 			t.Fatalf("expected local path to be %v, got %v", localPath, volume.LocalPath)
@@ -390,7 +390,7 @@ func TestRemoveVolume(t *testing.T) {
 	}
 
 	// check that the empty volume can be removed
-	if err := db.RemoveVolume(volume.ID, false); err != nil {
+	if err := db.RemoveVolume(int64(volume.ID), false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -652,7 +652,7 @@ func TestPrune(t *testing.T) {
 			Action: contracts.SectorActionAppend,
 		})
 	}
-	err = db.ReviseContract(c, contracts.Usage{}, 0, changes)
+	err = db.ReviseContract(c, contracts.Usage{}, changes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -776,7 +776,7 @@ func TestPrune(t *testing.T) {
 	changes = []contracts.SectorChange{
 		{Action: contracts.SectorActionTrim, A: uint64(len(contractSectors) / 2)},
 	}
-	if err := db.ReviseContract(c, contracts.Usage{}, uint64(len(contractSectors)), changes); err != nil {
+	if err := db.ReviseContract(c, contracts.Usage{}, changes); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Fixes numerous issues with migration and sector pruning.
- Fixes database is locked error while migrating large volumes (closes #179)
- Fixes an issue with physical sectors not being pruned after being removed from a contract.
- Adds a migration to recalculate the physical and contract sectors
- Fixes an edge case causing sector root_index to be off after trimming sectors
- Adds a migration to reset the root indices