### PR TITLE
Fix sector upload regression

### DIFF
--- a/.changeset/fixed_a_major_speed_regression_when_uploading_data_on_larger_nodes.md
+++ b/.changeset/fixed_a_major_speed_regression_when_uploading_data_on_larger_nodes.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed a major speed regression when uploading data on larger nodes

--- a/persist/sqlite/volumes.go
+++ b/persist/sqlite/volumes.go
@@ -509,7 +509,7 @@ WHERE v.sector_id=$1`
 // space available, ErrNotEnoughStorage is returned.
 func emptyLocation(tx *txn) (loc storage.SectorLocation, err error) {
 	const query = `SELECT vs.id, vs.volume_id, vs.volume_index
-	FROM volume_sectors vs
+	FROM volume_sectors vs INDEXED BY volume_sectors_sector_writes_volume_id_sector_id_volume_index_compound
 	INNER JOIN storage_volumes sv ON (sv.id=vs.volume_id)
 	WHERE vs.sector_id IS NULL AND sv.available=true AND sv.read_only=false
 	ORDER BY vs.sector_writes ASC
@@ -529,7 +529,7 @@ func emptyLocation(tx *txn) (loc storage.SectorLocation, err error) {
 // space available, ErrNotEnoughStorage is returned.
 func emptyLocationForMigration(tx *txn, volumeID int64, maxIndex uint64) (loc storage.SectorLocation, err error) {
 	const query = `SELECT vs.id, vs.volume_id, vs.volume_index
-	FROM volume_sectors vs
+	FROM volume_sectors vs INDEXED BY volume_sectors_sector_writes_volume_id_sector_id_volume_index_compound
 	INNER JOIN storage_volumes sv ON (sv.id=vs.volume_id)
 	WHERE vs.sector_id IS NULL AND sv.available=true AND (vs.volume_id <> $1 AND sv.read_only=false OR (vs.volume_id=$1 AND vs.volume_index < $2))
 	ORDER BY vs.sector_writes ASC

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -875,6 +875,16 @@ func BenchmarkVolumeMigrate(b *testing.B) {
 }
 
 func BenchmarkStoreSector(b *testing.B) {
+	const (
+		sectorsPerTiB uint64 = (1 << 40) / (1 << 22)
+		minSectors           = 20 * sectorsPerTiB
+	)
+
+	sectors := minSectors
+	if sectors < uint64(b.N) {
+		sectors = uint64(b.N)
+	}
+
 	log := zaptest.NewLogger(b)
 	db, err := OpenDatabase(filepath.Join(b.TempDir(), "test.db"), log)
 	if err != nil {
@@ -882,7 +892,7 @@ func BenchmarkStoreSector(b *testing.B) {
 	}
 	defer db.Close()
 
-	_, err = addTestVolume(db, "test", uint64(b.N*2))
+	_, err = addTestVolume(db, "test", sectors)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -900,6 +910,16 @@ func BenchmarkStoreSector(b *testing.B) {
 }
 
 func BenchmarkReadSector(b *testing.B) {
+	const (
+		sectorsPerTiB uint64 = (1 << 40) / (1 << 22)
+		minSectors           = 20 * sectorsPerTiB
+	)
+
+	sectors := minSectors
+	if sectors < uint64(b.N) {
+		sectors = uint64(b.N)
+	}
+
 	log := zaptest.NewLogger(b)
 	db, err := OpenDatabase(filepath.Join(b.TempDir(), "test.db"), log)
 	if err != nil {
@@ -907,7 +927,7 @@ func BenchmarkReadSector(b *testing.B) {
 	}
 	defer db.Close()
 
-	_, err = addTestVolume(db, "test", uint64(b.N*2))
+	_, err = addTestVolume(db, "test", sectors)
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
Fixes a major performance regression in v2.0.0 when uploading new sectors on decently sized nodes and adjusts the benchmarks to create a volume with at least 10TB to better emulate production nodes.

Version  | Read Sector | Write Sector
--|--|--
v1.1.2 | 0.03ms | 0.15ms
v2.0.0-beta.5 | 0.024 ms | 386 ms
nate/fix-upload-regression | 0.024ms | 0.12ms