### PR TITLE
Update AccountStore interface

### DIFF
--- a/host/accounts/accounts.go
+++ b/host/accounts/accounts.go
@@ -31,10 +31,10 @@ type (
 		// AccountBalance returns the balance of the account with the given ID.
 		AccountBalance(accountID rhp3.Account) (types.Currency, error)
 		// CreditAccountWithContract adds the specified amount to the account with the given ID.
-		CreditAccountWithContract(FundAccountWithContract) (types.Currency, error)
-		// DebitAccount subtracts the specified amount from the account with the given
-		// ID. Returns the remaining balance of the account.
-		DebitAccount(accountID rhp3.Account, usage Usage) (types.Currency, error)
+		CreditAccountWithContract(FundAccountWithContract) error
+		// DebitAccount subtracts the specified amount from the account with the
+		// given ID.
+		DebitAccount(accountID rhp3.Account, usage Usage) error
 	}
 
 	// Settings returns the host's current settings.
@@ -130,7 +130,7 @@ func (am *AccountManager) Credit(req FundAccountWithContract, refund bool) (type
 	}
 
 	// credit the account
-	if _, err = am.store.CreditAccountWithContract(req); err != nil {
+	if err = am.store.CreditAccountWithContract(req); err != nil {
 		return types.ZeroCurrency, fmt.Errorf("failed to credit account: %w", err)
 	}
 	// increment the balance in memory, if it exists

--- a/host/accounts/budget.go
+++ b/host/accounts/budget.go
@@ -127,8 +127,7 @@ func (b *Budget) Commit() error {
 		return nil
 	}
 	// debit the account
-	_, err := b.am.store.DebitAccount(b.accountID, b.usage)
-	if err != nil {
+	if err := b.am.store.DebitAccount(b.accountID, b.usage); err != nil {
 		return fmt.Errorf("failed to debit account: %w", err)
 	}
 	// calculate the remainder and zero out the budget

--- a/persist/sqlite/accounts.go
+++ b/persist/sqlite/accounts.go
@@ -37,8 +37,8 @@ func incrementContractAccountFunding(tx txn, accountID, contractID int64, amount
 }
 
 // CreditAccountWithContract adds the specified amount to the account with the given ID.
-func (s *Store) CreditAccountWithContract(fund accounts.FundAccountWithContract) (balance types.Currency, err error) {
-	err = s.transaction(func(tx txn) error {
+func (s *Store) CreditAccountWithContract(fund accounts.FundAccountWithContract) error {
+	return s.transaction(func(tx txn) error {
 		// get current balance
 		accountID, balance, err := accountBalance(tx, fund.Account)
 		exists := err == nil
@@ -88,14 +88,13 @@ func (s *Store) CreditAccountWithContract(fund accounts.FundAccountWithContract)
 		}
 		return nil
 	})
-	return
 }
 
 // DebitAccount subtracts the specified amount from the account with the given
 // ID. Returns the remaining balance of the account.
-func (s *Store) DebitAccount(accountID rhp3.Account, usage accounts.Usage) (balance types.Currency, err error) {
+func (s *Store) DebitAccount(accountID rhp3.Account, usage accounts.Usage) error {
 	amount := usage.Total()
-	err = s.transaction(func(tx txn) error {
+	return s.transaction(func(tx txn) error {
 		dbID, balance, err := accountBalance(tx, accountID)
 		if err != nil {
 			return fmt.Errorf("failed to query balance: %w", err)
@@ -120,7 +119,6 @@ func (s *Store) DebitAccount(accountID rhp3.Account, usage accounts.Usage) (bala
 
 		return nil
 	})
-	return
 }
 
 // Accounts returns all accounts in the database paginated.


### PR DESCRIPTION
While I was browsing the accounts code I found that both `CreditAccountWithContract` and `DebitAccount` don't actually return the account balance because of scoping. Since those return variables weren't being used I figured we might as well get rid of them.