### PR TITLE
Update dispatch to build master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,12 @@
 name: Publish
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on new SemVer tags
   push:
     branches:
       - master
-    tags: 
+    tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-**'
 
@@ -95,7 +95,7 @@ jobs:
         with:
           name: hostd
           path: release/
-  build-mac: 
+  build-mac:
     runs-on: macos-latest
     needs: [ test ]
     steps:
@@ -183,7 +183,7 @@ jobs:
         with:
           name: hostd
           path: release/
-  build-windows: 
+  build-windows:
     runs-on: windows-latest
     needs: [ test ]
     steps:
@@ -213,28 +213,61 @@ jobs:
         with:
           name: hostd
           path: release/
-  dispatch:
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+
+  dispatch-homebrew: # only runs on full releases
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: [ docker, build-linux, build-mac, build-windows ]
-    strategy:
-        matrix:
-            repo: ['siafoundation/homebrew-sia', 'siafoundation/linux']
     runs-on: ubuntu-latest
     steps:
       - name: Extract Tag Name
         id: get_tag
         run: echo "::set-output name=tag_name::${GITHUB_REF#refs/tags/}"
 
-      - name: Repository Dispatch
+      - name: Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PAT_REPOSITORY_DISPATCH }}
-          repository: ${{ matrix.repo }}
+          repository: siafoundation/homebrew-sia
           event-type: release-tagged
           client-payload: >
             {
-              "description": "Hostd: A host for Sia",
+              "description": "hostd: The Next-Gen Sia Host",
               "tag": "${{ steps.get_tag.outputs.tag_name }}",
               "project": "hostd",
               "workflow_id": "${{ github.run_id }}"
             }
+  dispatch-linux: # always runs
+    needs: [ docker, build-linux, build-mac, build-windows ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Dispatch Payload
+        id: get_payload
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isRelease = context.ref.startsWith('refs/tags/v'),
+              isBeta = isRelease && context.ref.includes('-beta'),
+              tag = isRelease ? context.ref.replace('refs/tags/', '') : 'master';
+
+            let component = 'nightly';
+            if (isBeta) {
+              component = 'beta';
+            } else if (isRelease) {
+              component = 'main';
+            }
+
+            return {
+              description: "hostd: The Next-Gen Sia Host",
+              tag: tag,
+              project: "hostd",
+              workflow_id: context.runId,
+              component: component
+            };
+
+      - name: Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT_REPOSITORY_DISPATCH }}
+          repository: siafoundation/linux
+          event-type: release-tagged
+          client-payload: ${{ steps.get_payload.outputs.result }}


### PR DESCRIPTION
I modified https://github.com/siafoundation/linux to publish three different `apt` releases `main`, `beta` and `nightly`. This will enable users to select a more frequent release type when installing via `apt`.

This modifies the linux dispatch payload to set the new required `component` field.

The logic should be as follows:
- If `v0.0.0` component is `main`
- If `v0.0.0-beta` component is `beta`
- Otherwise, component is `nightly`

Nightly releases will have their `apt` version set to `YYYYMMDD-{commit}`.