### PR TITLE
Separate console/file logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The Zen testnet version of `hostd` changes the default ports:
 ### Environment Variables
 + `HOSTD_API_PASSWORD` - The password for the UI and API
 + `HOSTD_SEED` - The recovery phrase for the wallet
-+ `HOSTD_LOG_PATH` - changes the path of the log file `hostd.log`. If unset, the
++ `HOSTD_LOG_FILE` - changes the location of the log file. If unset, the
   log file will be created in the data directory
 + `HOSTD_CONFIG_FILE` - changes the path of the optional config file. If unset,
   `hostd` will check for a config file in the current directory
@@ -99,8 +99,17 @@ rhp3:
   tcp: :9983
   websocket: :9984
 log:
-  path: /var/log/hostd
-  level: info
+  level: info # global log level
+  stdout:
+	enabled: true # enable logging to stdout
+    level: info # log level for console logger
+	format: human # log format (human, json)
+	enableANSI: true # enable ANSI color codes (disabled on Windows)
+  file:
+    enabled: true # enable logging to file
+	level: info # log level for file logger
+	path: /var/log/hostd/hostd.log # the path of the log file
+    format: json # log format (human, json)
 ```
 
 # Building

--- a/cmd/hostd/consts_default.go
+++ b/cmd/hostd/consts_default.go
@@ -5,8 +5,12 @@ package main
 const (
 	apiPasswordEnvVariable = "HOSTD_API_PASSWORD"
 	walletSeedEnvVariable  = "HOSTD_SEED"
-	logPathEnvVariable     = "HOSTD_LOG_PATH"
-	configPathEnvVariable  = "HOSTD_CONFIG_FILE"
+	// logPathEnvVariable overrides the path of the log file.
+	// Deprecated: use logFileEnvVar instead.
+	logPathEnvVariable = "HOSTD_LOG_PATH"
+	// logFileEnvVariable overrides the location of the log file.
+	logFileEnvVariable    = "HOSTD_LOG_FILE"
+	configPathEnvVariable = "HOSTD_CONFIG_FILE"
 
 	defaultAPIAddr     = "localhost:9980"
 	defaultGatewayAddr = ":9981"

--- a/cmd/hostd/consts_testnet.go
+++ b/cmd/hostd/consts_testnet.go
@@ -5,8 +5,12 @@ package main
 const (
 	apiPasswordEnvVariable = "HOSTD_ZEN_API_PASSWORD"
 	walletSeedEnvVariable  = "HOSTD_ZEN_SEED"
-	logPathEnvVariable     = "HOSTD_ZEN_LOG_PATH"
-	configPathEnvVariable  = "HOSTD_ZEN_CONFIG_FILE"
+	// logPathEnvVariable overrides the path of the log file.
+	// Deprecated: use logFileEnvVar instead.
+	logPathEnvVariable = "HOSTD_ZEN_LOG_PATH"
+	// logFileEnvVariable overrides the location of the log file.
+	logFileEnvVariable    = "HOSTD_ZEN_LOG_FILE"
+	configPathEnvVariable = "HOSTD_ZEN_CONFIG_FILE"
 
 	defaultAPIAddr     = "localhost:9880"
 	defaultGatewayAddr = ":9881"

--- a/config/config.go
+++ b/config/config.go
@@ -40,7 +40,7 @@ type (
 		Level      string `yaml:"level"` // override the stdout log level
 		Enabled    bool   `yaml:"enabled"`
 		Format     string `yaml:"format"`
-		EnableANSI bool   `yaml:"enableANSI"`
+		EnableANSI bool   `yaml:"enableANSI"` //nolint:tagliatelle
 	}
 
 	// Log contains the configuration for the logger.

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,8 @@ type (
 		Enabled bool   `yaml:"enabled"`
 		Level   string `yaml:"level"` // override the file log level
 		Format  string `yaml:"format"`
-		Path    string `yaml:"path"`
+		// Path is the path of the log file.
+		Path string `yaml:"path"`
 	}
 
 	// StdOut configures the standard output of the logger.
@@ -45,6 +46,9 @@ type (
 
 	// Log contains the configuration for the logger.
 	Log struct {
+		// Path is the directory to store the hostd.log file.
+		// Deprecated: use File.Path instead.
+		Path   string  `yaml:"path"`
 		Level  string  `yaml:"level"` // global log level
 		StdOut StdOut  `yaml:"stdout"`
 		File   LogFile `yaml:"file"`

--- a/config/config.go
+++ b/config/config.go
@@ -27,10 +27,27 @@ type (
 		KeyPath          string `yaml:"keyPath"`
 	}
 
+	// LogFile configures the file output of the logger.
+	LogFile struct {
+		Enabled bool   `yaml:"enabled"`
+		Level   string `yaml:"level"` // override the file log level
+		Format  string `yaml:"format"`
+		Path    string `yaml:"path"`
+	}
+
+	// StdOut configures the standard output of the logger.
+	StdOut struct {
+		Level      string `yaml:"level"` // override the stdout log level
+		Enabled    bool   `yaml:"enabled"`
+		Format     string `yaml:"format"`
+		EnableANSI bool   `yaml:"enableANSI"`
+	}
+
 	// Log contains the configuration for the logger.
 	Log struct {
-		Path  string `yaml:"path"`
-		Level string `yaml:"level"`
+		Level  string  `yaml:"level"` // global log level
+		StdOut StdOut  `yaml:"stdout"`
+		File   LogFile `yaml:"file"`
 	}
 
 	// Config contains the configuration for the host.


### PR DESCRIPTION
Adds additional configuration for controlling logging locations and formats. Closes #176 

```yaml
log:
  level: info # global log level. Defaults to info. Can be overridden per log type
  stdout:
    enabled: true # enable or disable stdout logging. Defaults to true
    level: info # stdout log level. Defaults to the global log level.
    format: human # set the log format. Either "human" or "json". Defaults to "human"
    enableANSI: true # enable or disable stdout log colors. Defaults to false on Windows, true everywhere else
  file:
    enabled: true # enable or disable file logging
    level: info # file log level. Defaults to the global log level.
    format: json # set the log format. Either "human" or "json". Defaults to "json"
    path: /my/logpath/hostd.log # set the log file location. Defaults to hostd.log in the data directory
```