### PR TITLE
fix(settings): Fix DDNS using invalid net address

### DIFF
--- a/host/settings/announce.go
+++ b/host/settings/announce.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
@@ -102,9 +103,13 @@ func (m *ConfigManager) Announce() error {
 func validateHostname(host string) error {
 	// Check that the host is not empty or localhost.
 	if host == "" {
-		return errors.New("empty net address")
+		return errors.New("empty hostname")
 	} else if host == "localhost" {
-		return errors.New("net address cannot be localhost")
+		return errors.New("hostname cannot be localhost")
+	} else if _, _, err := net.SplitHostPort(host); err == nil {
+		return errors.New("hostname should not contain a port")
+	} else if strings.HasPrefix(host, "[") || strings.HasSuffix(host, "]") {
+		return errors.New(`hostname must not start with "[" or end with "]"`)
 	}
 
 	// If the host is an IP address, check that it is a public IP address.

--- a/host/settings/ddns.go
+++ b/host/settings/ddns.go
@@ -87,11 +87,7 @@ func (m *ConfigManager) resetDDNS() {
 // UpdateDDNS triggers an update of the host's dynamic DNS records.
 func (m *ConfigManager) UpdateDDNS(force bool) error {
 	m.mu.Lock()
-	hostname, _, err := net.SplitHostPort(m.settings.NetAddress)
-	if err != nil {
-		m.mu.Unlock()
-		return fmt.Errorf("failed to split netaddress host and port: %w", err)
-	}
+	hostname := m.settings.NetAddress
 	settings := m.settings.DDNS
 	lastIPv4, lastIPv6 := m.lastIPv4, m.lastIPv6
 	m.mu.Unlock()
@@ -100,6 +96,7 @@ func (m *ConfigManager) UpdateDDNS(force bool) error {
 		lastIPv4, lastIPv6 = nil, nil
 	}
 
+	var err error
 	var ipv4 net.IP
 	if settings.IPv4 {
 		// get the IPv4 address

--- a/host/settings/validate_test.go
+++ b/host/settings/validate_test.go
@@ -1,0 +1,39 @@
+package settings
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateHostname(t *testing.T) {
+	tests := []struct {
+		addr   string
+		valid  bool
+		errStr string
+	}{
+		{"", false, "empty hostname"},
+		{"localhost", false, "hostname cannot be localhost"},
+		{"foo.bar:9982", false, "hostname should not contain a port"},
+		{"192.168.1.1", false, "only public IP addresses allowed"},
+		{"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:9982", false, "hostname should not contain a port"},
+		{"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]", false, `hostname must not start with "[" or end with "]"`},
+		{"2001:0db8:85a3:0000:0000:8a2e:0370:7334", true, ""},
+		{"55.123.123.123", true, ""},
+		{"foo.bar", true, ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.addr, func(t *testing.T) {
+			err := validateHostname(test.addr)
+			if err != nil {
+				if test.valid {
+					t.Fatalf("expected valid host, got %v", err)
+				} else if !strings.Contains(err.Error(), test.errStr) {
+					t.Fatalf("expected %v, got %v", test.errStr, err)
+				}
+			} else if !test.valid {
+				t.Fatalf("expected %v, got %v", test.errStr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The net address in the host settings was changed to only include the `hostname` instead of `hostname:port`. This broke DDNS updates as the port was still expected to be on the hostname. This adds additional validation to the host's net address setting and fixes DDNS updates.  