### PR TITLE
Enable writes while initializing or growing volumes

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -284,7 +284,7 @@ func (a *api) handleGETContract(c jape.Context) {
 }
 
 func (a *api) handleGETVolume(c jape.Context) {
-	var id int
+	var id int64
 	if err := c.DecodeParam("id", &id); err != nil {
 		return
 	} else if id < 0 {
@@ -292,7 +292,7 @@ func (a *api) handleGETVolume(c jape.Context) {
 		return
 	}
 
-	volume, err := a.volumes.Volume(int64(id))
+	volume, err := a.volumes.Volume(id)
 	if errors.Is(err, storage.ErrVolumeNotFound) {
 		c.Error(err, http.StatusNotFound)
 		return
@@ -303,7 +303,7 @@ func (a *api) handleGETVolume(c jape.Context) {
 }
 
 func (a *api) handlePUTVolume(c jape.Context) {
-	var id int
+	var id int64
 	if err := c.DecodeParam("id", &id); err != nil {
 		return
 	} else if id < 0 {
@@ -316,7 +316,7 @@ func (a *api) handlePUTVolume(c jape.Context) {
 		return
 	}
 
-	err := a.volumes.SetReadOnly(int64(id), req.ReadOnly)
+	err := a.volumes.SetReadOnly(id, req.ReadOnly)
 	if errors.Is(err, storage.ErrVolumeNotFound) {
 		c.Error(err, http.StatusNotFound)
 		return

--- a/api/volumes.go
+++ b/api/volumes.go
@@ -153,7 +153,7 @@ func (a *api) handlePOSTVolume(c jape.Context) {
 }
 
 func (a *api) handleDeleteVolume(c jape.Context) {
-	var id int
+	var id int64
 	var force bool
 	if err := c.DecodeParam("id", &id); err != nil {
 		return
@@ -163,12 +163,12 @@ func (a *api) handleDeleteVolume(c jape.Context) {
 	} else if err := c.DecodeForm("force", &force); err != nil {
 		return
 	}
-	err := a.volumeJobs.RemoveVolume(int64(id), force)
+	err := a.volumeJobs.RemoveVolume(id, force)
 	a.checkServerError(c, "failed to remove volume", err)
 }
 
 func (a *api) handlePUTVolumeResize(c jape.Context) {
-	var id int
+	var id int64
 	if err := c.DecodeParam("id", &id); err != nil {
 		return
 	} else if id < 0 {
@@ -181,12 +181,12 @@ func (a *api) handlePUTVolumeResize(c jape.Context) {
 		return
 	}
 
-	err := a.volumeJobs.ResizeVolume(int64(id), req.MaxSectors)
+	err := a.volumeJobs.ResizeVolume(id, req.MaxSectors)
 	a.checkServerError(c, "failed to resize volume", err)
 }
 
 func (a *api) handleDELETEVolumeCancelOp(c jape.Context) {
-	var id int
+	var id int64
 	if err := c.DecodeParam("id", &id); err != nil {
 		return
 	} else if id < 0 {
@@ -194,6 +194,6 @@ func (a *api) handleDELETEVolumeCancelOp(c jape.Context) {
 		return
 	}
 
-	err := a.volumeJobs.Cancel(int64(id))
+	err := a.volumeJobs.Cancel(id)
 	a.checkServerError(c, "failed to cancel operation", err)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.17
 	gitlab.com/NebulousLabs/encoding v0.0.0-20200604091946-456c3dc907fe
 	go.sia.tech/core v0.1.12-0.20231011160830-b58e9e8ec3ce
-	go.sia.tech/jape v0.9.1-0.20230525021720-ecf031ecbffb
+	go.sia.tech/jape v0.10.0
 	go.sia.tech/renterd v0.6.0
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca
 	go.sia.tech/web/hostd v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -228,6 +228,8 @@ go.sia.tech/core v0.1.12-0.20231011160830-b58e9e8ec3ce h1:rRji+HxWtZEyXAyc/LSqS4
 go.sia.tech/core v0.1.12-0.20231011160830-b58e9e8ec3ce/go.mod h1:3EoY+rR78w1/uGoXXVqcYdwSjSJKuEMI5bL7WROA27Q=
 go.sia.tech/jape v0.9.1-0.20230525021720-ecf031ecbffb h1:yLDEqkqC19E/HgBoq2Uhw9oH3SMNRyeRjZ7Ep4dPKR8=
 go.sia.tech/jape v0.9.1-0.20230525021720-ecf031ecbffb/go.mod h1:4QqmBB+t3W7cNplXPj++ZqpoUb2PeiS66RLpXmEGap4=
+go.sia.tech/jape v0.10.0 h1:wsIURirNV29fvqxhvvbd0yhKh+9JeNZvz4haJUL/+yI=
+go.sia.tech/jape v0.10.0/go.mod h1:4QqmBB+t3W7cNplXPj++ZqpoUb2PeiS66RLpXmEGap4=
 go.sia.tech/mux v1.2.0 h1:ofa1Us9mdymBbGMY2XH/lSpY8itFsKIo/Aq8zwe+GHU=
 go.sia.tech/mux v1.2.0/go.mod h1:Yyo6wZelOYTyvrHmJZ6aQfRoer3o4xyKQ4NmQLJrBSo=
 go.sia.tech/renterd v0.6.0 h1:eEWftx9xOvYVeGCejmyTopxKAql+KvnHxh1kMk5GEAo=

--- a/host/storage/consts_default.go
+++ b/host/storage/consts_default.go
@@ -5,5 +5,7 @@ package storage
 import "time"
 
 const (
+	resizeBatchSize = 64 // 256 MiB
+
 	cleanupInterval = 15 * time.Minute
 )

--- a/host/storage/consts_testing.go
+++ b/host/storage/consts_testing.go
@@ -4,4 +4,6 @@ package storage
 
 const (
 	cleanupInterval = 0
+
+	resizeBatchSize = 4 // 16 MiB
 )

--- a/host/storage/recorder.go
+++ b/host/storage/recorder.go
@@ -7,7 +7,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const flushInterval = 30 * time.Second
+const flushInterval = time.Minute
 
 type (
 	sectorAccessRecorder struct {

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -1084,8 +1084,6 @@ func TestVolumeShrink(t *testing.T) {
 		t.Fatalf("expected %v total sectors, got %v", remainingSectors, meta.TotalSectors)
 	} else if meta.UsedSectors != remainingSectors {
 		t.Fatalf("expected %v used sectors, got %v", remainingSectors, meta.UsedSectors)
-	} else if meta.Status != storage.VolumeStatusReady {
-		t.Fatalf("expected volume status to be ready, got %v", meta.Status)
 	}
 
 	// validate that the sectors were moved to the beginning of the volume

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -916,8 +916,6 @@ func TestVolumeGrow(t *testing.T) {
 		t.Fatalf("expected %v total sectors, got %v", newSectors, meta.TotalSectors)
 	} else if meta.UsedSectors != uint64(len(roots)) {
 		t.Fatalf("expected %v used sectors, got %v", len(roots), meta.UsedSectors)
-	} else if meta.Status != storage.VolumeStatusReady {
-		t.Fatalf("expected volume status to be ready, got %v", meta.Status)
 	}
 
 	f, err := os.Open(volumeFilePath)

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -772,15 +772,17 @@ func TestVolumeConcurrency(t *testing.T) {
 		t.Fatalf("expected %v used sectors, got %v", writeSectors, volume.UsedSectors)
 	}
 
-	// shrink the volume so it is nearly
+	// generate a random sector
+	var sector [rhp2.SectorSize]byte
+	_, _ = frand.Read(sector[:256])
+	root := rhp2.SectorRoot(&sector)
+
+	// shrink the volume so it is nearly full
 	if err := vm.ResizeVolume(context.Background(), volume.ID, writeSectors+1, result); err != nil {
 		t.Fatal(err)
 	}
 
 	// try to write a sector to the volume, which should fail
-	var sector [rhp2.SectorSize]byte
-	_, _ = frand.Read(sector[:256])
-	root := rhp2.SectorRoot(&sector)
 	if _, err := vm.Write(root, &sector); !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected %v, got %v", storage.ErrNotEnoughStorage, err)
 	}

--- a/host/storage/volume.go
+++ b/host/storage/volume.go
@@ -129,7 +129,6 @@ func (v *volume) SetStatus(status string) error {
 			return fmt.Errorf("volume is %v", v.stats.Status)
 		}
 	case VolumeStatusReady, VolumeStatusUnavailable:
-		break
 	default:
 		panic("cannot set status to " + status) // developer error
 	}


### PR DESCRIPTION
Improves new host onboarding by enabling writes to volumes before they finish initializing.

Closes #199 