### PR TITLE
Correctly migrate log directory

### DIFF
--- a/.changeset/fix_issue_when_migrating_log_directory_from_v112_config_file.md
+++ b/.changeset/fix_issue_when_migrating_log_directory_from_v112_config_file.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Fixed an inconsistency migrating the config's log directory from the v1.1.2 config file
+
+The deprecated `Log.Path` config field was a directory, while the new `Log.File.Path` is expected to be a file path. If the log directory was set, the log file path will be correctly migrated to `hostd.log` in the directory.

--- a/config/compat.go
+++ b/config/compat.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -146,8 +147,8 @@ func updateConfigV112(fp string, r io.Reader, cfg *Config) error {
 	cfg.Log.Level = old.Log.Level
 	if old.Log.File.Path != "" {
 		cfg.Log.File.Path = old.Log.File.Path
-	} else {
-		cfg.Log.File.Path = old.Log.Path
+	} else if old.Log.Path != "" {
+		cfg.Log.File.Path = filepath.Join(old.Log.Path, "hostd.log")
 	}
 	cfg.Log.StdOut.Level = old.Log.StdOut.Level
 	cfg.Log.StdOut.Enabled = old.Log.StdOut.Enabled


### PR DESCRIPTION
The deprecated `Log.Path` config field was a directory while the new `Log.File.Path` is expected to be a file path. Fixes config migration so if the log directory was set, the log file path will be correctly migrated to `hostd.log` in the directory.

i.e. 
```yml
log:
  path: /var/log
```

should become

```yml
log:
  file:
    path: /var/log/hostd.log
```

Fixes #577 
