### PR TITLE
Fix price pinning

### DIFF
--- a/.changeset/fixed_an_issue_with_price_pinning_not_updating_prices.md
+++ b/.changeset/fixed_an_issue_with_price_pinning_not_updating_prices.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed an issue with price pinning not updating prices

--- a/cmd/hostd/run.go
+++ b/cmd/hostd/run.go
@@ -421,6 +421,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 		if err != nil {
 			return fmt.Errorf("failed to create pin manager: %w", err)
 		}
+		defer pm.Close()
 
 		apiOpts = append(apiOpts, api.WithPinnedSettings(pm), api.WithExplorer(ex))
 	}

--- a/host/settings/pin/pin_test.go
+++ b/host/settings/pin/pin_test.go
@@ -131,6 +131,7 @@ func TestPinnedFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer pm.Close()
 
 	initialSettings := sm.Settings()
 	pin := pin.PinnedSettings{

--- a/host/settings/pin/pin_test.go
+++ b/host/settings/pin/pin_test.go
@@ -230,19 +230,7 @@ func TestAutomaticUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		if err := pm.Run(ctx); err != nil {
-			if errors.Is(err, context.Canceled) {
-				return
-			}
-			panic(err)
-		}
-	}()
+	defer pm.Close()
 
 	time.Sleep(time.Second)
 


### PR DESCRIPTION
In the v2 beta, the price pinning loop was not being started correctly. This refactors the manager so it is implicitly started when the Pinner is initialized.