### PR TITLE
Fix force remove

### DIFF
--- a/host/metrics/types.go
+++ b/host/metrics/types.go
@@ -84,6 +84,7 @@ type (
 	Storage struct {
 		TotalSectors    uint64 `json:"totalSectors"`
 		PhysicalSectors uint64 `json:"physicalSectors"`
+		LostSectors     uint64 `json:"lostSectors"`
 		ContractSectors uint64 `json:"contractSectors"`
 		TempSectors     uint64 `json:"tempSectors"`
 

--- a/host/storage/persist.go
+++ b/host/storage/persist.go
@@ -8,6 +8,10 @@ import (
 )
 
 type (
+	// MigrateFunc is a callback function that is called for each sector that
+	// needs to be migrated If the function returns an error, the sector should
+	// be skipped and migration should continue.
+	MigrateFunc func(location SectorLocation) error
 
 	// A VolumeStore stores and retrieves information about storage volumes.
 	VolumeStore interface {
@@ -42,7 +46,7 @@ type (
 		// volume starting at min. The sector data should be copied to the new
 		// location and synced to disk during migrateFn. If migrateFn returns an
 		// error, migration will continue, but that sector is not migrated.
-		MigrateSectors(ctx context.Context, volumeID int64, min uint64, migrateFn func(SectorLocation) error) (migrated, failed int, err error)
+		MigrateSectors(ctx context.Context, volumeID int64, min uint64, migrateFn MigrateFunc) (migrated, failed int, err error)
 		// StoreSector calls fn with an empty location in a writable volume. If
 		// the sector root already exists, fn is called with the existing
 		// location and exists is true. Unless exists is true, The sector must
@@ -75,6 +79,8 @@ type (
 )
 
 var (
+	// ErrMigrationFailed is returned when a volume fails to migrate all
+	// of its sectors.
 	ErrMigrationFailed = errors.New("migration failed")
 	// ErrNotEnoughStorage is returned when there is not enough storage space to
 	// store a sector.

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -495,6 +495,8 @@ func TestRemoveCorrupt(t *testing.T) {
 		t.Fatalf("expected %v total sectors, got %v", expectedSectors-1, m.Storage.TotalSectors)
 	} else if m.Storage.PhysicalSectors != 9 {
 		t.Fatalf("expected 9 used sectors, got %v", m.Storage.PhysicalSectors)
+	} else if m.Storage.LostSectors != 1 {
+		t.Fatalf("expected 1 lost sectors, got %v", m.Storage.LostSectors)
 	}
 
 	if vol, err := vm.Volume(volume2.ID); err != nil {
@@ -680,6 +682,8 @@ func TestRemoveMissing(t *testing.T) {
 		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
 	} else if m.Storage.PhysicalSectors != 0 {
 		t.Fatalf("expected 0 used sectors, got %v", m.Storage.PhysicalSectors)
+	} else if m.Storage.LostSectors != 10 {
+		t.Fatalf("expected 10 lost sectors, got %v", m.Storage.LostSectors)
 	}
 
 	if _, err := vm.Volume(volume.ID); !errors.Is(err, storage.ErrVolumeNotFound) {

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	rhp2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
@@ -379,22 +380,52 @@ func TestRemoveCorrupt(t *testing.T) {
 		defer release()
 	}
 
-	// attempt to remove the volume. Should return ErrNotEnoughStorage since
+	// check that the volume metrics did not change
+	if m, err := db.Metrics(time.Now()); err != nil {
+		t.Fatal(err)
+	} else if m.Storage.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
+	} else if m.Storage.PhysicalSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
+	}
+
+	if vol, err := vm.Volume(volume.ID); err != nil {
+		t.Fatal(err)
+	} else if vol.Status != storage.VolumeStatusReady {
+		t.Fatal("volume should be ready")
+	} else if vol.UsedSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
+	} else if vol.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
+	}
+
+	// attempt to remove the volume. Should return ErrMigrationFailed since
 	// there is only one volume.
 	if err := vm.RemoveVolume(context.Background(), volume.ID, false, result); err != nil {
 		// blocking error should be nil
 		t.Fatal(err)
-	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
-		// async error should be ErrNotEnoughStorage
-		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
+	} else if err := <-result; !errors.Is(err, storage.ErrMigrationFailed) {
+		// async error should be ErrMigrationFailed
+		t.Fatalf("expected ErrMigrationFailed, got %v", err)
 	}
 
-	// add a second volume to the manager
-	_, err = vm.AddVolume(context.Background(), filepath.Join(t.TempDir(), "vol2.dat"), expectedSectors, result)
-	if err != nil {
+	// check that the volume metrics did not change
+	if m, err := db.Metrics(time.Now()); err != nil {
 		t.Fatal(err)
-	} else if err := <-result; err != nil {
+	} else if m.Storage.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
+	} else if m.Storage.PhysicalSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
+	}
+
+	if vol, err := vm.Volume(volume.ID); err != nil {
 		t.Fatal(err)
+	} else if vol.Status != storage.VolumeStatusReady {
+		t.Fatal("volume should be ready")
+	} else if vol.UsedSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
+	} else if vol.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
 	}
 
 	f, err := os.OpenFile(volumePath, os.O_RDWR, 0)
@@ -417,7 +448,37 @@ func TestRemoveCorrupt(t *testing.T) {
 		t.Fatal(err) // blocking error should be nil
 	} else if err := <-result; err == nil {
 		t.Fatal("expected error when removing corrupt volume", err)
+	} else if !errors.Is(err, storage.ErrMigrationFailed) {
+		t.Fatalf("expected ErrMigrationFailed, got %v", err)
 	}
+
+	// check that the volume metrics did not change
+	if m, err := db.Metrics(time.Now()); err != nil {
+		t.Fatal(err)
+	} else if m.Storage.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
+	} else if m.Storage.PhysicalSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
+	}
+
+	if vol, err := vm.Volume(volume.ID); err != nil {
+		t.Fatal(err)
+	} else if vol.Status != storage.VolumeStatusReady {
+		t.Fatal("volume should be ready")
+	} else if vol.UsedSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
+	} else if vol.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
+	}
+
+	// add a second volume to accept the data
+	volume2, err := vm.AddVolume(context.Background(), filepath.Join(t.TempDir(), "hostdata.dat"), expectedSectors, result)
+	if err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
+		t.Fatal(err)
+	}
+
 	// force remove the volume
 	if err := vm.RemoveVolume(context.Background(), volume.ID, true, result); err != nil {
 		t.Fatal(err)
@@ -425,6 +486,25 @@ func TestRemoveCorrupt(t *testing.T) {
 		t.Fatal(err)
 	} else if _, err := os.Stat(volumePath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatal("volume file still exists", err)
+	}
+
+	// check that the corrupt sector was removed from the volume metrics
+	if m, err := db.Metrics(time.Now()); err != nil {
+		t.Fatal(err)
+	} else if m.Storage.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors-1, m.Storage.TotalSectors)
+	} else if m.Storage.PhysicalSectors != 9 {
+		t.Fatalf("expected 9 used sectors, got %v", m.Storage.PhysicalSectors)
+	}
+
+	if vol, err := vm.Volume(volume2.ID); err != nil {
+		t.Fatal(err)
+	} else if vol.Status != storage.VolumeStatusReady {
+		t.Fatal("volume should be ready")
+	} else if vol.UsedSectors != 9 {
+		t.Fatalf("expected 9 used sectors, got %v", vol.UsedSectors)
+	} else if vol.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
 	}
 }
 
@@ -498,20 +578,31 @@ func TestRemoveMissing(t *testing.T) {
 		defer release()
 	}
 
-	// attempt to remove the volume. Should return ErrNotEnoughStorage since
+	// attempt to remove the volume. Should return ErrMigrationFailed since
 	// there is only one volume.
 	if err := vm.RemoveVolume(context.Background(), volume.ID, false, result); err != nil {
 		t.Fatal(err)
-	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
-		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
+	} else if err := <-result; !errors.Is(err, storage.ErrMigrationFailed) {
+		t.Fatalf("expected ErrMigrationFailed, got %v", err)
 	}
 
-	// add a second volume to the manager
-	_, err = vm.AddVolume(context.Background(), filepath.Join(t.TempDir(), "vol2.dat"), expectedSectors, result)
-	if err != nil {
+	// check that the volume metrics did not change
+	if m, err := db.Metrics(time.Now()); err != nil {
 		t.Fatal(err)
-	} else if err := <-result; err != nil {
+	} else if m.Storage.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
+	} else if m.Storage.PhysicalSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
+	}
+
+	if vol, err := vm.Volume(volume.ID); err != nil {
 		t.Fatal(err)
+	} else if vol.Status != storage.VolumeStatusReady {
+		t.Fatal("volume should be ready")
+	} else if vol.UsedSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
+	} else if vol.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
 	}
 
 	// close the volume manager
@@ -531,24 +622,68 @@ func TestRemoveMissing(t *testing.T) {
 	}
 	defer vm.Close()
 
-	vol, err := vm.Volume(volume.ID)
-	if err != nil {
+	// check that the volume metrics did not change
+	if m, err := db.Metrics(time.Now()); err != nil {
+		t.Fatal(err)
+	} else if m.Storage.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
+	} else if m.Storage.PhysicalSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
+	}
+
+	if vol, err := vm.Volume(volume.ID); err != nil {
 		t.Fatal(err)
 	} else if vol.Status != storage.VolumeStatusUnavailable {
 		t.Fatal("volume should be unavailable")
+	} else if vol.UsedSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
+	} else if vol.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
 	}
 
 	// remove the volume
 	if err := vm.RemoveVolume(context.Background(), volume.ID, false, result); err != nil {
 		t.Fatal(err)
-	} else if err := <-result; err == nil {
-		t.Fatal("expected error when removing missing volume")
+	} else if err := <-result; !errors.Is(err, storage.ErrMigrationFailed) {
+		t.Fatalf("expected ErrMigrationFailed, got %v", err)
+	}
+
+	// check that the volume metrics did not change
+	if m, err := db.Metrics(time.Now()); err != nil {
+		t.Fatal(err)
+	} else if m.Storage.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
+	} else if m.Storage.PhysicalSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
+	}
+
+	if vol, err := vm.Volume(volume.ID); err != nil {
+		t.Fatal(err)
+	} else if vol.Status != storage.VolumeStatusUnavailable {
+		t.Fatal("volume should be unavailable")
+	} else if vol.UsedSectors != 10 {
+		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
+	} else if vol.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
 	}
 
 	if err := vm.RemoveVolume(context.Background(), volume.ID, true, result); err != nil {
 		t.Fatal(err)
 	} else if err := <-result; err != nil {
 		t.Fatal(err)
+	}
+
+	// check that the volume metrics did not change
+	if m, err := db.Metrics(time.Now()); err != nil {
+		t.Fatal(err)
+	} else if m.Storage.TotalSectors != expectedSectors {
+		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
+	} else if m.Storage.PhysicalSectors != 0 {
+		t.Fatalf("expected 0 used sectors, got %v", m.Storage.PhysicalSectors)
+	}
+
+	if _, err := vm.Volume(volume.ID); !errors.Is(err, storage.ErrVolumeNotFound) {
+		t.Fatalf("expected ErrVolumeNotFound, got %v", err)
 	}
 }
 

--- a/persist/sqlite/metrics.go
+++ b/persist/sqlite/metrics.go
@@ -28,6 +28,7 @@ const (
 	// storage
 	metricTotalSectors    = "totalSectors"
 	metricPhysicalSectors = "physicalSectors"
+	metricLostSectors     = "lostSectors"
 	metricContractSectors = "contractSectors"
 	metricTempSectors     = "tempSectors"
 	metricSectorReads     = "sectorReads"
@@ -362,6 +363,8 @@ func mustParseMetricValue(stat string, buf []byte, m *metrics.Metrics) {
 		m.Storage.TotalSectors = mustScanUint64(buf)
 	case metricPhysicalSectors:
 		m.Storage.PhysicalSectors = mustScanUint64(buf)
+	case metricLostSectors:
+		m.Storage.LostSectors = mustScanUint64(buf)
 	case metricContractSectors:
 		m.Storage.ContractSectors = mustScanUint64(buf)
 	case metricTempSectors:

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -10,8 +10,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// migrateVersion26 recalculates the contract and physical sectors metrics
-func migrateVersion26(tx txn, log *zap.Logger) error {
+// migrateVersion25 recalculates the contract and physical sectors metrics
+func migrateVersion25(tx txn, log *zap.Logger) error {
 	// recalculate the contract sectors metric
 	var contractSectorCount int64
 	if err := tx.QueryRow(`SELECT COUNT(*) FROM contract_sector_roots`).Scan(&contractSectorCount); err != nil {
@@ -50,11 +50,6 @@ func migrateVersion26(tx txn, log *zap.Logger) error {
 			return fmt.Errorf("failed to update volume stats: %w", err)
 		}
 	}
-	return nil
-}
-
-// migrateVersion25 is a no-op migration to trigger foreign key checks
-func migrateVersion25(tx txn, log *zap.Logger) error {
 	return nil
 }
 
@@ -738,4 +733,5 @@ var migrations = []func(tx txn, log *zap.Logger) error{
 	migrateVersion22,
 	migrateVersion23,
 	migrateVersion24,
+	migrateVersion25,
 }

--- a/persist/sqlite/sectors.go
+++ b/persist/sqlite/sectors.go
@@ -73,6 +73,8 @@ func (s *Store) RemoveSector(root types.Hash256) (err error) {
 		// decrement volume usage and metrics
 		if err = incrementVolumeUsage(tx, volumeID, -1); err != nil {
 			return fmt.Errorf("failed to update volume usage: %w", err)
+		} else if err := incrementNumericStat(tx, metricLostSectors, 1, time.Now()); err != nil {
+			return fmt.Errorf("failed to update metric: %w", err)
 		}
 		return nil
 	})

--- a/persist/sqlite/volumes.go
+++ b/persist/sqlite/volumes.go
@@ -175,6 +175,8 @@ func (s *Store) batchRemoveVolumeSectors(id int64, force bool) (removed, lost in
 				// count.
 				if err := incrementNumericStat(tx, metricPhysicalSectors, -int(lost), time.Now()); err != nil {
 					return fmt.Errorf("failed to update physical sector metric: %w", err)
+				} else if err := incrementNumericStat(tx, metricLostSectors, int(lost), time.Now()); err != nil {
+					return fmt.Errorf("failed to update lost sector metric: %w", err)
 				}
 			}
 		} else {


### PR DESCRIPTION
Changes migration to attempt to migrate every sector regardless of individual sector errors. Changes force remove to remove sectors when data is missing and there is not another volume to "migrate" the data to. Adds a new metric, "lost sectors," for when a sector is removed either explicitly with `[DELETE] /sectors/:root` or when force removing a volume. 