### PR TITLE
Increase default rejection buffer to 18 blocks

### DIFF
--- a/host/contracts/manager.go
+++ b/host/contracts/manager.go
@@ -385,6 +385,9 @@ func NewManager(store ContractStore, storage StorageManager, chain ChainManager,
 		syncer:  syncer,
 		wallet:  wallet,
 
+		rejectBuffer:             18,
+		revisionSubmissionBuffer: 144,
+
 		alerts: alerts.NewNop(),
 		tg:     threadgroup.New(),
 		log:    zap.NewNop(),

--- a/host/contracts/manager_test.go
+++ b/host/contracts/manager_test.go
@@ -286,8 +286,15 @@ func TestContractLifecycle(t *testing.T) {
 		assertContractStatus(t, node.Contracts, rev.Revision.ParentID, contracts.ContractStatusPending)
 		assertContractMetrics(t, node.Store, 0, 0, types.ZeroCurrency, types.ZeroCurrency)
 
-		// mine until the contract is rejected
-		testutil.MineAndSync(t, node, types.VoidAddress, 20)
+		for i := 0; i < 10; i++ {
+			// mine until the contract is rejected
+			testutil.MineAndSync(t, node, types.VoidAddress, 1)
+			assertContractStatus(t, node.Contracts, rev.Revision.ParentID, contracts.ContractStatusPending)
+			assertContractMetrics(t, node.Store, 0, 0, types.ZeroCurrency, types.ZeroCurrency)
+		}
+
+		// contract should now be rejected
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
 		assertContractStatus(t, node.Contracts, rev.Revision.ParentID, contracts.ContractStatusRejected)
 		assertContractMetrics(t, node.Store, 0, 0, types.ZeroCurrency, types.ZeroCurrency)
 	})

--- a/host/contracts/update.go
+++ b/host/contracts/update.go
@@ -194,8 +194,17 @@ func (cm *Manager) ProcessActions(index types.ChainIndex) error {
 			log.Error("failed to add formation transaction to pool", zap.Error(err))
 			continue
 		}
+		if len(formationSet) == 0 {
+			log.Debug("formation set does not contain any transactions")
+			continue
+		}
+		formationTxn := formationSet[len(formationSet)-1]
+		if len(formationTxn.FileContracts) == 0 {
+			log.Debug("formation set does not contain file contract")
+			continue
+		}
 		cm.syncer.BroadcastTransactionSet(formationSet)
-		log.Debug("rebroadcast formation transaction", zap.String("transactionID", formationSet[len(formationSet)-1].ID().String()))
+		log.Debug("rebroadcast formation transaction", zap.Stringer("contractID", formationTxn.FileContractID(0)), zap.String("transactionID", formationSet[len(formationSet)-1].ID().String()))
 	}
 
 	for _, revision := range actions.BroadcastRevision {
@@ -572,10 +581,10 @@ func (cm *Manager) UpdateChainState(tx UpdateStateTx, reverted []chain.RevertUpd
 			}
 
 			if len(rejectedV1) > 0 {
-				log.Debug("rejected contracts", zap.Int("count", len(rejectedV1)))
+				log.Debug("rejected contracts", zap.Int("count", len(rejectedV1)), zap.Stringers("contracts", rejectedV1))
 			}
 			if len(rejectedV2) > 0 {
-				log.Debug("rejected v2 contracts", zap.Int("count", len(rejectedV2)))
+				log.Debug("rejected v2 contracts", zap.Int("count", len(rejectedV2)), zap.Stringers("contracts", rejectedV2))
 			}
 		}
 


### PR DESCRIPTION
In the current v2 beta, the rejection buffer is unset meaning if the contract is not confirmed in a single block it will be marked as rejected and not retried. This sets the default rejection buffer back to 18 blocks.