### PR TITLE
Close registry recorder on shutdown

### DIFF
--- a/cmd/hostd/node.go
+++ b/cmd/hostd/node.go
@@ -55,6 +55,7 @@ func (n *node) Close() error {
 	n.rhp3.Close()
 	n.rhp2.Close()
 	n.data.Close()
+	n.registry.Close()
 	n.storage.Close()
 	n.contracts.Close()
 	n.w.Close()

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	go.sia.tech/renterd v0.6.0
 	go.sia.tech/siad v1.5.10-0.20230228235644-3059c0b930ca
 	go.sia.tech/web/hostd v0.37.0
+	go.uber.org/goleak v1.2.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/sys v0.16.0
 	golang.org/x/term v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,7 @@ golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1m
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=

--- a/host/contracts/revenue_test.go
+++ b/host/contracts/revenue_test.go
@@ -14,9 +14,14 @@ import (
 	"go.sia.tech/hostd/internal/test"
 	rhp3 "go.sia.tech/hostd/internal/test/rhp/v3"
 	"go.sia.tech/hostd/persist/sqlite"
+	"go.uber.org/goleak"
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func checkRevenueConsistency(s *sqlite.Store, potential, earned metrics.Revenue) error {
 	time.Sleep(time.Second) // commit time

--- a/host/registry/registry.go
+++ b/host/registry/registry.go
@@ -122,6 +122,10 @@ func NewManager(privkey types.PrivateKey, store Store, log *zap.Logger) *Manager
 			log: log.Named("recorder"),
 		},
 	}
-	go m.recorder.Run(m.tg.Done())
+	done, _ := m.tg.Add()
+	go func() {
+		m.recorder.Run(m.tg.Done())
+		done()
+	}()
 	return m
 }

--- a/internal/test/host.go
+++ b/internal/test/host.go
@@ -84,6 +84,7 @@ func (h *Host) Close() error {
 	h.settings.Close()
 	h.wallet.Close()
 	h.contracts.Close()
+	h.registry.Close()
 	h.storage.Close()
 	h.store.Close()
 	h.Node.Close()

--- a/rhp/v2/rpc_test.go
+++ b/rhp/v2/rpc_test.go
@@ -13,9 +13,14 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/internal/test"
 	"go.sia.tech/renterd/wallet"
+	"go.uber.org/goleak"
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestSettings(t *testing.T) {
 	log := zaptest.NewLogger(t)

--- a/rhp/v3/websocket_test.go
+++ b/rhp/v3/websocket_test.go
@@ -7,9 +7,14 @@ import (
 
 	rhp3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/hostd/internal/test"
+	"go.uber.org/goleak"
 	"go.uber.org/zap/zaptest"
 	"nhooyr.io/websocket"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestWebSockets(t *testing.T) {
 	log := zaptest.NewLogger(t)


### PR DESCRIPTION
Tried to enable `goleak` in `renterd` in our integration tests and it kept failing due to the registry recorder not waiting for a shutdown.
I thought it might make sense to add it to `hostd` too.