### PR TITLE
Fix startup error when directory is empty

### DIFF
--- a/cmd/hostd/main.go
+++ b/cmd/hostd/main.go
@@ -403,9 +403,11 @@ func main() {
 			setSeedPhrase()
 		}
 
-		// create the data directory if it does not already exist
-		if err := os.MkdirAll(cfg.Directory, 0700); err != nil {
-			checkFatalError("failed to create config directory", err)
+		if cfg.Directory != "" {
+			// create the data directory if it does not already exist
+			if err := os.MkdirAll(cfg.Directory, 0700); err != nil {
+				checkFatalError("failed to create data directory", err)
+			}
 		}
 
 		// configure the logger


### PR DESCRIPTION
Fixes an error starting up when the data directory is unset and an existing database exists in the current directory.