### PR TITLE
Pre-validate auto announcement

### DIFF
--- a/host/settings/announce.go
+++ b/host/settings/announce.go
@@ -159,6 +159,12 @@ func (cm *ConfigManager) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// get the current net address
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
+
+	if err := validateNetAddress(cm.settings.NetAddress); err != nil {
+		log.Debug("skipping auto announcement for invalid net address", zap.Error(err))
+		return
+	}
+
 	currentNetAddress := cm.settings.NetAddress
 	cm.scanHeight = uint64(cc.BlockHeight)
 	timestamp := time.Unix(int64(cc.AppliedBlocks[len(cc.AppliedBlocks)-1].Timestamp), 0)
@@ -168,7 +174,7 @@ func (cm *ConfigManager) ProcessConsensusChange(cc modules.ConsensusChange) {
 
 	// if the address hasn't changed, don't reannounce
 	if cm.scanHeight < nextAnnounceHeight && currentNetAddress == lastAnnouncement.Address {
-		log.Debug("skipping announcement")
+		log.Debug("skipping announcement for unchanged address")
 		return
 	}
 

--- a/host/settings/netaddress_default.go
+++ b/host/settings/netaddress_default.go
@@ -3,6 +3,7 @@
 package settings
 
 import (
+	"errors"
 	"fmt"
 	"net"
 )
@@ -11,6 +12,10 @@ func validateNetAddress(netaddress string) error {
 	addr, _, err := net.SplitHostPort(netaddress)
 	if err != nil {
 		return fmt.Errorf("invalid net address %q: net addresses must contain an IP and port: %w", netaddress, err)
+	} else if addr == "" {
+		return errors.New("empty net address")
+	} else if addr == "localhost" {
+		return errors.New("net address cannot be localhost")
 	}
 
 	ip := net.ParseIP(addr)


### PR DESCRIPTION
Prevent log messages when trying and failing to announce "localhost"