### PR TITLE
Switch Docker base from scratch to debian:slim

### DIFF
--- a/.changeset/switch_docker_base_image_from_scratch_to_debianbookworm_slim.md
+++ b/.changeset/switch_docker_base_image_from_scratch_to_debianbookworm_slim.md
@@ -1,0 +1,5 @@
+---
+default: major
+---
+
+# Switched Docker base image from scratch to debian:bookworm-slim

--- a/cmd/hostd/run.go
+++ b/cmd/hostd/run.go
@@ -50,9 +50,9 @@ func defaultDataDirectory(fp string) string {
 
 	// check for databases in the current directory
 	if _, err := os.Stat("hostd.db"); err == nil {
-		return ""
+		return "."
 	} else if _, err := os.Stat("hostd.sqlite3"); err == nil {
-		return ""
+		return "."
 	}
 
 	// default to the operating system's application directory
@@ -64,7 +64,7 @@ func defaultDataDirectory(fp string) string {
 	case "linux", "freebsd", "openbsd":
 		return filepath.Join(string(filepath.Separator), "var", "lib", "hostd")
 	default:
-		return ""
+		return "."
 	}
 }
 


### PR DESCRIPTION
`hostd` images built on the current version of Docker with the `scratch` base layer are different from the current stable image. This switches the base image from `scratch` to `debian:bookworm-slim` in hopes that SQLite behaves better. The alternative is setting the `SQLITE_TEMPDIR` environment variable in the image, but there are other inconsistencies caused by using `scratch`.