### PR TITLE
Prevent price pin failure from crashing node

### DIFF
--- a/cmd/hostd/main.go
+++ b/cmd/hostd/main.go
@@ -396,7 +396,7 @@ func main() {
 		defer cancel()
 
 		if _, err := ex.SiacoinExchangeRate(ctx, "usd"); err != nil {
-			log.Fatal("failed to get exchange rate", zap.Error(err))
+			log.Error("failed to get exchange rate. explorer features may not work correctly", zap.Error(err))
 		}
 	}
 

--- a/cmd/hostd/node.go
+++ b/cmd/hostd/node.go
@@ -187,6 +187,7 @@ func newNode(ctx context.Context, walletKey types.PrivateKey, ex *explorer.Explo
 	var pm *pin.Manager
 	if !cfg.Explorer.Disable {
 		pm, err = pin.NewManager(
+			pin.WithAlerts(am),
 			pin.WithStore(db),
 			pin.WithSettings(sr),
 			pin.WithExchangeRateRetriever(ex),

--- a/host/settings/pin/options.go
+++ b/host/settings/pin/options.go
@@ -16,6 +16,12 @@ func WithLogger(log *zap.Logger) Option {
 	}
 }
 
+func WithAlerts(a Alerts) Option {
+	return func(m *Manager) {
+		m.alerts = a
+	}
+}
+
 // WithFrequency sets the frequency at which the manager updates the host's
 // settings based on the current exchange rate.
 func WithFrequency(frequency time.Duration) Option {

--- a/host/settings/pin/options.go
+++ b/host/settings/pin/options.go
@@ -16,6 +16,7 @@ func WithLogger(log *zap.Logger) Option {
 	}
 }
 
+// WithAlerts sets the alerts manager for the pinner to register alerts with.
 func WithAlerts(a Alerts) Option {
 	return func(m *Manager) {
 		m.alerts = a


### PR DESCRIPTION
Removes the fatal startup check for explorer configuration and adds an alert instead.