### PR TITLE
Increase volume concurrency

### DIFF
--- a/.changeset/fixed_a_concurrency_issue_when_migrating_data_from_large_volumes.md
+++ b/.changeset/fixed_a_concurrency_issue_when_migrating_data_from_large_volumes.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed a concurrency issue when migrating data from large volumes

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -520,7 +520,7 @@ func (s *Store) ExpireContractSectors(height uint64) error {
 			return nil
 		}
 		log.Debug("removed sectors", zap.Int("expired", expired), zap.Int("batch", i))
-		jitterSleep(time.Millisecond) // allow other transactions to run
+		jitterSleep(50 * time.Millisecond) // allow other transactions to run
 	}
 }
 
@@ -537,7 +537,7 @@ func (s *Store) ExpireV2ContractSectors(height uint64) error {
 			return nil
 		}
 		log.Debug("removed sectors", zap.Int("expired", expired), zap.Int("batch", i))
-		jitterSleep(time.Millisecond) // allow other transactions to run
+		jitterSleep(50 * time.Millisecond) // allow other transactions to run
 	}
 }
 

--- a/persist/sqlite/sectors.go
+++ b/persist/sqlite/sectors.go
@@ -157,7 +157,7 @@ func (s *Store) ExpireTempSectors(height uint64) error {
 			return nil
 		}
 		log.Debug("expired temp sectors", zap.Int("expired", expired), zap.Stringers("removed", removed), zap.Int("batch", i))
-		jitterSleep(time.Millisecond) // allow other transactions to run
+		jitterSleep(50 * time.Millisecond) // allow other transactions to run
 	}
 }
 

--- a/persist/sqlite/volumes.go
+++ b/persist/sqlite/volumes.go
@@ -300,15 +300,13 @@ LIMIT 1;`
 			return nil
 		})
 		if err != nil {
-			err = fmt.Errorf("failed to migrated sector: %w", err)
+			err = fmt.Errorf("failed to migrate sector: %w", err)
 			return
 		} else if done {
 			return
 		}
-
-		if index%256 == 0 {
-			jitterSleep(time.Millisecond) // allow other transactions to run
-		}
+		// allow other transactions to run
+		jitterSleep(50 * time.Millisecond) // maximum of 48000 sectors per hour
 	}
 }
 
@@ -338,7 +336,7 @@ func (s *Store) RemoveVolume(id int64, force bool) error {
 		} else if removed == 0 {
 			break
 		}
-		jitterSleep(time.Millisecond)
+		jitterSleep(50 * time.Millisecond)
 	}
 
 	return s.transaction(func(tx *txn) error {


### PR DESCRIPTION
Increases the sleep time between batches when performing background volume actions. This improves concurrency and usability of the host during these background tasks at the cost of performance. Migrating data from sectors will take at least 5 hours per TiB. IO from slow disks will cause this to be longer since atomicity is very important in migration. This is more performant than explicitly setting an `EXCLUSIVE` transaction isolation for heavy write transactions. 