### PR TITLE
Fix unlock panic

### DIFF
--- a/.changeset/fix_a_potential_panic_when_rpclock_fails.md
+++ b/.changeset/fix_a_potential_panic_when_rpclock_fails.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix a potential panic when rpcLock fails

--- a/rhp/v2/rpc.go
+++ b/rhp/v2/rpc.go
@@ -88,7 +88,6 @@ func (sh *SessionHandler) rpcLock(s *session, log *zap.Logger) (contracts.Usage,
 		return contracts.Usage{}, err
 	}
 
-	// set the contract
 	s.contract = contract
 	lockResp := &rhp2.RPCLockResponse{
 		Acquired:     true,
@@ -96,9 +95,9 @@ func (sh *SessionHandler) rpcLock(s *session, log *zap.Logger) (contracts.Usage,
 		Revision:     contract.Revision,
 		Signatures:   contract.Signatures(),
 	}
-	// avoid holding lock during network round trip
 	if err := s.writeResponse(lockResp, 30*time.Second); err != nil {
 		sh.contracts.Unlock(contract.Revision.ParentID)
+		s.contract = contracts.SignedRevision{}
 		return contracts.Usage{}, fmt.Errorf("failed to write lock response: %w", err)
 	}
 	return contracts.Usage{}, nil


### PR DESCRIPTION
Fixes a potential panic when the RHP2 connection closes after rpcLock has failed. The contract is still set even if the lock is released. 

Only a partial error log was given
```
goroutine 991452 [running]:
go.sia.tech/hostd/host/contracts.(*locker).Unlock(0xc000045d30, {0xcb, 0x43, 0xe5, 0xce, 0x16, 0xa3, 0x59, 0x5a, 0x76, ...})
        go.sia.tech/hostd/host/contracts/lock.go:38 +0xed
go.sia.tech/hostd/host/contracts.(*Manager).Unlock(0xc008604650?, {0xcb, 0x43, 0xe5, 0xce, 0x16, 0xa3, 0x59, 0x5a, 0x76, ...})
        go.sia.tech/hostd/host/contracts/lock.go:109 +0x2d
go.sia.tech/hostd/rhp/v2.(*SessionHandler).upgrade.func1()
        go.sia.tech/hostd/rhp/v2/rhp.go:170 +0x89
go.sia.tech/hostd/rhp/v2.(*SessionHandler).upgrade(0xc0072e90e0, {0x186bff0, 0xc005441c20})
        go.sia.tech/hostd/rhp/v2/rhp.go:178 +0x3f6
go.sia.tech/hostd/rhp/v2.(*SessionHandler).Serve.func1()
        go.sia.tech/hostd/rhp/v2/rhp.go:200 +0x88
created by go.sia.tech/hostd/rhp/v2.(*SessionHandler).Serve in goroutine 3564
        go.sia.tech/hostd/rhp/v2/rhp.go:198 +0x26
```