### PR TITLE
Use standard directories

### DIFF
--- a/.changeset/use_default_data_directories.md
+++ b/.changeset/use_default_data_directories.md
@@ -1,0 +1,19 @@
+---
+default: patch
+---
+
+# Use standard locations for application data
+
+Uses standard locations for application data instead of the current directory. This brings `hostd` in line with other system services and makes it easier to manage application data.
+
+#### Linux, FreeBSD, OpenBSD
+- Configuration: `/etc/hostd`
+- Data directory: `/var/lib/hostd`
+
+#### macOS
+- Configuration: `~/Library/Application Support/hostd`
+- Data directory: `~/Library/Application Support/hostd`
+
+#### Windows
+- Configuration: `%APPDATA%\SiaFoundation\hostd`
+- Data directory: `%APPDATA%\SiaFoundation\hostd`

--- a/.changeset/use_default_data_directories.md
+++ b/.changeset/use_default_data_directories.md
@@ -7,13 +7,17 @@ default: major
 Uses standard locations for application data instead of the current directory. This brings `hostd` in line with other system services and makes it easier to manage application data.
 
 #### Linux, FreeBSD, OpenBSD
-- Configuration: `/etc/hostd`
+- Configuration: `/etc/hostd/hostd.yml`
 - Data directory: `/var/lib/hostd`
 
 #### macOS
-- Configuration: `~/Library/Application Support/hostd`
+- Configuration: `~/Library/Application Support/hostd.yml`
 - Data directory: `~/Library/Application Support/hostd`
 
 #### Windows
-- Configuration: `%APPDATA%\SiaFoundation\hostd`
+- Configuration: `%APPDATA%\SiaFoundation\hostd.yml`
 - Data directory: `%APPDATA%\SiaFoundation\hostd`
+
+#### Docker
+- Configuration: `/data/hostd.yml`
+- Data directory: `/data`

--- a/.changeset/use_default_data_directories.md
+++ b/.changeset/use_default_data_directories.md
@@ -1,5 +1,5 @@
 ---
-default: patch
+default: major
 ---
 
 # Use standard locations for application data

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ EXPOSE 9983/tcp
 
 USER ${PUID}:${PGID}
 
-ENTRYPOINT [ "hostd", "--env", "--dir", "/data", "--http", ":9980" ]
+ENTRYPOINT [ "hostd", "--env", "--http", ":9980" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,17 @@ RUN CGO_ENABLED=1 go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflag
 FROM scratch
 
 LABEL maintainer="The Sia Foundation <info@sia.tech>" \
-      org.opencontainers.image.description.vendor="The Sia Foundation" \
-      org.opencontainers.image.description="A hostd container - provide storage on the Sia network and earn Siacoin" \
-      org.opencontainers.image.source="https://github.com/SiaFoundation/hostd" \
-      org.opencontainers.image.licenses=MIT
+    org.opencontainers.image.description.vendor="The Sia Foundation" \
+    org.opencontainers.image.description="A hostd container - provide storage on the Sia network and earn Siacoin" \
+    org.opencontainers.image.source="https://github.com/SiaFoundation/hostd" \
+    org.opencontainers.image.licenses=MIT
 
 ENV PUID=0
 ENV PGID=0
 
 ENV HOSTD_API_PASSWORD=
 ENV HOSTD_WALLET_SEED=
+ENV HOSTD_DATA_DIR=/data
 ENV HOSTD_CONFIG_FILE=/data/hostd.yml
 
 # copy binary and prepare data dir.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,31 @@ ensuring a smooth user experience across a diverse range of devices.
 
 ## Configuration
 
-`hostd` can be configured in multiple ways. Some settings, like the wallet key,
-can be configured via environment variables or stdin. Others, like the RHP
-ports, can be configured via CLI flags. To simplify more complex configurations,
-`hostd` also supports the use of a YAML configuration file for all settings.
+The YAML config file is the recommended way to configure `hostd`. `hostd` includes a command to interactively generate a config file: `hostd config`. Some settings can be overridden using CLI flags or environment variables. 
+
+### Default Paths
+
+#### Data Directory
+
+The host's consensus database, host database, and log files are stored in the data directory.
+
+Operating System | Path
+---|---
+Windows | `%APPDATA%/hostd`
+macOS | `~/Library/Application Support/hostd`
+Linux | `/var/lib/hostd`
+Docker | `/data`
+
+#### Config File
+
+Operating System | Path
+---|---
+Windows | `%APPDATA%/hostd/hostd.yml`
+macOS | `~/Library/Application Support/hostd/hostd.yml`
+Linux | `/etc/hostd/hostd.yml`
+Docker | `/data/hostd.yml`
+
+The default config path can be changed using the `HOSTD_CONFIG_FILE` environment variable. For backwards compatibility with earlier versions, `hostd` will also check for `hostd.yml` in the current directory.
 
 ### Default Ports
 + `9980` - UI and API
@@ -31,9 +52,7 @@ ports, can be configured via CLI flags. To simplify more complex configurations,
 + `9983` - RHP3
 + `9984` - RHP4
 
-### YAML
-The YAML config file is the recommended way to configure `hostd`. It defaults to `hostd.yml` in the current directory, but can be changed
-with the `HOSTD_CONFIG_FILE` environment variable. In Docker, the config file defaults to `/data/hostd.yml`.
+### Example Config File
 
 ```yaml
 directory: /etc/hostd
@@ -69,8 +88,7 @@ log:
 + `HOSTD_API_PASSWORD` - The password for the UI and API
 + `HOSTD_WALLET_SEED` - The recovery phrase for the wallet
 + `HOSTD_LOG_FILE` - changes the location of the log file. If unset, the log file will be created in the data directory
-+ `HOSTD_CONFIG_FILE` - changes the path of the optional config file. If unset,
-  `hostd` will check for a config file in the current directory
++ `HOSTD_CONFIG_FILE` - changes the path of the `hostd` config file.
 
 ### CLI Flags
 ```sh

--- a/cmd/hostd/config.go
+++ b/cmd/hostd/config.go
@@ -261,7 +261,7 @@ func configPath() string {
 	case "darwin":
 		return filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "hostd", "hostd.yml")
 	case "linux", "freebsd", "openbsd":
-		return filepath.Join("/etc", "hostd", "hostd.yml")
+		return filepath.Join(string(filepath.Separator), "etc", "hostd", "hostd.yml")
 	default:
 		return "hostd.yml"
 	}

--- a/cmd/hostd/config.go
+++ b/cmd/hostd/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -285,6 +286,11 @@ func runConfigCmd(fp string) {
 		if !promptYesNo(fmt.Sprintf("%q already exists. Would you like to overwrite it?", fp)) {
 			return
 		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		checkFatalError("failed to check if config file exists", err)
+	} else {
+		// ensure the config directory exists
+		checkFatalError("failed to create config directory", os.MkdirAll(filepath.Dir(fp), 0700))
 	}
 
 	fmt.Println("")

--- a/cmd/hostd/main.go
+++ b/cmd/hostd/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -26,11 +25,13 @@ const (
 	walletSeedEnvVar  = "HOSTD_WALLET_SEED"
 	apiPasswordEnvVar = "HOSTD_API_PASSWORD"
 	configFileEnvVar  = "HOSTD_CONFIG_FILE"
+	dataDirEnvVar     = "HOSTD_DATA_DIR"
 	logFileEnvVar     = "HOSTD_LOG_FILE_PATH"
 )
 
 var (
 	cfg = config.Config{
+		Directory:      os.Getenv(dataDirEnvVar),    // default to env variable
 		RecoveryPhrase: os.Getenv(walletSeedEnvVar), // default to env variable
 		AutoOpenWebUI:  true,
 
@@ -109,8 +110,8 @@ func tryConfigPaths() []string {
 		paths = append(paths, filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "hostd", "hostd.yml"))
 	case "linux", "freebsd", "openbsd":
 		paths = append(paths,
-			filepath.Join("/etc", "hostd", "hostd.yml"), // prefer /etc over /var
-			filepath.Join("/var", "lib", "hostd", "hostd.yml"),
+			filepath.Join(string(filepath.Separator), "etc", "hostd", "hostd.yml"),
+			filepath.Join(string(filepath.Separator), "var", "lib", "hostd", "hostd.yml"), // old default for the Linux service
 			filepath.Join(os.Getenv("HOME"), ".hostd", "hostd.yml"),
 		)
 	}
@@ -277,7 +278,6 @@ func main() {
 	configPath := tryLoadConfig()
 	// set the data directory to the default if it is not set
 	cfg.Directory = defaultDatabasePath(cfg.Directory)
-	log.Println(cfg.Directory)
 
 	rootCmd := flagg.Root
 	rootCmd.Usage = flagg.SimpleUsage(rootCmd, rootUsage)

--- a/cmd/hostd/main.go
+++ b/cmd/hostd/main.go
@@ -276,9 +276,15 @@ func runRecalcCommand(srcPath string, log *zap.Logger) error {
 }
 
 func main() {
+	log := initStdoutLog(cfg.Log.StdOut.EnableANSI, cfg.Log.Level)
+	defer log.Sync()
+
 	// attempt to load the config file, command line flags will override any
 	// values set in the config file
 	configPath := tryLoadConfig()
+	if configPath != "" {
+		log.Info("loaded config file", zap.String("path", configPath))
+	}
 	// set the data directory to the default if it is not set
 	cfg.Directory = defaultDataDirectory(cfg.Directory)
 
@@ -334,7 +340,6 @@ func main() {
 		fmt.Println("hostd", build.Version())
 		fmt.Println("Commit:", build.Commit())
 		fmt.Println("Build Date:", build.Time())
-
 	case seedCmd:
 		if len(cmd.Args()) != 0 {
 			cmd.Usage()
@@ -359,9 +364,6 @@ func main() {
 			cmd.Usage()
 			return
 		}
-
-		log := initStdoutLog(cfg.Log.StdOut.EnableANSI, cfg.Log.Level)
-		defer log.Sync()
 
 		checkFatalError("command failed", runRecalcCommand(cmd.Arg(0), log))
 	case sqlite3Cmd:

--- a/cmd/hostd/main.go
+++ b/cmd/hostd/main.go
@@ -103,6 +103,10 @@ func tryConfigPaths() []string {
 	paths := []string{
 		"hostd.yml",
 	}
+	if str := os.Getenv(dataDirEnvVar); str != "" {
+		paths = append(paths, filepath.Join(str, "hostd.yml"))
+	}
+
 	switch runtime.GOOS {
 	case "windows":
 		paths = append(paths, filepath.Join(os.Getenv("APPDATA"), "hostd", "hostd.yml"))
@@ -112,7 +116,6 @@ func tryConfigPaths() []string {
 		paths = append(paths,
 			filepath.Join(string(filepath.Separator), "etc", "hostd", "hostd.yml"),
 			filepath.Join(string(filepath.Separator), "var", "lib", "hostd", "hostd.yml"), // old default for the Linux service
-			filepath.Join(os.Getenv("HOME"), ".hostd", "hostd.yml"),
 		)
 	}
 	return paths

--- a/cmd/hostd/main.go
+++ b/cmd/hostd/main.go
@@ -277,7 +277,7 @@ func main() {
 	// values set in the config file
 	configPath := tryLoadConfig()
 	// set the data directory to the default if it is not set
-	cfg.Directory = defaultDatabasePath(cfg.Directory)
+	cfg.Directory = defaultDataDirectory(cfg.Directory)
 
 	rootCmd := flagg.Root
 	rootCmd.Usage = flagg.SimpleUsage(rootCmd, rootUsage)

--- a/cmd/hostd/run.go
+++ b/cmd/hostd/run.go
@@ -50,9 +50,9 @@ func defaultDataDirectory(fp string) string {
 
 	// check for databases in the current directory
 	if _, err := os.Stat("hostd.db"); err == nil {
-		return "."
+		return ""
 	} else if _, err := os.Stat("hostd.sqlite3"); err == nil {
-		return "."
+		return ""
 	}
 
 	// default to the operating system's application directory

--- a/cmd/hostd/run.go
+++ b/cmd/hostd/run.go
@@ -64,7 +64,7 @@ func defaultDataDirectory(fp string) string {
 	case "linux", "freebsd", "openbsd":
 		return filepath.Join(string(filepath.Separator), "var", "lib", "hostd")
 	default:
-		return "."
+		return ""
 	}
 }
 

--- a/cmd/hostd/run.go
+++ b/cmd/hostd/run.go
@@ -42,7 +42,7 @@ import (
 	"lukechampine.com/upnp"
 )
 
-func defaultDatabasePath(fp string) string {
+func defaultDataDirectory(fp string) string {
 	// use the provided path if it's not empty
 	if fp != "" {
 		return fp

--- a/cmd/hostd/run.go
+++ b/cmd/hostd/run.go
@@ -62,7 +62,7 @@ func defaultDatabasePath(fp string) string {
 	case "darwin":
 		return filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "hostd")
 	case "linux", "freebsd", "openbsd":
-		return filepath.Join("/var", "lib", "hostd")
+		return filepath.Join(string(filepath.Separator), "var", "lib", "hostd")
 	default:
 		return "."
 	}


### PR DESCRIPTION
Uses standard locations for application data instead of the current directory. This brings `hostd` in line with other system services and makes it easier to manage application data. This should fall back to `PWD` if a database file already exists.

#### Linux, FreeBSD, OpenBSD
- Configuration: `/etc/hostd`
- Data directory: `/var/lib/hostd`

#### macOS
- Configuration: `~/Library/Application Support/hostd`
- Data directory: `~/Library/Application Support/hostd`

#### Windows
- Configuration: `%APPDATA%\SiaFoundation\hostd`
- Data directory: `%APPDATA%\SiaFoundation\hostd`

#### Docker
- Configuration: `/data`
- Data directory: `/data`