### PR TITLE
fix(sqlite): Recalculate contract metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	go.sia.tech/core v0.7.1
 	go.sia.tech/coreutils v0.7.1-0.20241203172514-7bf95dd18f31
 	go.sia.tech/jape v0.12.1
+	go.sia.tech/mux v1.3.0
 	go.sia.tech/web/hostd v0.52.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
@@ -33,7 +34,6 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	go.etcd.io/bbolt v1.3.11 // indirect
-	go.sia.tech/mux v1.3.0 // indirect
 	go.sia.tech/web v0.0.0-20240610131903-5611d44a533e // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.29.0 // indirect

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -12,6 +12,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// migrateVersion36 recalculates the contract metrics to remove the pending contract
+// values from the metrics.
+func migrateVersion36(tx *txn, log *zap.Logger) error {
+	return recalcContractMetrics(tx, log)
+}
+
 // migrateVersion35 trims the port from the net_address in the host settings
 // table.
 func migrateVersion35(tx *txn, _ *zap.Logger) error {
@@ -1009,4 +1015,5 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion33,
 	migrateVersion34,
 	migrateVersion35,
+	migrateVersion36,
 }


### PR DESCRIPTION
In v2, the global metrics were changed to only include active contracts. This requires recalculating the existing metrics to remove pending contracts from the global metrics.