### PR TITLE
Re-add missing consensus index endpoints

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -99,7 +99,7 @@ func (a *api) handleGETState(jc jape.Context) {
 }
 
 func (a *api) handleGETConsensusTip(jc jape.Context) {
-	jc.Encode(a.chain.Tip())
+	a.writeResponse(jc, ConsensusIndexResp(a.chain.Tip()))
 }
 func (a *api) handleGETConsensusTipState(jc jape.Context) {
 	jc.Encode(a.chain.TipState())
@@ -148,7 +148,7 @@ func (a *api) handlePUTSyncerPeer(jc jape.Context) {
 }
 
 func (a *api) handleGETIndexTip(jc jape.Context) {
-	jc.Encode(a.index.Tip())
+	a.writeResponse(jc, ConsensusIndexResp(a.index.Tip()))
 }
 
 func (a *api) handleGETAlerts(jc jape.Context) {
@@ -172,8 +172,7 @@ func (a *api) handlePOSTAnnounce(jc jape.Context) {
 }
 
 func (a *api) handleGETSettings(jc jape.Context) {
-	hs := HostSettings(a.settings.Settings())
-	a.writeResponse(jc, hs)
+	a.writeResponse(jc, HostSettings(a.settings.Settings()))
 }
 
 func (a *api) handlePATCHSettings(jc jape.Context) {

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -102,7 +102,7 @@ func (a *api) handleGETConsensusTip(jc jape.Context) {
 	a.writeResponse(jc, ConsensusIndexResp(a.chain.Tip()))
 }
 func (a *api) handleGETConsensusTipState(jc jape.Context) {
-	jc.Encode(a.chain.TipState())
+	a.writeResponse(jc, ConsensusStateResp(a.chain.TipState()))
 }
 func (a *api) handleGETConsensusNetwork(jc jape.Context) {
 	jc.Encode(a.chain.TipState().Network)

--- a/api/prometheus.go
+++ b/api/prometheus.go
@@ -40,6 +40,20 @@ func (s State) PrometheusMetric() []prometheus.Metric {
 	}
 }
 
+// PrometheusMetric returns Prometheus samples for the host's consensus index.
+func (cs ConsensusIndexResp) PrometheusMetric() []prometheus.Metric {
+	return []prometheus.Metric{
+		{
+			Name: "hostd_consensus_height",
+			Labels: map[string]any{
+				"block_id": cs.ID,
+			},
+			Value:     float64(cs.Height),
+			Timestamp: time.Now(),
+		},
+	}
+}
+
 // PrometheusMetric returns Prometheus samples for the host settings.
 func (hs HostSettings) PrometheusMetric() []prometheus.Metric {
 	return []prometheus.Metric{

--- a/api/prometheus.go
+++ b/api/prometheus.go
@@ -54,6 +54,27 @@ func (cs ConsensusIndexResp) PrometheusMetric() []prometheus.Metric {
 	}
 }
 
+// PrometheusMetric returns Prometheus samples for the host's consensus state.
+func (cs ConsensusStateResp) PrometheusMetric() []prometheus.Metric {
+	return []prometheus.Metric{
+		{
+			Name: "hostd_consensus_state_network",
+			Labels: map[string]any{
+				"name": cs.Network.Name,
+			},
+			Value: 1,
+		},
+		{
+			Name: "hostd_consensus_state_height",
+			Labels: map[string]any{
+				"block_id": cs.Index.ID,
+			},
+			Value:     float64(cs.Index.Height),
+			Timestamp: cs.PrevTimestamps[0],
+		},
+	}
+}
+
 // PrometheusMetric returns Prometheus samples for the host settings.
 func (hs HostSettings) PrometheusMetric() []prometheus.Metric {
 	return []prometheus.Metric{

--- a/api/types.go
+++ b/api/types.go
@@ -184,6 +184,9 @@ type (
 	// PeerResp is the response body for the [GET] /syncer/address endpoint
 	PeerResp []Peer
 
+	// ConsensusIndexResp is the response body for the [GET] /consensus/tip and [GET] /index/tip endpoints
+	ConsensusIndexResp types.ChainIndex
+
 	// SyncerAddrResp is the response body for the [GET] /syncer/peers endpoint
 	SyncerAddrResp string
 

--- a/api/types.go
+++ b/api/types.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"time"
 
+	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/hostd/alerts"
@@ -186,6 +187,9 @@ type (
 
 	// ConsensusIndexResp is the response body for the [GET] /consensus/tip and [GET] /index/tip endpoints
 	ConsensusIndexResp types.ChainIndex
+
+	// ConsensusStateResp is the response body for the [GET] /consensus/state endpoint
+	ConsensusStateResp consensus.State
 
 	// SyncerAddrResp is the response body for the [GET] /syncer/peers endpoint
 	SyncerAddrResp string


### PR DESCRIPTION
Adds prometheus responses to `[GET] /consensus/tip` and `[GET] /index/tip`