### PR TITLE
fix(contracts,sqlite): Fix contract account usage calculation

### DIFF
--- a/persist/sqlite/accounts.go
+++ b/persist/sqlite/accounts.go
@@ -440,10 +440,6 @@ func distributeRHP3AccountUsage(tx *txn, accountID int64, usage accounts.Usage, 
 		distributeFunds(&usage.RegistryWrite, &additionalUsage.RegistryWrite, &remainder)
 		distributeFunds(&usage.RPCRevenue, &additionalUsage.RPCRevenue, &remainder)
 
-		// add the additional usage to the contract
-		if err := incrementContractUsage(tx, f.ContractID, additionalUsage); err != nil {
-			return fmt.Errorf("failed to increment contract usage: %w", err)
-		}
 		// update the remaining value for the funding source
 		if err := setContractAccountFunding(tx, f.ID, remainder); err != nil {
 			return fmt.Errorf("failed to set account funding: %w", err)

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -12,6 +12,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// migrateVersion37 recalculates the contract metrics to remove the pending contract
+// values from the metrics.
+func migrateVersion37(tx *txn, log *zap.Logger) error {
+	return recalcContractMetrics(tx, log)
+}
+
 // migrateVersion36 recalculates the contract metrics to remove the pending contract
 // values from the metrics.
 func migrateVersion36(tx *txn, log *zap.Logger) error {
@@ -1016,4 +1022,5 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion34,
 	migrateVersion35,
 	migrateVersion36,
+	migrateVersion37,
 }

--- a/persist/sqlite/recalc.go
+++ b/persist/sqlite/recalc.go
@@ -178,7 +178,7 @@ func recalcContractMetrics(tx *txn, log *zap.Logger) error {
 			var lockedCollateral types.Currency
 			var usage contracts.Usage
 
-			if err := rows.Scan(&status, decode(&lockedCollateral), decode(&usage.RiskedCollateral), decode(&usage.RPCRevenue), decode(&usage.StorageRevenue), decode(&usage.IngressRevenue), decode(&usage.EgressRevenue), decode(&usage.AccountFunding), decode(&usage.RegistryRead), decode(&usage.RegistryWrite)); err != nil {
+			if err := rows.Scan(&status, decode(&lockedCollateral), decode(&usage.RiskedCollateral), decode(&usage.RPCRevenue), decode(&usage.StorageRevenue), decode(&usage.IngressRevenue), decode(&usage.EgressRevenue), decode(&usage.AccountFunding)); err != nil {
 				return fmt.Errorf("failed to scan contract: %w", err)
 			}
 


### PR DESCRIPTION
`incrementContractUsage` is called from `updateContractUsage` for `distributeRHP3AccountUsage` effectively doubling the contract usage columns. 