### PR TITLE
Change renewal validation

### DIFF
--- a/rhp/v3/rpc.go
+++ b/rhp/v3/rpc.go
@@ -597,10 +597,5 @@ func validRenewalTxnSet(txnset []types.Transaction) error {
 	case len(txnset[len(txnset)-1].FileContractRevisions) != 1:
 		return errors.New("transaction set must contain exactly one file contract revision")
 	}
-	for _, txn := range txnset[:len(txnset)-1] {
-		if len(txn.FileContracts) != 0 || len(txn.FileContractRevisions) != 0 {
-			return errors.New("transaction set contains non-renewal transactions")
-		}
-	}
 	return nil
 }


### PR DESCRIPTION
Remove parent transaction check in renewal validation to allow unconfirmed parents with other contracts