### PR TITLE
Refactor volumes

### DIFF
--- a/.changeset/refactor_sector_management.md
+++ b/.changeset/refactor_sector_management.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Refactor Sector Management
+
+Improves sector lookups by 50% on average by removing the sector lock tables and moving reference pruning out of the hot path.

--- a/api/volumes.go
+++ b/api/volumes.go
@@ -218,7 +218,7 @@ func (a *api) handleGETVerifySector(jc jape.Context) {
 
 	// if the sector is not referenced return the empty response without
 	// attempting to read the sector data
-	if len(refs.Contracts) == 0 && refs.TempStorage == 0 && refs.Locks == 0 {
+	if len(refs.Contracts) == 0 && refs.TempStorage == 0 {
 		jc.Encode(resp)
 		return
 	}

--- a/host/accounts/budget_test.go
+++ b/host/accounts/budget_test.go
@@ -23,7 +23,6 @@ func TestUsageTotal(t *testing.T) {
 	for i := 0; i < uv.NumField(); i++ {
 		v := types.NewCurrency(frand.Uint64n(math.MaxUint64), 0)
 		total = total.Add(v)
-		t.Log("setting field", uv.Type().Field(i).Name, "to", v.ExactString())
 		uv.Field(i).Set(reflect.ValueOf(v))
 	}
 

--- a/host/contracts/contracts_test.go
+++ b/host/contracts/contracts_test.go
@@ -96,22 +96,12 @@ func TestContractUpdater(t *testing.T) {
 			}
 			defer updater.Close()
 
-			var releaseFuncs []func() error
-			defer func() {
-				for _, release := range releaseFuncs {
-					if err := release(); err != nil {
-						t.Fatal(err)
-					}
-				}
-			}()
-
 			for i := 0; i < test.append; i++ {
 				root := frand.Entropy256()
-				release, err := node.Store.StoreSector(root, func(loc storage.SectorLocation, exists bool) error { return nil })
+				err := node.Store.StoreSector(root, func(loc storage.SectorLocation) error { return nil })
 				if err != nil {
 					t.Fatal(err)
 				}
-				releaseFuncs = append(releaseFuncs, release)
 				updater.AppendSector(root)
 				roots = append(roots, root)
 			}
@@ -134,11 +124,6 @@ func TestContractUpdater(t *testing.T) {
 				t.Fatal(err)
 			} else if err := updater.Close(); err != nil {
 				t.Fatal(err)
-			}
-			for _, release := range releaseFuncs {
-				if err := release(); err != nil {
-					t.Fatal(err)
-				}
 			}
 
 			// check that the sector roots are correct in the database

--- a/host/contracts/integrity_test.go
+++ b/host/contracts/integrity_test.go
@@ -104,16 +104,14 @@ func TestCheckIntegrity(t *testing.T) {
 	defer updater.Close()
 
 	var roots []types.Hash256
-	var releases []func() error
 	for i := 0; i < 5; i++ {
 		var sector [rhp2.SectorSize]byte
 		frand.Read(sector[:256])
 		root := rhp2.SectorRoot(&sector)
-		release, err := host.Volumes.Write(root, &sector)
+		err := host.Volumes.Write(root, &sector)
 		if err != nil {
 			t.Fatal(err)
 		}
-		releases = append(releases, release)
 		roots = append(roots, root)
 		updater.AppendSector(root)
 	}
@@ -124,12 +122,6 @@ func TestCheckIntegrity(t *testing.T) {
 
 	if err := updater.Commit(contract.SignedRevision, contracts.Usage{}); err != nil {
 		t.Fatal(err)
-	}
-
-	for _, release := range releases {
-		if err := release(); err != nil {
-			t.Fatal(err)
-		}
 	}
 
 	// helper func to serialize integrity check

--- a/host/storage/options.go
+++ b/host/storage/options.go
@@ -1,6 +1,10 @@
 package storage
 
-import "go.uber.org/zap"
+import (
+	"time"
+
+	"go.uber.org/zap"
+)
 
 // A VolumeManagerOption configures a VolumeManager.
 type VolumeManagerOption func(*VolumeManager)
@@ -23,5 +27,13 @@ func WithAlerter(a Alerts) VolumeManagerOption {
 func WithCacheSize(cacheSize int) VolumeManagerOption {
 	return func(s *VolumeManager) {
 		s.cacheSize = cacheSize
+	}
+}
+
+// WithPruneInterval sets the time between cleaning up dereferenced
+// sectors.
+func WithPruneInterval(d time.Duration) VolumeManagerOption {
+	return func(vm *VolumeManager) {
+		vm.pruneInterval = d
 	}
 }

--- a/host/storage/persist.go
+++ b/host/storage/persist.go
@@ -3,15 +3,19 @@ package storage
 import (
 	"context"
 	"errors"
+	"time"
 
 	"go.sia.tech/core/types"
 )
 
 type (
-	// MigrateFunc is a callback function that is called for each sector that
-	// needs to be migrated If the function returns an error, the sector should
-	// be skipped and migration should continue.
-	MigrateFunc func(location SectorLocation) error
+	// StoreFunc is called for every sector that needs written
+	// to disk.
+	StoreFunc func(loc SectorLocation) error
+	// MigrateFunc is called for every sector that needs migration.
+	// The sector should be migrated from 'from' to 'to' during
+	// migrate func.
+	MigrateFunc func(from, to SectorLocation) error
 
 	// A VolumeStore stores and retrieves information about storage volumes.
 	VolumeStore interface {
@@ -42,31 +46,40 @@ type (
 		// SetAvailable sets the available flag on a volume.
 		SetAvailable(volumeID int64, available bool) error
 
+		// PruneSectors removes all sectors that have not been accessed since
+		// lastAccess and are no longer referenced by a contract or temp storage.
+		// If the context is canceled, pruning is stopped and the function returns
+		// with the error.
+		PruneSectors(ctx context.Context, lastAccess time.Time) error
+
 		// MigrateSectors returns a new location for each occupied sector of a
 		// volume starting at min. The sector data should be copied to the new
 		// location and synced to disk during migrateFn. If migrateFn returns an
 		// error, migration will continue, but that sector is not migrated.
-		MigrateSectors(ctx context.Context, volumeID int64, min uint64, migrateFn MigrateFunc) (migrated, failed int, err error)
+		MigrateSectors(ctx context.Context, volumeID int64, min uint64, fn MigrateFunc) (migrated, failed int, err error)
 		// StoreSector calls fn with an empty location in a writable volume. If
-		// the sector root already exists, fn is called with the existing
-		// location and exists is true. Unless exists is true, The sector must
-		// be written to disk within fn. If fn returns an error, the metadata is
-		// rolled back. If no space is available, ErrNotEnoughStorage is
-		// returned. The location is locked until release is called.
-		//
-		// The sector should be referenced by either a contract or temp store
-		// before release is called to prevent Prune() from removing it.
-		StoreSector(root types.Hash256, fn func(loc SectorLocation, exists bool) error) (release func() error, err error)
+		// the sector root already exists, nil is returned. The sector should be
+		// written to disk within fn. If fn returns an error, the metadata is
+		// rolled back and the error is returned. If no space is available,
+		// ErrNotEnoughStorage is returned.
+		StoreSector(root types.Hash256, fn StoreFunc) error
 		// RemoveSector removes the metadata of a sector and returns its
 		// location in the volume.
 		RemoveSector(root types.Hash256) error
+		// HasSector returns true if the sector is stored by the host.
+		HasSector(root types.Hash256) (bool, error)
 		// SectorLocation returns the location of a sector or an error if the
 		// sector is not found. The location is locked until release is
 		// called.
-		SectorLocation(root types.Hash256) (loc SectorLocation, release func() error, err error)
+		SectorLocation(root types.Hash256) (loc SectorLocation, err error)
+		// AddTempSector adds a sector to temporary storage. The sectors will be deleted
+		// after the expiration height
+		AddTempSector(root types.Hash256, expiration uint64) error
 		// AddTemporarySectors adds a list of sectors to the temporary store.
 		// The sectors are not referenced by a contract and will be removed
 		// at the expiration height.
+		//
+		//deprecated: use AddTempSector
 		AddTemporarySectors(sectors []TempSector) error
 		// ExpireTempSectors removes all temporary sectors that expired before
 		// the given height.

--- a/host/storage/persist.go
+++ b/host/storage/persist.go
@@ -79,7 +79,7 @@ type (
 		// The sectors are not referenced by a contract and will be removed
 		// at the expiration height.
 		//
-		//deprecated: use AddTempSector
+		// Deprecated: use AddTempSector
 		AddTemporarySectors(sectors []TempSector) error
 		// ExpireTempSectors removes all temporary sectors that expired before
 		// the given height.

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -1151,7 +1151,7 @@ func TestStoragePrune(t *testing.T) {
 	defer db.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, storage.WithLogger(log.Named("volumes")), storage.WithCacheSize(0), storage.WithPruneInterval(time.Second))
+	vm, err := storage.NewVolumeManager(db, storage.WithLogger(log.Named("volumes")), storage.WithCacheSize(0), storage.WithPruneInterval(500*time.Millisecond))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1169,7 +1169,7 @@ func TestStoragePrune(t *testing.T) {
 	assertUsedSectors := func(t *testing.T, used uint64) {
 		t.Helper()
 
-		time.Sleep(time.Second) // prune interval
+		time.Sleep(2 * time.Second) // note: longer than prune interval for timing issues
 		volume, err := vm.Volume(vol.ID)
 		if err != nil {
 			t.Fatal(err)

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -57,12 +57,9 @@ func TestVolumeLoad(t *testing.T) {
 	var sector [rhp2.SectorSize]byte
 	frand.Read(sector[:])
 	root := rhp2.SectorRoot(&sector)
-	release, err := vm.Write(root, &sector)
-	if err != nil {
+	if err = vm.Write(root, &sector); err != nil {
 		t.Fatal(err)
 	} else if err := vm.AddTemporarySectors([]storage.TempSector{{Root: root, Expiration: 1}}); err != nil { // must add a temp sector to prevent pruning
-		t.Fatal(err)
-	} else if err := release(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -103,10 +100,7 @@ func TestVolumeLoad(t *testing.T) {
 	// write a new sector
 	frand.Read(sector[:])
 	root = rhp2.SectorRoot(&sector)
-	release, err = vm.Write(root, &sector)
-	if err != nil {
-		t.Fatal(err)
-	} else if err := release(); err != nil {
+	if err = vm.Write(root, &sector); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -193,12 +187,10 @@ func TestRemoveVolume(t *testing.T) {
 		roots[i] = rhp2.SectorRoot(&sector)
 
 		// write the sector
-		release, err := vm.Write(roots[i], &sector)
-		if err != nil {
+
+		if err := vm.Write(roots[i], &sector); err != nil {
 			t.Fatal(err)
 		} else if err := vm.AddTemporarySectors([]storage.TempSector{{Root: roots[i], Expiration: 1}}); err != nil { // must add a temp sector to prevent pruning
-			t.Fatal(err)
-		} else if err := release(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -232,8 +224,7 @@ func TestRemoveVolume(t *testing.T) {
 	if err := vm.RemoveVolume(context.Background(), volume.ID, false, result); err != nil {
 		// blocking error should be nil
 		t.Fatal(err)
-	} else if err := <-result; !errors.Is(err, storage.ErrMigrationFailed) {
-		// async error should be ErrMigrationFailed
+	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
 
@@ -260,7 +251,7 @@ func TestRemoveVolume(t *testing.T) {
 	// but some sectors should be migrated to the second volume.
 	if err := vm.RemoveVolume(context.Background(), volume.ID, false, result); err != nil {
 		t.Fatal(err)
-	} else if err := <-result; !errors.Is(err, storage.ErrMigrationFailed) {
+	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatal(err)
 	}
 
@@ -309,12 +300,28 @@ func TestRemoveCorrupt(t *testing.T) {
 	}
 	defer db.Close()
 
+	assertMetrics := func(t *testing.T, physical, lost, total uint64) {
+		t.Helper()
+
+		if m, err := db.Metrics(time.Now()); err != nil {
+			t.Fatal(err)
+		} else if m.Storage.TotalSectors != total {
+			t.Fatalf("expected %v total sectors, got %v", total, m.Storage.TotalSectors)
+		} else if m.Storage.PhysicalSectors != physical {
+			t.Fatalf("expected %v used sectors, got %v", physical, m.Storage.PhysicalSectors)
+		} else if m.Storage.LostSectors != lost {
+			t.Fatalf("expected %v lost sectors, got %v", lost, m.Storage.LostSectors)
+		}
+	}
+
 	// initialize the storage manager
 	vm, err := storage.NewVolumeManager(db, storage.WithLogger(log.Named("volumes")))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer vm.Close()
+
+	assertMetrics(t, 0, 0, 0)
 
 	result := make(chan error, 1)
 	volumePath := filepath.Join(t.TempDir(), "hostdata.dat")
@@ -325,59 +332,44 @@ func TestRemoveCorrupt(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	assertVolume := func(t *testing.T, volumeID int64, used, total uint64) {
+		t.Helper()
+
+		if vol, err := vm.Volume(volumeID); err != nil {
+			t.Fatal(err)
+		} else if vol.Status != storage.VolumeStatusReady {
+			t.Fatal("volume should be ready")
+		} else if vol.UsedSectors != used {
+			t.Fatalf("expected %v used sectors, got %v", used, vol.UsedSectors)
+		} else if vol.TotalSectors != total {
+			t.Fatalf("expected %v total sectors, got %v", total, vol.TotalSectors)
+		}
+	}
+
+	assertVolume(t, volume.ID, 0, expectedSectors)
+	assertMetrics(t, 0, 0, expectedSectors)
+
 	for i := 0; i < 10; i++ {
 		if _, err := storeRandomSector(vm, 1); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// check that the volume metrics did not change
-	if m, err := db.Metrics(time.Now()); err != nil {
-		t.Fatal(err)
-	} else if m.Storage.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
-	} else if m.Storage.PhysicalSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
-	}
+	assertMetrics(t, 10, 0, expectedSectors)
+	assertVolume(t, volume.ID, 10, expectedSectors)
 
-	if vol, err := vm.Volume(volume.ID); err != nil {
-		t.Fatal(err)
-	} else if vol.Status != storage.VolumeStatusReady {
-		t.Fatal("volume should be ready")
-	} else if vol.UsedSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
-	} else if vol.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
-	}
-
-	// attempt to remove the volume. Should return ErrMigrationFailed since
+	// attempt to remove the volume. Should return ErrNotEnoughStorage since
 	// there is only one volume.
 	if err := vm.RemoveVolume(context.Background(), volume.ID, false, result); err != nil {
 		// blocking error should be nil
 		t.Fatal(err)
-	} else if err := <-result; !errors.Is(err, storage.ErrMigrationFailed) {
-		// async error should be ErrMigrationFailed
-		t.Fatalf("expected ErrMigrationFailed, got %v", err)
+	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
+		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
 
-	// check that the volume metrics did not change
-	if m, err := db.Metrics(time.Now()); err != nil {
-		t.Fatal(err)
-	} else if m.Storage.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
-	} else if m.Storage.PhysicalSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
-	}
-
-	if vol, err := vm.Volume(volume.ID); err != nil {
-		t.Fatal(err)
-	} else if vol.Status != storage.VolumeStatusReady {
-		t.Fatal("volume should be ready")
-	} else if vol.UsedSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
-	} else if vol.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
-	}
+	// check that the metrics did not change
+	assertMetrics(t, 10, 0, expectedSectors)
+	assertVolume(t, volume.ID, 10, expectedSectors)
 
 	f, err := os.OpenFile(volumePath, os.O_RDWR, 0)
 	if err != nil {
@@ -394,6 +386,19 @@ func TestRemoveCorrupt(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// add a second volume to accept the data
+	volume2, err := vm.AddVolume(context.Background(), filepath.Join(t.TempDir(), "hostdata.dat"), expectedSectors, result)
+	if err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
+		t.Fatal(err)
+	}
+
+	// check that the total metrics doubled, but the volume metrics are unchanged
+	assertMetrics(t, 10, 0, expectedSectors*2)
+	assertVolume(t, volume.ID, 10, expectedSectors)
+	assertVolume(t, volume2.ID, 0, expectedSectors)
+
 	// remove the volume
 	if err := vm.RemoveVolume(context.Background(), volume.ID, false, result); err != nil {
 		t.Fatal(err) // blocking error should be nil
@@ -403,41 +408,10 @@ func TestRemoveCorrupt(t *testing.T) {
 		t.Fatalf("expected ErrMigrationFailed, got %v", err)
 	}
 
-	// check that the volume metrics did not change
-	if m, err := db.Metrics(time.Now()); err != nil {
-		t.Fatal(err)
-	} else if m.Storage.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
-	} else if m.Storage.PhysicalSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
-	}
-
-	if vol, err := vm.Volume(volume.ID); err != nil {
-		t.Fatal(err)
-	} else if vol.Status != storage.VolumeStatusReady {
-		t.Fatal("volume should be ready")
-	} else if vol.UsedSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
-	} else if vol.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
-	}
-
-	// add a second volume to accept the data
-	volume2, err := vm.AddVolume(context.Background(), filepath.Join(t.TempDir(), "hostdata.dat"), expectedSectors, result)
-	if err != nil {
-		t.Fatal(err)
-	} else if err := <-result; err != nil {
-		t.Fatal(err)
-	}
-
-	// check that the volume metrics doubled
-	if m, err := db.Metrics(time.Now()); err != nil {
-		t.Fatal(err)
-	} else if m.Storage.TotalSectors != expectedSectors*2 {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors*2, m.Storage.TotalSectors)
-	} else if m.Storage.PhysicalSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
-	}
+	// check that only the one failed sector is left in the original volume
+	assertMetrics(t, 10, 0, expectedSectors*2)
+	assertVolume(t, volume.ID, 1, expectedSectors)
+	assertVolume(t, volume2.ID, 9, expectedSectors)
 
 	// force remove the volume
 	if err := vm.RemoveVolume(context.Background(), volume.ID, true, result); err != nil {
@@ -449,24 +423,11 @@ func TestRemoveCorrupt(t *testing.T) {
 	}
 
 	// check that the corrupt sector was removed from the volume metrics
-	if m, err := db.Metrics(time.Now()); err != nil {
-		t.Fatal(err)
-	} else if m.Storage.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors-1, m.Storage.TotalSectors)
-	} else if m.Storage.PhysicalSectors != 9 {
-		t.Fatalf("expected 9 used sectors, got %v", m.Storage.PhysicalSectors)
-	} else if m.Storage.LostSectors != 1 {
-		t.Fatalf("expected 1 lost sectors, got %v", m.Storage.LostSectors)
-	}
+	assertMetrics(t, 9, 1, expectedSectors)
+	assertVolume(t, volume2.ID, 9, expectedSectors)
 
-	if vol, err := vm.Volume(volume2.ID); err != nil {
-		t.Fatal(err)
-	} else if vol.Status != storage.VolumeStatusReady {
-		t.Fatal("volume should be ready")
-	} else if vol.UsedSectors != 9 {
-		t.Fatalf("expected 9 used sectors, got %v", vol.UsedSectors)
-	} else if vol.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
+	if _, err := vm.Volume(volume.ID); !errors.Is(err, storage.ErrVolumeNotFound) {
+		t.Fatalf("expected ErrVolumeNotFound, got %v", err)
 	}
 }
 
@@ -482,12 +443,28 @@ func TestRemoveMissing(t *testing.T) {
 	}
 	defer db.Close()
 
+	assertMetrics := func(t *testing.T, physical, lost, total uint64) {
+		t.Helper()
+
+		if m, err := db.Metrics(time.Now()); err != nil {
+			t.Fatal(err)
+		} else if m.Storage.TotalSectors != total {
+			t.Fatalf("expected %v total sectors, got %v", total, m.Storage.TotalSectors)
+		} else if m.Storage.PhysicalSectors != physical {
+			t.Fatalf("expected %v used sectors, got %v", physical, m.Storage.PhysicalSectors)
+		} else if m.Storage.LostSectors != lost {
+			t.Fatalf("expected %v lost sectors, got %v", lost, m.Storage.LostSectors)
+		}
+	}
+
 	// initialize the storage manager
 	vm, err := storage.NewVolumeManager(db, storage.WithLogger(log.Named("volumes")))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer vm.Close()
+
+	assertMetrics(t, 0, 0, 0)
 
 	result := make(chan error, 1)
 	volumePath := filepath.Join(t.TempDir(), "hostdata.dat")
@@ -498,38 +475,44 @@ func TestRemoveMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	assertVolume := func(t *testing.T, volumeID int64, used, total uint64) {
+		t.Helper()
+
+		if vol, err := vm.Volume(volumeID); err != nil {
+			t.Fatal(err)
+		} else if vol.UsedSectors != used {
+			t.Fatalf("expected %v used sectors, got %v", used, vol.UsedSectors)
+		} else if vol.TotalSectors != total {
+			t.Fatalf("expected %v total sectors, got %v", total, vol.TotalSectors)
+		}
+	}
+
+	assertMetrics(t, 0, 0, expectedSectors)
+	assertVolume(t, volume.ID, 0, expectedSectors)
+
+	assertVolume(t, volume.ID, 0, expectedSectors)
+	assertMetrics(t, 0, 0, expectedSectors)
+
 	for i := 0; i < 10; i++ {
 		if _, err := storeRandomSector(vm, 1); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// attempt to remove the volume. Should return ErrMigrationFailed since
+	assertMetrics(t, 10, 0, expectedSectors)
+	assertVolume(t, volume.ID, 10, expectedSectors)
+
+	// attempt to remove the volume. Should return ErrNotEnoughStorage since
 	// there is only one volume.
 	if err := vm.RemoveVolume(context.Background(), volume.ID, false, result); err != nil {
 		t.Fatal(err)
-	} else if err := <-result; !errors.Is(err, storage.ErrMigrationFailed) {
-		t.Fatalf("expected ErrMigrationFailed, got %v", err)
+	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
+		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
 
 	// check that the volume metrics did not change
-	if m, err := db.Metrics(time.Now()); err != nil {
-		t.Fatal(err)
-	} else if m.Storage.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
-	} else if m.Storage.PhysicalSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
-	}
-
-	if vol, err := vm.Volume(volume.ID); err != nil {
-		t.Fatal(err)
-	} else if vol.Status != storage.VolumeStatusReady {
-		t.Fatal("volume should be ready")
-	} else if vol.UsedSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
-	} else if vol.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
-	}
+	assertMetrics(t, 10, 0, expectedSectors)
+	assertVolume(t, volume.ID, 10, expectedSectors)
 
 	// close the volume manager
 	if err := vm.Close(); err != nil {
@@ -549,23 +532,21 @@ func TestRemoveMissing(t *testing.T) {
 	defer vm.Close()
 
 	// check that the volume metrics did not change
-	if m, err := db.Metrics(time.Now()); err != nil {
+	assertMetrics(t, 10, 0, expectedSectors)
+	assertVolume(t, volume.ID, 10, expectedSectors)
+
+	// add a volume to accept the data
+	volume2, err := vm.AddVolume(context.Background(), filepath.Join(t.TempDir(), "hostdata.dat"), expectedSectors, result)
+	if err != nil {
 		t.Fatal(err)
-	} else if m.Storage.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
-	} else if m.Storage.PhysicalSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
+	} else if err := <-result; err != nil {
+		t.Fatal(err)
 	}
 
-	if vol, err := vm.Volume(volume.ID); err != nil {
-		t.Fatal(err)
-	} else if vol.Status != storage.VolumeStatusUnavailable {
-		t.Fatal("volume should be unavailable")
-	} else if vol.UsedSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
-	} else if vol.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
-	}
+	// check that the total metrics doubled and the volume metrics did not change
+	assertMetrics(t, 10, 0, expectedSectors*2)
+	assertVolume(t, volume.ID, 10, expectedSectors)
+	assertVolume(t, volume2.ID, 0, expectedSectors)
 
 	// remove the volume
 	if err := vm.RemoveVolume(context.Background(), volume.ID, false, result); err != nil {
@@ -575,40 +556,20 @@ func TestRemoveMissing(t *testing.T) {
 	}
 
 	// check that the volume metrics did not change
-	if m, err := db.Metrics(time.Now()); err != nil {
-		t.Fatal(err)
-	} else if m.Storage.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
-	} else if m.Storage.PhysicalSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", m.Storage.PhysicalSectors)
-	}
+	assertMetrics(t, 10, 0, expectedSectors*2)
+	assertVolume(t, volume.ID, 10, expectedSectors)
+	assertVolume(t, volume2.ID, 0, expectedSectors)
 
-	if vol, err := vm.Volume(volume.ID); err != nil {
-		t.Fatal(err)
-	} else if vol.Status != storage.VolumeStatusUnavailable {
-		t.Fatal("volume should be unavailable")
-	} else if vol.UsedSectors != 10 {
-		t.Fatalf("expected 10 used sectors, got %v", vol.UsedSectors)
-	} else if vol.TotalSectors != expectedSectors {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, vol.TotalSectors)
-	}
-
+	// force remve the volume
 	if err := vm.RemoveVolume(context.Background(), volume.ID, true, result); err != nil {
 		t.Fatal(err)
 	} else if err := <-result; err != nil {
 		t.Fatal(err)
 	}
 
-	// check that the volume metrics did not change
-	if m, err := db.Metrics(time.Now()); err != nil {
-		t.Fatal(err)
-	} else if m.Storage.TotalSectors != 0 {
-		t.Fatalf("expected %v total sectors, got %v", expectedSectors, m.Storage.TotalSectors)
-	} else if m.Storage.PhysicalSectors != 0 {
-		t.Fatalf("expected 0 used sectors, got %v", m.Storage.PhysicalSectors)
-	} else if m.Storage.LostSectors != 10 {
-		t.Fatalf("expected 10 lost sectors, got %v", m.Storage.LostSectors)
-	}
+	// check that the sectors were marked as lost
+	assertMetrics(t, 0, 10, expectedSectors)
+	assertVolume(t, volume2.ID, 0, expectedSectors)
 
 	if _, err := vm.Volume(volume.ID); !errors.Is(err, storage.ErrVolumeNotFound) {
 		t.Fatalf("expected ErrVolumeNotFound, got %v", err)
@@ -722,7 +683,7 @@ func TestVolumeConcurrency(t *testing.T) {
 	}
 
 	// try to write a sector to the volume, which should fail
-	if _, err := vm.Write(root, &sector); !errors.Is(err, storage.ErrNotEnoughStorage) {
+	if err := vm.Write(root, &sector); !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected %v, got %v", storage.ErrNotEnoughStorage, err)
 	}
 
@@ -748,7 +709,7 @@ func TestVolumeConcurrency(t *testing.T) {
 	}
 
 	// write the sector again, which should succeed
-	if _, err := vm.Write(root, &sector); err != nil {
+	if err := vm.Write(root, &sector); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -907,10 +868,8 @@ func TestVolumeShrink(t *testing.T) {
 	}
 
 	sectorLocation := func(root types.Hash256) (storage.SectorLocation, error) {
-		loc, release, err := db.SectorLocation(root)
+		loc, err := db.SectorLocation(root)
 		if err != nil {
-			return loc, err
-		} else if err := release(); err != nil {
 			return loc, err
 		}
 		return loc, nil
@@ -934,8 +893,8 @@ func TestVolumeShrink(t *testing.T) {
 	remainingSectors := uint64(sectors - toRemove)
 	if err := vm.ResizeVolume(context.Background(), volume.ID, remainingSectors, result); err != nil {
 		t.Fatal(err)
-	} else if err := <-result; !errors.Is(err, storage.ErrMigrationFailed) {
-		t.Fatalf("expected ErrMigrationFailed, got %v", err)
+	} else if err := <-result; !errors.Is(err, storage.ErrNotEnoughStorage) {
+		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
 
 	// remove some sectors from the beginning of the volume
@@ -1061,17 +1020,16 @@ func storeRandomSector(vm *storage.VolumeManager, expiration uint64) (types.Hash
 		return types.Hash256{}, fmt.Errorf("failed to generate random sector: %w", err)
 	}
 	root := rhp2.SectorRoot(&sector)
-	release, err := vm.Write(root, &sector)
+	err := vm.Write(root, &sector)
 	if err != nil {
 		return types.Hash256{}, fmt.Errorf("failed to write sector: %w", err)
 	}
-	defer release()
 
 	err = vm.AddTemporarySectors([]storage.TempSector{{Root: root, Expiration: expiration}})
 	if err != nil {
 		return types.Hash256{}, fmt.Errorf("failed to add temporary sector: %w", err)
 	}
-	return root, release()
+	return root, nil
 }
 
 func TestSectorCache(t *testing.T) {
@@ -1221,10 +1179,8 @@ func BenchmarkVolumeManagerWrite(b *testing.B) {
 	// fill the volume
 	for i := 0; i < b.N; i++ {
 		root, sector := roots[i], sectors[i]
-		release, err := vm.Write(root, &sector)
+		err := vm.Write(root, &sector)
 		if err != nil {
-			b.Fatal(i, err)
-		} else if err := release(); err != nil {
 			b.Fatal(i, err)
 		}
 	}
@@ -1298,10 +1254,8 @@ func BenchmarkVolumeManagerRead(b *testing.B) {
 		var sector [rhp2.SectorSize]byte
 		frand.Read(sector[:256])
 		root := rhp2.SectorRoot(&sector)
-		release, err := vm.Write(root, &sector)
+		err := vm.Write(root, &sector)
 		if err != nil {
-			b.Fatal(i, err)
-		} else if err := release(); err != nil {
 			b.Fatal(i, err)
 		}
 		written = append(written, root)
@@ -1350,10 +1304,8 @@ func BenchmarkVolumeRemove(b *testing.B) {
 		var sector [rhp2.SectorSize]byte
 		frand.Read(sector[:256])
 		root := rhp2.SectorRoot(&sector)
-		release, err := vm.Write(root, &sector)
+		err := vm.Write(root, &sector)
 		if err != nil {
-			b.Fatal(i, err)
-		} else if err := release(); err != nil {
 			b.Fatal(i, err)
 		}
 	}

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -30,12 +30,6 @@ CREATE TABLE stored_sectors (
 CREATE INDEX stored_sectors_sector_root ON stored_sectors(sector_root);
 CREATE INDEX stored_sectors_last_access ON stored_sectors(last_access_timestamp);
 
-CREATE TABLE locked_sectors ( -- should be cleared at startup. currently persisted for simplicity, but may be moved to memory
-	id INTEGER PRIMARY KEY,
-	sector_id INTEGER NOT NULL REFERENCES stored_sectors(id)
-);
-CREATE INDEX locked_sectors_sector_id ON locked_sectors(sector_id);
-
 CREATE TABLE storage_volumes (
 	id INTEGER PRIMARY KEY,
 	disk_path TEXT UNIQUE NOT NULL,
@@ -60,12 +54,6 @@ CREATE INDEX volume_sectors_volume_id_sector_id ON volume_sectors(volume_id, sec
 CREATE INDEX volume_sectors_volume_id ON volume_sectors(volume_id);
 CREATE INDEX volume_sectors_volume_index ON volume_sectors(volume_index ASC);
 CREATE INDEX volume_sectors_sector_id ON volume_sectors(sector_id);
-
-CREATE TABLE locked_volume_sectors ( -- should be cleared at startup. currently persisted for simplicity, but may be moved to memory
-	id INTEGER PRIMARY KEY,
-	volume_sector_id INTEGER REFERENCES volume_sectors(id) ON DELETE CASCADE
-);
-CREATE INDEX locked_volume_sectors_sector_id ON locked_volume_sectors(volume_sector_id);
 
 CREATE TABLE contract_renters (
 	id INTEGER PRIMARY KEY,

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -10,6 +10,18 @@ import (
 	"go.uber.org/zap"
 )
 
+// migrateVersion34 removes the lock tables
+func migrateVersion34(tx *txn, log *zap.Logger) error {
+	_, err := tx.Exec(`DROP TABLE locked_sectors;
+DROP TABLE locked_volume_sectors;`)
+	if err != nil {
+		return fmt.Errorf("failed to remove lock tables: %w", err)
+	} else if err := recalcVolumeMetrics(tx, log); err != nil {
+		return fmt.Errorf("failed to recalculate volume metrics: %w", err)
+	}
+	return nil
+}
+
 // migrateVersion33 adds the contract_v2_account_funding table.
 func migrateVersion33(tx *txn, _ *zap.Logger) error {
 	_, err := tx.Exec(`CREATE TABLE contract_v2_account_funding (
@@ -974,4 +986,5 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion31,
 	migrateVersion32,
 	migrateVersion33,
+	migrateVersion34,
 }

--- a/persist/sqlite/sectors.go
+++ b/persist/sqlite/sectors.go
@@ -114,7 +114,7 @@ WHERE ss.sector_root=$1`, encode(root)).Scan(&sectorID)
 		} else if err := incrementNumericStat(tx, metricTempSectors, 1, time.Now()); err != nil {
 			return fmt.Errorf("failed to update metric: %w", err)
 		}
-		_, err = tx.Exec(`INSERT INTO temp_storage_sector_roots (sector_id, expiration) VALUES ($1, $2)`, sectorID, expiration)
+		_, err = tx.Exec(`INSERT INTO temp_storage_sector_roots (sector_id, expiration_height) VALUES ($1, $2)`, sectorID, expiration)
 		return err
 	})
 }

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -44,10 +44,8 @@ func TestVolumeSetReadOnly(t *testing.T) {
 	}
 
 	// try to add a sector to the volume
-	release, err := db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation, exists bool) error { return nil })
+	err = db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation) error { return nil })
 	if err != nil {
-		t.Fatal(err)
-	} else if err := release(); err != nil { // immediately release the sector so it can be used again
 		t.Fatal(err)
 	}
 
@@ -58,7 +56,7 @@ func TestVolumeSetReadOnly(t *testing.T) {
 
 	// try to add another sector to the volume, should fail with
 	// ErrNotEnoughStorage
-	_, err = db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation, exists bool) error { return nil })
+	err = db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation) error { return nil })
 	if !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
@@ -82,7 +80,7 @@ func TestAddSector(t *testing.T) {
 	root := frand.Entropy256()
 	// try to store a sector in the empty volume, should return
 	// ErrNotEnoughStorage
-	_, err = db.StoreSector(root, func(storage.SectorLocation, bool) error { return nil })
+	err = db.StoreSector(root, func(storage.SectorLocation) error { return nil })
 	if !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
@@ -92,7 +90,7 @@ func TestAddSector(t *testing.T) {
 		t.Fatal(err)
 	}
 	// store the sector
-	release, err := db.StoreSector(root, func(loc storage.SectorLocation, exists bool) error {
+	err = db.StoreSector(root, func(loc storage.SectorLocation) error {
 		// check that the sector was stored in the expected location
 		if loc.Volume != volumeID {
 			t.Fatalf("expected volume ID %v, got %v", volumeID, loc.Volume)
@@ -104,17 +102,10 @@ func TestAddSector(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		if err := release(); err != nil {
-			t.Fatal("failed to release sector1:", err)
-		}
-	}()
 
 	// check the location was added
-	loc, release, err := db.SectorLocation(root)
+	loc, err := db.SectorLocation(root)
 	if err != nil {
-		t.Fatal(err)
-	} else if err := release(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -135,10 +126,8 @@ func TestAddSector(t *testing.T) {
 	}
 
 	// store the sector again, exists should be true
-	release, err = db.StoreSector(root, func(loc storage.SectorLocation, exists bool) error {
+	err = db.StoreSector(root, func(loc storage.SectorLocation) error {
 		switch {
-		case !exists:
-			t.Fatal("sector does not exist")
 		case loc.Volume != volumeID:
 			t.Fatalf("expected volume ID %v, got %v", volumeID, loc.Volume)
 		case loc.Index != 0:
@@ -147,8 +136,6 @@ func TestAddSector(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Fatal(err)
-	} else if err := release(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -164,7 +151,7 @@ func TestAddSector(t *testing.T) {
 
 	// try to store another sector in the volume, should return
 	// ErrNotEnoughStorage
-	_, err = db.StoreSector(frand.Entropy256(), func(storage.SectorLocation, bool) error { return nil })
+	err = db.StoreSector(frand.Entropy256(), func(storage.SectorLocation) error { return nil })
 	if !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
@@ -337,22 +324,18 @@ func TestShrinkVolume(t *testing.T) {
 	}
 
 	// add a few sectors
-	var releaseFns []func() error
 	for i := 0; i < 5; i++ {
-		release, err := db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation, exists bool) error {
+		err := db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation) error {
 			if loc.Volume != volume.ID {
 				t.Fatalf("expected volume ID %v, got %v", volume.ID, loc.Volume)
 			} else if loc.Index != uint64(i) {
 				t.Fatalf("expected sector index %v, got %v", i, loc.Index)
-			} else if exists {
-				t.Fatal("sector exists")
 			}
 			return nil
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		releaseFns = append(releaseFns, release)
 	}
 
 	// check that the volume cannot be shrunk below the used sectors
@@ -367,12 +350,6 @@ func TestShrinkVolume(t *testing.T) {
 		t.Fatal(err)
 	} else if m.Storage.TotalSectors != 5 {
 		t.Fatalf("expected %v total sectors, got %v", 5, m.Storage.TotalSectors)
-	}
-
-	for _, fn := range releaseFns {
-		if err := fn(); err != nil {
-			t.Fatal(err)
-		}
 	}
 }
 
@@ -404,13 +381,11 @@ func TestRemoveVolume(t *testing.T) {
 	// add a few sectors
 	for i := 0; i < 5; i++ {
 		sectorRoot := frand.Entropy256()
-		release, err := db.StoreSector(sectorRoot, func(loc storage.SectorLocation, exists bool) error {
+		err := db.StoreSector(sectorRoot, func(loc storage.SectorLocation) error {
 			if loc.Volume != volume.ID {
 				t.Fatalf("expected volume ID %v, got %v", volume.ID, loc.Volume)
 			} else if loc.Index != uint64(i) {
 				t.Fatalf("expected sector index 0, got %v", loc.Index)
-			} else if exists {
-				t.Fatal("sector exists")
 			}
 			return nil
 		})
@@ -420,8 +395,6 @@ func TestRemoveVolume(t *testing.T) {
 
 		err = db.AddTemporarySectors([]storage.TempSector{{Root: sectorRoot, Expiration: uint64(i)}})
 		if err != nil {
-			t.Fatal(err)
-		} else if err := release(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -442,6 +415,8 @@ func TestRemoveVolume(t *testing.T) {
 
 	// expire all of the temporary sectors
 	if err := db.ExpireTempSectors(5); err != nil {
+		t.Fatal(err)
+	} else if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -479,23 +454,17 @@ func TestMigrateSectors(t *testing.T) {
 	for i := range roots {
 		root := frand.Entropy256()
 		roots[i] = root
-		release, err := db.StoreSector(root, func(loc storage.SectorLocation, exists bool) error {
+		err := db.StoreSector(root, func(loc storage.SectorLocation) error {
 			if loc.Volume != volume.ID {
 				t.Fatalf("expected volume ID %v, got %v", volume.ID, loc.Volume)
 			} else if loc.Index != uint64(i) {
 				t.Fatalf("expected sector index %v, got %v", i, loc.Index)
-			} else if exists {
-				t.Fatal("sector already exists")
 			}
 			return nil
 		})
 		if err != nil {
 			t.Fatal(err)
-		}
-
-		if err := db.AddTemporarySectors([]storage.TempSector{{Root: root, Expiration: uint64(i)}}); err != nil {
-			t.Fatal(err)
-		} else if err := release(); err != nil {
+		} else if err := db.AddTemporarySectors([]storage.TempSector{{Root: root, Expiration: uint64(i)}}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -508,16 +477,15 @@ func TestMigrateSectors(t *testing.T) {
 	}
 
 	roots = roots[initialSectors/2:]
-
 	// migrate the remaining sectors to the first half of the volume
 	var i int
-	migrated, failed, err := db.MigrateSectors(context.Background(), volume.ID, initialSectors/2, func(loc storage.SectorLocation) error {
-		if loc.Volume != volume.ID {
-			t.Fatalf("expected volume ID %v, got %v", volume.ID, loc.Volume)
-		} else if loc.Index != uint64(i) {
-			t.Fatalf("expected sector index %v, got %v", i, loc.Index)
-		} else if loc.Root != roots[i] {
-			t.Fatalf("expected sector root index %d %v, got %v", i, roots[i], loc.Root)
+	migrated, failed, err := db.MigrateSectors(context.Background(), volume.ID, initialSectors/2, func(from, to storage.SectorLocation) error {
+		if to.Volume != volume.ID {
+			t.Fatalf("expected volume ID %v, got %v", volume.ID, to.Volume)
+		} else if to.Index != uint64(i) {
+			t.Fatalf("expected sector index %v, got %v", i, to.Index)
+		} else if to.Root != roots[i] {
+			t.Fatalf("expected sector root index %d %v, got %v", i, roots[i], to.Root)
 		}
 		i++
 		return nil
@@ -534,14 +502,12 @@ func TestMigrateSectors(t *testing.T) {
 
 	// check that the sector metadata has been updated
 	for i, root := range roots {
-		if loc, release, err := db.SectorLocation(root); err != nil {
+		if loc, err := db.SectorLocation(root); err != nil {
 			t.Fatal(err)
 		} else if loc.Volume != volume.ID {
 			t.Fatalf("expected volume ID %v, got %v", volume.ID, loc.Volume)
 		} else if loc.Index != uint64(i) {
 			t.Fatalf("expected sector index %v, got %v", i, loc.Index)
-		} else if err := release(); err != nil {
-			t.Fatal(err)
 		}
 	}
 
@@ -554,14 +520,14 @@ func TestMigrateSectors(t *testing.T) {
 	}
 
 	// migrate the remaining sectors from the first volume; should partially complete
-	migrated, failed, err = db.MigrateSectors(context.Background(), volume.ID, 0, func(loc storage.SectorLocation) error {
+	migrated, failed, err = db.MigrateSectors(context.Background(), volume.ID, 0, func(from, to storage.SectorLocation) error {
 		return nil
 	})
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, storage.ErrNotEnoughStorage) {
+		t.Fatalf("expected not enough storage error, got %v", err)
 	} else if migrated != initialSectors/4 {
 		t.Fatalf("expected %v migrated sectors, got %v", initialSectors/4, migrated)
-	} else if failed != len(roots)-(initialSectors/4) {
+	} else if failed != 0 {
 		t.Fatalf("expected %v failed sectors, got %v", initialSectors-(initialSectors/4), failed)
 	}
 
@@ -587,7 +553,7 @@ func TestMigrateSectors(t *testing.T) {
 }
 
 func TestPrune(t *testing.T) {
-	const sectors = 100
+	const sectors = 75
 
 	log := zaptest.NewLogger(t)
 	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log)
@@ -603,16 +569,13 @@ func TestPrune(t *testing.T) {
 
 	// store enough sectors to fill the volume
 	roots := make([]types.Hash256, 0, sectors)
-	releaseFns := make([]func() error, 0, sectors)
 	for i := 0; i < sectors; i++ {
 		root := frand.Entropy256()
-		release, err := db.StoreSector(root, func(loc storage.SectorLocation, exists bool) error {
+		err := db.StoreSector(root, func(loc storage.SectorLocation) error {
 			if loc.Volume != volume.ID {
 				t.Fatalf("expected volume ID %v, got %v", volume.ID, loc.Volume)
 			} else if loc.Index != uint64(i) {
 				t.Fatalf("expected sector index %v, got %v", i, loc.Index)
-			} else if exists {
-				t.Fatal("sector already exists")
 			}
 			return nil
 		})
@@ -620,47 +583,60 @@ func TestPrune(t *testing.T) {
 			t.Fatal(err)
 		}
 		roots = append(roots, root)
-		releaseFns = append(releaseFns, release)
 	}
 
 	renterKey := types.NewPrivateKeyFromSeed(frand.Bytes(32))
 	hostKey := types.NewPrivateKeyFromSeed(frand.Bytes(32))
 
-	// add a contract to store the sectors
-	contractUnlockConditions := types.UnlockConditions{
-		PublicKeys: []types.UnlockKey{
-			renterKey.PublicKey().UnlockKey(),
-			hostKey.PublicKey().UnlockKey(),
-		},
-		SignaturesRequired: 2,
-	}
-	c := contracts.SignedRevision{
-		Revision: types.FileContractRevision{
-			UnlockConditions: contractUnlockConditions,
-			ParentID:         types.FileContractID(frand.Entropy256()),
-			FileContract: types.FileContract{
-				UnlockHash:  contractUnlockConditions.UnlockHash(),
-				WindowStart: 90,
-				WindowEnd:   100,
+	addContract := func(t *testing.T, expiration uint64) contracts.SignedRevision {
+		// add a contract to store the sectors
+		contractUnlockConditions := types.UnlockConditions{
+			PublicKeys: []types.UnlockKey{
+				renterKey.PublicKey().UnlockKey(),
+				hostKey.PublicKey().UnlockKey(),
 			},
-		},
+			SignaturesRequired: 2,
+		}
+		c := contracts.SignedRevision{
+			Revision: types.FileContractRevision{
+				ParentID:         types.FileContractID(frand.Entropy256()),
+				UnlockConditions: contractUnlockConditions,
+				FileContract: types.FileContract{
+					UnlockHash:  contractUnlockConditions.UnlockHash(),
+					WindowStart: expiration,
+					WindowEnd:   expiration,
+				},
+			},
+		}
+		if err := db.AddContract(c, []types.Transaction{}, types.MaxCurrency, contracts.Usage{}, 100); err != nil {
+			t.Fatal(err)
+		}
+		return c
 	}
-	if err := db.AddContract(c, []types.Transaction{}, types.MaxCurrency, contracts.Usage{}, 100); err != nil {
-		t.Fatal(err)
+
+	addSectorsToContract := func(t *testing.T, c *contracts.SignedRevision, sectors []types.Hash256) {
+		// append the contract sectors to the contract
+		var changes []contracts.SectorChange
+		for _, root := range sectors {
+			changes = append(changes, contracts.SectorChange{
+				Root:   root,
+				Action: contracts.SectorActionAppend,
+			})
+		}
+		err = db.ReviseContract(*c, []types.Hash256{}, contracts.Usage{}, changes)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
-	contractSectors, tempSectors, lockedSectors, deletedSectors := roots[:20], roots[20:40], roots[40:60], roots[60:]
-	// append the contract sectors to the contract
-	var changes []contracts.SectorChange
-	for _, root := range contractSectors {
-		changes = append(changes, contracts.SectorChange{
-			Root:   root,
-			Action: contracts.SectorActionAppend,
-		})
-	}
-	err = db.ReviseContract(c, []types.Hash256{}, contracts.Usage{}, changes)
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	contract1Sectors, contract2Sectors, tempSectors, unreferencedSectors := roots[:10], roots[10:25], roots[25:50], roots[50:]
+
+	c1 := addContract(t, 100)
+	c2 := addContract(t, 110)
+
+	// add the sectors to the contract
+	addSectorsToContract(t, &c1, contract1Sectors)
+	addSectorsToContract(t, &c2, contract2Sectors)
 
 	// add the temporary sectors
 	var tempRoots []storage.TempSector
@@ -674,133 +650,72 @@ func TestPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// lock the remaining sectors
-	var locks []int64
-	for _, root := range lockedSectors {
-		err := db.transaction(func(tx *txn) error {
-			sectorID, err := sectorDBID(tx, root)
-			if err != nil {
-				return err
-			}
-			lockID, err := lockSector(tx, sectorID)
-			if err != nil {
-				return err
-			}
-			locks = append(locks, lockID)
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
+	assertSectors := func(t *testing.T, contract, temp uint64, available, deleted []types.Hash256) {
+		t.Helper()
 
-	// remove the initial locks
-	for _, fn := range releaseFns {
-		if err := fn(); err != nil {
-			t.Fatal(err)
+		for _, root := range available {
+			if _, err := db.SectorLocation(root); err != nil {
+				t.Fatalf("sector %v not found: %s", available, err)
+			}
 		}
-	}
-
-	checkConsistency := func(contract, temp, locked, deleted []types.Hash256) error {
-		for _, root := range contract {
-			if _, release, err := db.SectorLocation(root); err != nil {
-				return fmt.Errorf("sector %v not found: %w", root, err)
-			} else if err := release(); err != nil {
-				return fmt.Errorf("failed to release sector %v: %w", root, err)
+		for _, root := range deleted {
+			if _, err := db.SectorLocation(root); !errors.Is(err, storage.ErrSectorNotFound) {
+				t.Fatalf("expected ErrSectorNotFound, got %v", err)
 			}
 		}
 
-		for _, root := range temp {
-			if _, release, err := db.SectorLocation(root); err != nil {
-				return fmt.Errorf("sector %v not found: %w", root, err)
-			} else if err := release(); err != nil {
-				return fmt.Errorf("failed to release sector %v: %w", root, err)
-			}
-		}
-
-		for _, root := range locked {
-			if _, release, err := db.SectorLocation(root); err != nil {
-				return fmt.Errorf("sector %v not found: %w", root, err)
-			} else if err := release(); err != nil {
-				return fmt.Errorf("failed to release sector %v: %w", root, err)
-			}
-		}
-
-		for i, root := range deleted {
-			if _, _, err := db.SectorLocation(root); !errors.Is(err, storage.ErrSectorNotFound) {
-				return fmt.Errorf("expected ErrSectorNotFound for sector %d %q, got %v", i, root, err)
-			}
-		}
-
-		// check the volume usage
-		expectedSectors := uint64(len(contract) + len(temp) + len(locked))
 		used, _, err := db.StorageUsage()
 		if err != nil {
-			return fmt.Errorf("failed to get storage usage: %w", err)
-		} else if used != expectedSectors {
-			return fmt.Errorf("expected %v sectors, got %v", expectedSectors, used)
+			t.Fatalf("failed to get storage usage: %v", err)
+		} else if used != uint64(len(available)) {
+			t.Fatalf("expected %v sectors, got %v", used, len(available))
 		}
 
-		// check the metrics
 		m, err := db.Metrics(time.Now())
 		if err != nil {
-			return fmt.Errorf("failed to get metrics: %w", err)
-		} else if m.Storage.PhysicalSectors != expectedSectors {
-			return fmt.Errorf("expected %v total sectors, got %v", expectedSectors, m.Storage.PhysicalSectors)
-		} else if m.Storage.ContractSectors != uint64(len(contract)) {
-			return fmt.Errorf("expected %v contract sectors, got %v", len(contract), m.Storage.ContractSectors)
-		} else if m.Storage.TempSectors != uint64(len(temp)) {
-			return fmt.Errorf("expected %v temporary sectors, got %v", len(temp), m.Storage.TempSectors)
+			t.Fatalf("failed to get metrics: %v", err)
+		} else if m.Storage.PhysicalSectors != uint64(len(available)) {
+			t.Fatalf("expected %v physical sectors, got %v", len(available), m.Storage.PhysicalSectors)
+		} else if m.Storage.ContractSectors != contract {
+			t.Fatalf("expected %v contract sectors, got %v", contract, m.Storage.ContractSectors)
+		} else if m.Storage.TempSectors != temp {
+			t.Fatalf("expected %v temporary sectors, got %v", temp, m.Storage.TempSectors)
 		}
-		return nil
 	}
+	assertSectors(t, 25, 25, roots, nil)
 
-	if err := checkConsistency(contractSectors, tempSectors, lockedSectors, deletedSectors); err != nil {
+	// prune unreferenced sectors
+	available, deleted := roots[:len(roots)-len(unreferencedSectors)], unreferencedSectors
+	if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
+	assertSectors(t, 25, 25, available, deleted)
 
-	// unlock locked sectors
-	err = db.transaction(func(tx *txn) error {
-		return unlockSector(tx, log.Named("unlockSector"), locks...)
-	})
-	if err != nil {
+	// expire one of the contract's sectors
+	if err := db.ExpireContractSectors(101); err != nil {
+		t.Fatal(err)
+	} else if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
-
-	if err := checkConsistency(contractSectors, tempSectors, nil, roots[60:]); err != nil {
-		t.Fatal(err)
-	}
+	available, deleted = append(contract2Sectors, tempSectors...), append(deleted, contract1Sectors...)
+	assertSectors(t, 15, 25, available, deleted)
 
 	// expire the temp sectors
-	if err := db.ExpireTempSectors(100); err != nil {
+	if err := db.ExpireTempSectors(101); err != nil {
+		t.Fatal(err)
+	} else if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
+	available, deleted = contract2Sectors, append(deleted, tempSectors...)
+	assertSectors(t, 15, 0, available, deleted)
 
-	if err := checkConsistency(contractSectors, nil, nil, roots[40:]); err != nil {
+	if err := db.ExpireContractSectors(111); err != nil {
+		t.Fatal(err)
+	} else if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
-
-	// trim half of the contract sectors
-	changes = []contracts.SectorChange{
-		{Action: contracts.SectorActionTrim, A: uint64(len(contractSectors) / 2)},
-	}
-	if err := db.ReviseContract(c, contractSectors, contracts.Usage{}, changes); err != nil {
-		t.Fatal(err)
-	}
-	contractSectors = contractSectors[:len(contractSectors)/2]
-
-	if err := checkConsistency(contractSectors, nil, nil, roots[50:]); err != nil {
-		t.Fatal(err)
-	}
-
-	// expire the rest of the contract sectors
-	if err := db.ExpireContractSectors(c.Revision.WindowEnd + 1); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := checkConsistency(nil, nil, nil, roots); err != nil {
-		t.Fatal(err)
-	}
+	available, deleted = nil, append(deleted, contract1Sectors...)
+	assertSectors(t, 0, 0, available, deleted)
 }
 
 func BenchmarkVolumeGrow(b *testing.B) {
@@ -870,11 +785,9 @@ func BenchmarkVolumeMigrate(b *testing.B) {
 	roots := make([]types.Hash256, b.N)
 	for i := range roots {
 		roots[i] = frand.Entropy256()
-		release, err := db.StoreSector(roots[i], func(loc storage.SectorLocation, exists bool) error { return nil })
+		err := db.StoreSector(roots[i], func(loc storage.SectorLocation) error { return nil })
 		if err != nil {
 			b.Fatalf("failed to store sector %v: %v", i, err)
-		} else if err := release(); err != nil {
-			b.Fatal(err)
 		}
 	}
 
@@ -888,7 +801,7 @@ func BenchmarkVolumeMigrate(b *testing.B) {
 	b.ReportMetric(float64(b.N), "sectors")
 
 	// migrate all sectors from the first volume to the second
-	migrated, failed, err := db.MigrateSectors(context.Background(), volume1.ID, 0, func(loc storage.SectorLocation) error {
+	migrated, failed, err := db.MigrateSectors(context.Background(), volume1.ID, 0, func(from, to storage.SectorLocation) error {
 		return nil
 	})
 	if err != nil {
@@ -918,8 +831,38 @@ func BenchmarkStoreSector(b *testing.B) {
 	b.ReportMetric(float64(b.N), "sectors")
 
 	for i := 0; i < b.N; i++ {
-		_, err := db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation, exists bool) error { return nil })
+		err := db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation) error { return nil })
 		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkReadSector(b *testing.B) {
+	log := zaptest.NewLogger(b)
+	db, err := OpenDatabase(filepath.Join(b.TempDir(), "test.db"), log)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	_, err = addTestVolume(db, "test", uint64(b.N*2))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	root := frand.Entropy256()
+	err = db.StoreSector(root, func(loc storage.SectorLocation) error { return nil })
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.ReportMetric(float64(b.N), "sectors")
+
+	for i := 0; i < b.N; i++ {
+		if _, err := db.SectorLocation(root); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/rhp/v2/rhp.go
+++ b/rhp/v2/rhp.go
@@ -50,10 +50,8 @@ type (
 
 	// Sectors reads and writes sectors to persistent storage
 	Sectors interface {
-		// Write writes a sector to persistent storage. release should only be
-		// called after the contract roots have been committed to prevent the
-		// sector from being deleted.
-		Write(root types.Hash256, data *[rhp2.SectorSize]byte) (release func() error, _ error)
+		// Write writes a sector to persistent storage
+		Write(root types.Hash256, data *[rhp2.SectorSize]byte) error
 		// Read reads the sector with the given root from the manager.
 		Read(root types.Hash256) (*[rhp2.SectorSize]byte, error)
 		// Sync syncs the data files of changed volumes.

--- a/rhp/v3/execute.go
+++ b/rhp/v3/execute.go
@@ -132,7 +132,6 @@ func (pe *programExecutor) executeAppendSectorRoot(instr *rhp3.InstrAppendSector
 		return nil, nil, fmt.Errorf("failed to pay for instruction: %w", err)
 	}
 
-	// lock the sector to prevent it from being garbage collected
 	exists, err := pe.sectors.HasSector(root)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read sector: %w", err)

--- a/rhp/v3/rpc_test.go
+++ b/rhp/v3/rpc_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	crhp2 "go.sia.tech/core/rhp/v2"
 	crhp3 "go.sia.tech/core/rhp/v3"
@@ -325,6 +326,10 @@ func TestStoreSector(t *testing.T) {
 
 	// mine until the sector expires
 	testutil.MineAndSync(t, node, node.Wallet.Address(), 10)
+	// ensure the dereferenced sector has been pruned
+	if err := node.Store.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
 
 	// check that the sector was deleted
 	usage = pt.ReadSectorCost(crhp2.SectorSize)


### PR DESCRIPTION
Improves sector lookups by 50% on average by removing the sector lock tables and moving reference pruning out of the hot path.

Broken out of #490 