### PR TITLE
Set default registry entries to 0

### DIFF
--- a/.changeset/the_default_number_of_registry_entries_is_now_0_the_registry_is_deprecated_and_will_not_be_supported_after_the_v2_hardfork.md
+++ b/.changeset/the_default_number_of_registry_entries_is_now_0_the_registry_is_deprecated_and_will_not_be_supported_after_the_v2_hardfork.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# The default number of registry entries is now 0. The registry is deprecated and will not be supported after the V2 hardfork.

--- a/host/settings/settings.go
+++ b/host/settings/settings.go
@@ -194,7 +194,7 @@ var (
 		MaxAccountBalance: types.Siacoins(10),  // 10SC
 		WindowSize:        144,                 // 144 blocks
 
-		MaxRegistryEntries: 100000,
+		MaxRegistryEntries: 0,
 	}
 	// ErrNoSettings must be returned by the store if the host has no settings yet
 	ErrNoSettings = errors.New("no settings found")


### PR DESCRIPTION
The RHP3 registry will not be supported in RHP4 and should be considered deprecated. This sets the default number of registry entries to 0 for new hosts. The registry will be removed at the same time as RHP2 and RHP3. 

Fixes #451 