### PR TITLE
Fix panic updating metrics when reverting contract formations

### DIFF
--- a/.changeset/fixed_a_panic_updating_metrics_when_a_contract_formation_is_reverted.md
+++ b/.changeset/fixed_a_panic_updating_metrics_when_a_contract_formation_is_reverted.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed a panic updating metrics when a contract formation is reverted

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -859,8 +859,10 @@ func updateStatusMetrics(oldStatus, newStatus contracts.ContractStatus, fn func(
 		}
 	}
 
-	if err := fn(contractStatusMetric(newStatus), 1, time.Now()); err != nil {
-		return fmt.Errorf("failed to update metric %q: %w", contractStatusMetric(newStatus), err)
+	if newStatus != contracts.ContractStatusPending {
+		if err := fn(contractStatusMetric(newStatus), 1, time.Now()); err != nil {
+			return fmt.Errorf("failed to update metric %q: %w", contractStatusMetric(newStatus), err)
+		}
 	}
 	return nil
 }
@@ -895,8 +897,10 @@ func updateV2StatusMetrics(oldStatus, newStatus contracts.V2ContractStatus, fn f
 		}
 	}
 
-	if err := fn(v2ContractStatusMetric(newStatus), 1, time.Now()); err != nil {
-		return fmt.Errorf("failed to update metric %q: %w", v2ContractStatusMetric(newStatus), err)
+	if newStatus != contracts.V2ContractStatusPending {
+		if err := fn(v2ContractStatusMetric(newStatus), 1, time.Now()); err != nil {
+			return fmt.Errorf("failed to update metric %q: %w", v2ContractStatusMetric(newStatus), err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
In v2, we removed pending contracts from the contract metrics. There was a single spot where this was not taken into account, when an active contract is reverted back to pending after a reorg. Difficult to detect since the exact situation would require a reorg to occur at the same height as a formation. Added an additional lifecycle test to test reorgs and ensure all of the metrics revert cleanly.

```
panic: unexpected contract status: pending
goroutine 225 [running]:
go.sia.tech/hostd/persist/sqlite.contractStatusMetric(0x96?)
       go.sia.tech/hostd/persist/sqlite/consensus.go:845 +0xbf
go.sia.tech/hostd/persist/sqlite.updateStatusMetrics(0x2?, 0x0, 0xc004f26c00)
       go.sia.tech/hostd/persist/sqlite/consensus.go:862 +0x98
go.sia.tech/hostd/persist/sqlite.revertContractFormation(0xc002800260, {0xc004a60b60, 0x1, 0xc00481a9c8?})
       go.sia.tech/hostd/persist/sqlite/consensus.go:1208 +0x5d2
go.sia.tech/hostd/persist/sqlite.(*updateTx).RevertContracts(_, {0x7b2f8, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...}}, ...)
       go.sia.tech/hostd/persist/sqlite/consensus.go:356 +0x3a
go.sia.tech/hostd/host/contracts.(*Manager).UpdateChainState(0xc0014a21e0, {0x7006ceba4258, 0xc002800270}, {0xc001441908, 0x1, 0xf11b69?}, {0xc004b6a008, 0x4, 0x7006ceb6bc18?})
       go.sia.tech/hostd/host/contracts/update.go:548 +0x37e
go.sia.tech/hostd/index.(*Manager).syncDB.func1({0x186a6f0, 0xc002800270})
       go.sia.tech/hostd/index/update.go:57 +0x165
go.sia.tech/hostd/persist/sqlite.(*Store).UpdateChainState.func1(0xc002800260)
       go.sia.tech/hostd/persist/sqlite/consensus.go:564 +0x5c
go.sia.tech/hostd/persist/sqlite.doTransaction(0xc00049d080?, 0xc00049d100, 0xc00481e8f0)
       go.sia.tech/hostd/persist/sqlite/store.go:115 +0x17f
go.sia.tech/hostd/persist/sqlite.(*Store).transaction(0xc00049e0d0, 0xc00481e8f0)
       go.sia.tech/hostd/persist/sqlite/store.go:49 +0x3ec
go.sia.tech/hostd/persist/sqlite.(*Store).UpdateChainState(0x7b2fb?, 0x0?)
       go.sia.tech/hostd/persist/sqlite/consensus.go:563 +0x29
go.sia.tech/hostd/index.(*Manager).syncDB(0xc0004ce140, {0x18640b0, 0xc000002190})
       go.sia.tech/hostd/index/update.go:54 +0x362
go.sia.tech/hostd/index.NewManager.func2()
       go.sia.tech/hostd/index/manager.go:153 +0x248
created by go.sia.tech/hostd/index.NewManager in goroutine 1
       go.sia.tech/hostd/index/manager.go:138 +0x4d9
```