### PR TITLE
Ignore conventional commits

### DIFF
--- a/.changeset/add_support_for_rhp4.md
+++ b/.changeset/add_support_for_rhp4.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Add RHP4 support
+
+RHP4 is the next generation of renter-host protocol for the Sia storage network. It dramatically increases performance compared to RHP3, improves contract payouts, reduces collateral lockup, and enables features necessary for light clients. The new protocol will be available and activated starting at block height `513400` (March 10th, 2025).

--- a/.changeset/add_support_for_rhp4_accounts.md
+++ b/.changeset/add_support_for_rhp4_accounts.md
@@ -1,5 +1,0 @@
----
-default: minor
----
-
-# Add support for RHP4 accounts

--- a/.changeset/added_support_for_announcing_rhp4_addresses.md
+++ b/.changeset/added_support_for_announcing_rhp4_addresses.md
@@ -1,5 +1,0 @@
----
-default: minor
----
-
-# Support announcing RHP4 addresses

--- a/.changeset/support_v2_hardfork.md
+++ b/.changeset/support_v2_hardfork.md
@@ -1,0 +1,26 @@
+---
+default: major
+---
+
+# Support V2 Hardfork
+
+The V2 hardfork is scheduled to modernize Sia's consensus protocol, which has been untouched since Sia's mainnet launch back in 2014, and improve accessibility of the storage network. To ensure a smooth transition from V1, it will be executed in two phases. Additional documentation on upgrading will be released in the near future.
+
+#### V2 Highlights
+- Drastically reduces blockchain size on disk
+- Improves UTXO spend policies - including HTLC support for Atomic Swaps
+- More efficient contract renewals - reducing lock up requirements for hosts and renters
+- Improved transfer speeds - enables hot storage
+
+#### Phase 1 - Allow Height
+- **Activation Height:** `513400` (March 10th, 2025)
+- **New Features:** V2 transactions, contracts, and RHP4
+- **V1 Support:** Both V1 and V2 will be supported during this phase
+- **Purpose:** This period gives time for integrators to transition from V1 to V2
+- **Requirements:** Users will need to update to support the hardfork before this block height
+
+#### Phase 2 - Require Height
+- **Activation Height:** `526000` (June 6th, 2025)
+- **New Features:** The consensus database can be trimmed to only store the Merkle proofs
+- **V1 Support:** V1 will be disabled, including RHP2 and RHP3. Only V2 transactions will be accepted
+- **Requirements:** Developers will need to update their apps to support V2 transactions and RHP4 before this block height

--- a/.changeset/switch_to_core_consensus.md
+++ b/.changeset/switch_to_core_consensus.md
@@ -1,0 +1,7 @@
+---
+default: major
+---
+
+# Switch to `core` consensus
+
+Removes the last legacy code from `siad`. Switching between Mainnet and Testnet can now be done with a CLI flag e.g. `--network=zen`. This will require hosts to resync the blockchain. Refrain from upgrading if contracts are about to expire.

--- a/knope.toml
+++ b/knope.toml
@@ -18,6 +18,7 @@ command = "git switch -c release"
 
 [[workflows.steps]]
 type = "PrepareRelease"
+ignore_conventional_commits = true
 
 [[workflows.steps]]
 type = "Command"
@@ -46,7 +47,7 @@ variables = { "$changelog" = "ChangelogEntry", "$version" = "Version" }
 # Do not enable releases, just changelogs for now.
 # [[workflows]]
 # name = "release"
-# 
+#
 # [[workflows.steps]]
 # type = "Release"
 


### PR DESCRIPTION
Changes the Knope config to exclude conventional commits so that only explicit change set files will be included in the final change log.