### PR TITLE
Add prometheus response format to endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -46,8 +46,8 @@ type (
 		UpdateDDNS(force bool) error
 	}
 
-	// Metrics retrieves metrics related to the host
-	Metrics interface {
+	// A MetricManager retrieves metrics related to the host
+	MetricManager interface {
 		// PeriodMetrics returns metrics for n periods starting at start.
 		PeriodMetrics(start time.Time, periods int, interval metrics.Interval) (period []metrics.Metrics, err error)
 		// Metrics returns aggregated metrics for the host as of the timestamp.
@@ -147,7 +147,7 @@ type (
 		contracts ContractManager
 		volumes   VolumeManager
 		wallet    Wallet
-		metrics   Metrics
+		metrics   MetricManager
 		settings  Settings
 		sessions  RHPSessionReporter
 
@@ -157,7 +157,7 @@ type (
 )
 
 // NewServer initializes the API
-func NewServer(name string, hostKey types.PublicKey, a Alerts, wh WebHooks, g Syncer, chain ChainManager, tp TPool, cm ContractManager, am AccountManager, vm VolumeManager, rsr RHPSessionReporter, m Metrics, s Settings, w Wallet, log *zap.Logger) http.Handler {
+func NewServer(name string, hostKey types.PublicKey, a Alerts, wh WebHooks, g Syncer, chain ChainManager, tp TPool, cm ContractManager, am AccountManager, vm VolumeManager, rsr RHPSessionReporter, m MetricManager, s Settings, w Wallet, log *zap.Logger) http.Handler {
 	api := &api{
 		hostKey: hostKey,
 		name:    name,

--- a/api/prometheus.go
+++ b/api/prometheus.go
@@ -1,0 +1,273 @@
+package api
+
+import (
+	"time"
+
+	rhp2 "go.sia.tech/core/rhp/v2"
+	"go.sia.tech/hostd/internal/prometheus"
+)
+
+// PrometheusMetric returns a Prometheus metric for the host state.
+func (hs HostState) PrometheusMetric() []prometheus.Metric {
+	return []prometheus.Metric{
+		{
+			Name: "hostd_host_state",
+			Labels: map[string]any{
+				"name":           hs.Name,
+				"public_key":     hs.PublicKey,
+				"wallet_address": hs.WalletAddress,
+				"network":        hs.Network,
+				"version":        hs.Version,
+				"commit":         hs.Commit,
+				"os":             hs.OS,
+				"build_time":     hs.BuildTime,
+			},
+		},
+		{
+			Name:      "hostd_start_time",
+			Value:     1,
+			Timestamp: hs.StartTime,
+		},
+		{
+			Name:      "hostd_last_announcement",
+			Labels:    map[string]any{"address": hs.LastAnnouncement.Address, "id": hs.LastAnnouncement.Index.ID},
+			Value:     float64(hs.LastAnnouncement.Index.Height),
+			Timestamp: time.Now(),
+		},
+	}
+}
+
+// PrometheusMetric returns a Prometheus metric for the consensus state.
+func (cs ConsensusState) PrometheusMetric() []prometheus.Metric {
+	return []prometheus.Metric{
+		{
+			Name: "hostd_consensus_state_synced",
+			Value: func() float64 {
+				if cs.Synced {
+					return 1
+				}
+				return 0
+			}(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_consensus_state_index",
+			Labels:    map[string]any{"id": cs.ChainIndex.ID},
+			Value:     float64(cs.ChainIndex.Height),
+			Timestamp: time.Now(),
+		},
+	}
+}
+
+// PrometheusMetric returns Prometheus samples for the host settings.
+func (hs HostSettings) PrometheusMetric() []prometheus.Metric {
+	return []prometheus.Metric{
+		{
+			Name: "hostd_settings",
+			Labels: map[string]any{
+				"accepting_contracts": hs.AcceptingContracts,
+			},
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_settings_max_contract_duration",
+			Value:     float64(hs.MaxContractDuration),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_settings_contract_price",
+			Value:     hs.ContractPrice.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_settings_base_rpc_price",
+			Value:     hs.BaseRPCPrice.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_settings_sector_access_price",
+			Value:     hs.SectorAccessPrice.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_settings_storage_price",
+			Value:     hs.StoragePrice.Mul64(1e12).Mul64(4320).Siacoins(), // price * 1TB * 4320 blocks per month
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_settings_ingress_price",
+			Value:     hs.IngressPrice.Mul64(1e12).Siacoins(), // price * 1TB
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_settings_egress_price",
+			Value:     hs.EgressPrice.Mul64(1e12).Siacoins(), // price * 1TB
+			Timestamp: time.Now(),
+		},
+	}
+}
+
+// PrometheusMetric returns Prometheus samples for the host metrics.
+func (m Metrics) PrometheusMetric() []prometheus.Metric {
+	return []prometheus.Metric{
+		{
+			Name:      "host_metrics_accounts_active",
+			Value:     float64(m.Accounts.Active),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_accounts_balance",
+			Value:     m.Accounts.Balance.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_revenue_potential_rpc",
+			Value:     m.Revenue.Potential.RPC.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_revenue_potential_storage",
+			Value:     m.Revenue.Potential.Storage.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_revenue_potential_ingress",
+			Value:     m.Revenue.Potential.Ingress.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_revenue_potential_egress",
+			Value:     m.Revenue.Potential.Egress.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_revenue_earned_rpc",
+			Value:     m.Revenue.Earned.RPC.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_revenue_earned_storage",
+			Value:     m.Revenue.Earned.Storage.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_revenue_earned_ingress",
+			Value:     m.Revenue.Earned.Ingress.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_revenue_earned_egress",
+			Value:     m.Revenue.Earned.Egress.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_contracts_active",
+			Value:     float64(m.Contracts.Active),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_contracts_pending",
+			Value:     float64(m.Contracts.Pending),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_contracts_rejected",
+			Value:     float64(m.Contracts.Rejected),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_contracts_failed",
+			Value:     float64(m.Contracts.Failed),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_contracts_successful",
+			Value:     float64(m.Contracts.Successful),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_contracts_locked_collateral",
+			Value:     m.Contracts.LockedCollateral.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_metrics_contracts_risked_collateral",
+			Value:     m.Contracts.RiskedCollateral.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_storage_total_bytes",
+			Value:     float64(m.Storage.TotalSectors * rhp2.SectorSize),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_storage_physical_used_bytes",
+			Value:     float64(m.Storage.PhysicalSectors * rhp2.SectorSize),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_storage_contract_used_bytes",
+			Value:     float64(m.Storage.ContractSectors * rhp2.SectorSize),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_storage_temp_used_bytes",
+			Value:     float64(m.Storage.TempSectors * rhp2.SectorSize),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_storage_reads",
+			Value:     float64(m.Storage.Reads),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_storage_writes",
+			Value:     float64(m.Storage.Writes),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_data_rhp_ingress_bytes",
+			Value:     float64(m.Data.RHP.Ingress),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_data_rhp_egress_bytes",
+			Value:     float64(m.Data.RHP.Egress),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_wallet_balance",
+			Value:     m.Balance.Siacoins(),
+			Timestamp: time.Now(),
+		},
+	}
+}
+
+// PrometheusMetric returns Prometheus samples for the host wallet.
+func (wr WalletResponse) PrometheusMetric() []prometheus.Metric {
+	return []prometheus.Metric{
+		{
+			Name: "hostd_wallet",
+			Labels: map[string]any{
+				"address": wr.Address,
+			},
+			Value:     float64(wr.ScanHeight),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_wallet_spendable",
+			Value:     wr.Spendable.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_wallet_confirmed",
+			Value:     wr.Confirmed.Siacoins(),
+			Timestamp: time.Now(),
+		},
+		{
+			Name:      "hostd_wallet_unconfirmed",
+			Value:     wr.Unconfirmed.Siacoins(),
+			Timestamp: time.Now(),
+		},
+	}
+}

--- a/api/types.go
+++ b/api/types.go
@@ -9,6 +9,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/host/contracts"
+	"go.sia.tech/hostd/host/metrics"
 	"go.sia.tech/hostd/host/settings"
 	"go.sia.tech/hostd/host/storage"
 )
@@ -58,6 +59,12 @@ type (
 		StartTime        time.Time             `json:"startTime"`
 		BuildState
 	}
+
+	// HostSettings is the response body for the [GET] /settings endpoint.
+	HostSettings settings.Settings
+
+	// Metrics is the response body for the [GET] /metrics endpoint.
+	Metrics metrics.Metrics
 
 	// ConsensusState is the response body for the [GET] /consensus endpoint.
 	ConsensusState struct {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.5
 	github.com/mattn/go-sqlite3 v1.14.17
 	gitlab.com/NebulousLabs/encoding v0.0.0-20200604091946-456c3dc907fe
-	go.sia.tech/core v0.1.12-0.20231211182757-77190f04f90b
+	go.sia.tech/core v0.1.13-0.20240116022021-2cd44b4d828d
 	go.sia.tech/jape v0.10.0
 	go.sia.tech/renterd v0.6.0
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ gitlab.com/NebulousLabs/threadgroup v0.0.0-20200608151952-38921fbef213 h1:owERlK
 gitlab.com/NebulousLabs/threadgroup v0.0.0-20200608151952-38921fbef213/go.mod h1:vIutAvl7lmJqLVYTCBY5WDdJomP+V74At8LCeEYoH8w=
 gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20200618142844-c59a90f49130/go.mod h1:SxigdS5Q1ui+OMgGAXt1E/Fg3RB6PvKXMov2O3gvIzs=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
-go.sia.tech/core v0.1.12-0.20231211182757-77190f04f90b h1:xJSxYN2kZD3NAijHIwjXhG5+7GoPyjDNIJPEoD3b72g=
-go.sia.tech/core v0.1.12-0.20231211182757-77190f04f90b/go.mod h1:3EoY+rR78w1/uGoXXVqcYdwSjSJKuEMI5bL7WROA27Q=
+go.sia.tech/core v0.1.13-0.20240116022021-2cd44b4d828d h1:gcqhQHYuc+k9L2WqT+r302dmorERpjkCrhW31I71omU=
+go.sia.tech/core v0.1.13-0.20240116022021-2cd44b4d828d/go.mod h1:3EoY+rR78w1/uGoXXVqcYdwSjSJKuEMI5bL7WROA27Q=
 go.sia.tech/jape v0.10.0 h1:wsIURirNV29fvqxhvvbd0yhKh+9JeNZvz4haJUL/+yI=
 go.sia.tech/jape v0.10.0/go.mod h1:4QqmBB+t3W7cNplXPj++ZqpoUb2PeiS66RLpXmEGap4=
 go.sia.tech/mux v1.2.0 h1:ofa1Us9mdymBbGMY2XH/lSpY8itFsKIo/Aq8zwe+GHU=

--- a/host/settings/settings.go
+++ b/host/settings/settings.go
@@ -151,8 +151,8 @@ var (
 		MaxContractDuration: 6 * blocksPerMonth, // 6 months
 
 		ContractPrice:     types.Siacoins(1).Div64(5),   // 200 ms / contract
-		BaseRPCPrice:      types.Siacoins(1).Div64(1e7), // 1 SC / million RPCs
-		SectorAccessPrice: types.Siacoins(1).Div64(1e7), // 1 SC / million sectors
+		BaseRPCPrice:      types.Siacoins(1).Div64(1e6), // 1 SC / million RPCs
+		SectorAccessPrice: types.Siacoins(1).Div64(1e6), // 1 SC / million sectors
 
 		CollateralMultiplier: 2.0, // 2x storage price
 		MaxCollateral:        types.Siacoins(1000),

--- a/internal/prometheus/encoder.go
+++ b/internal/prometheus/encoder.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+// A Metric is a Prometheus metric.
 type Metric struct {
 	Name      string
 	Labels    map[string]any
@@ -15,7 +16,7 @@ type Metric struct {
 	Timestamp time.Time
 }
 
-// EncodePrometheus encodes a Metric into a Prometheus metric string.
+// encode encodes a Metric into a Prometheus metric string.
 func (m *Metric) encode(sb *strings.Builder) error {
 	sb.WriteString(m.Name)
 
@@ -66,10 +67,12 @@ func (m *Metric) encode(sb *strings.Builder) error {
 	return nil
 }
 
+// A Marshaller can be marshalled into Prometheus samples
 type Marshaller interface {
 	PrometheusMetric() []Metric
 }
 
+// An Encoder writes Prometheus samples to the writer
 type Encoder struct {
 	used bool
 	sb   strings.Builder
@@ -103,6 +106,7 @@ func (e *Encoder) Append(m Marshaller) error {
 	return nil
 }
 
+// NewEncoder creates a new Prometheus encoder.
 func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{
 		w: w,

--- a/internal/prometheus/encoder.go
+++ b/internal/prometheus/encoder.go
@@ -1,0 +1,110 @@
+package prometheus
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Metric struct {
+	Name      string
+	Labels    map[string]any
+	Value     float64
+	Timestamp time.Time
+}
+
+// EncodePrometheus encodes a Metric into a Prometheus metric string.
+func (m *Metric) encode(sb *strings.Builder) error {
+	sb.WriteString(m.Name)
+
+	// write optional labels
+	if len(m.Labels) > 0 {
+		sb.WriteString("{")
+		n := len(m.Labels)
+		for k, v := range m.Labels {
+			sb.WriteString(k)
+			sb.WriteString(`="`)
+			switch v := v.(type) {
+			case string:
+				sb.WriteString(v)
+			case []byte:
+				sb.Write(v)
+			case int:
+				sb.WriteString(strconv.Itoa(v))
+			case int64:
+				sb.WriteString(strconv.FormatInt(v, 10))
+			case float64:
+				sb.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+			case bool:
+				sb.WriteString(strconv.FormatBool(v))
+			case fmt.Stringer:
+				sb.WriteString(v.String())
+			default:
+				return fmt.Errorf("unsupported label value %T", v)
+			}
+			sb.WriteString(`"`)
+
+			if n > 1 {
+				sb.WriteString(",")
+			}
+			n--
+		}
+		sb.WriteString("}")
+	}
+
+	// write value
+	sb.WriteString(" ")
+	sb.WriteString(strconv.FormatFloat(m.Value, 'f', -1, 64))
+
+	// write optional timestamp
+	if !m.Timestamp.IsZero() {
+		sb.WriteString(" ")
+		sb.WriteString(strconv.FormatInt(m.Timestamp.Unix(), 10))
+	}
+	return nil
+}
+
+type Marshaller interface {
+	PrometheusMetric() []Metric
+}
+
+type Encoder struct {
+	used bool
+	sb   strings.Builder
+	w    io.Writer
+}
+
+// Append marshals a Marshaller and appends it to the encoder's buffer.
+func (e *Encoder) Append(m Marshaller) error {
+	e.sb.Reset() // reset the string builder
+
+	// if this is not the first, add a newline to separate the samples
+	if e.used {
+		e.sb.Write([]byte("\n"))
+	}
+	e.used = true
+
+	for i, m := range m.PrometheusMetric() {
+		if i > 0 {
+			// each sample must be separated by a newline
+			e.sb.Write([]byte("\n"))
+		}
+
+		if err := m.encode(&e.sb); err != nil {
+			return fmt.Errorf("failed to encode metric: %v", err)
+		}
+	}
+
+	if _, err := e.w.Write([]byte(e.sb.String())); err != nil {
+		return fmt.Errorf("failed to write metric: %v", err)
+	}
+	return nil
+}
+
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{
+		w: w,
+	}
+}


### PR DESCRIPTION
Adds an internal Prometheus encoder for encoding responses in the Prometheus sample format.

Also adds a `response` path param to some endpoints to support different output formats (i.e. `http://localhost:9980/api/settings?response=prometheus`)

Supported formats:
- `prometheus`
- `json`

Supported endpoints:
- `GET /state/host`
- `GET /state/consensus`
- `GET /settings`
- `GET /metrics`
- `GET /wallet`
