### PR TITLE
Prometheus: remove id label on hostd_consensus_state_index

### DIFF
--- a/api/prometheus.go
+++ b/api/prometheus.go
@@ -56,9 +56,8 @@ func (cs ConsensusState) PrometheusMetric() []prometheus.Metric {
 			}(),
 		},
 		{
-			Name:   "hostd_consensus_state_index",
-			Labels: map[string]any{"id": cs.ChainIndex.ID},
-			Value:  float64(cs.ChainIndex.Height),
+			Name:  "hostd_consensus_state_index",
+			Value: float64(cs.ChainIndex.Height),
 		},
 	}
 }


### PR DESCRIPTION
The id label on hostd_consensus_state_index is breaking continuity with block height panels and was introduced during the refactor. Removing the label will restore continuity. 

![Screenshot 2024-02-21 173716](https://github.com/SiaFoundation/hostd/assets/7598211/ee0cf428-f260-42a4-bc0f-5d6f14be8f85)
