### PR TITLE
Return error before checking duration of preparing statement

### DIFF
--- a/persist/sqlite/sql.go
+++ b/persist/sqlite/sql.go
@@ -154,10 +154,10 @@ func (lt *loggedTxn) Exec(query string, args ...any) (sql.Result, error) {
 func (lt *loggedTxn) Prepare(query string) (*loggedStmt, error) {
 	start := time.Now()
 	stmt, err := lt.Tx.Prepare(query)
-	if dur := time.Since(start); dur > longQueryDuration {
-		lt.log.Debug("slow prepare", zap.String("query", query), zap.Duration("elapsed", dur), zap.Stack("stack"))
-	} else if err != nil {
+	if err != nil {
 		return nil, err
+	} else if dur := time.Since(start); dur > longQueryDuration {
+		lt.log.Debug("slow prepare", zap.String("query", query), zap.Duration("elapsed", dur), zap.Stack("stack"))
 	}
 	return &loggedStmt{
 		Stmt:  stmt,


### PR DESCRIPTION
While unlikely, if `longQueryDuration` is set to `0` or `Prepare` takes a long time,, `Prepare` will not return an error.