### PR TITLE
Revert sector delete check

### DIFF
--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -699,14 +699,6 @@ func deleteContractSectors(tx txn, refs []contractSectorRootRef) (int, error) {
 		}
 		deleted[id] = true
 	}
-	if len(deleted) != len(rootIDs) {
-		return 0, errors.New("failed to delete all sectors")
-	}
-	for _, rootID := range rootIDs {
-		if !deleted[rootID] {
-			return 0, errors.New("failed to delete all sectors")
-		}
-	}
 
 	// decrement the contract metrics
 	if err := incrementNumericStat(tx, metricContractSectors, -len(refs), time.Now()); err != nil {


### PR DESCRIPTION
Reverts a change made in v1.0.2 that checks if the number of sectors deleted from the database matches the number requested. I haven't been able to discover the edge case that causes the logic to fail yet. The `SELECT` and `DELETE` happen in the same transaction, so they should all be present and the `contract_sector_roots` table doesn't have any external constraints that would be preventing deletion.

Closes #309 