### PR TITLE
Add V2 sector roots to cache

### DIFF
--- a/.changeset/fixed_an_issue_with_v2_contract_sector_roots_not_being_reloaded.md
+++ b/.changeset/fixed_an_issue_with_v2_contract_sector_roots_not_being_reloaded.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed an issue with v2 contract sector roots not being reloaded

--- a/host/contracts/integrity.go
+++ b/host/contracts/integrity.go
@@ -147,3 +147,92 @@ func (cm *Manager) CheckIntegrity(ctx context.Context, contractID types.FileCont
 	}()
 	return results, uint64(len(roots)), nil
 }
+
+// V2CheckIntegrity checks the integrity of a contract's sector roots on disk. The
+// result of every checked sector is sent on the returned channel. The channel is closed
+// when all checks are complete.
+func (cm *Manager) V2CheckIntegrity(ctx context.Context, contractID types.FileContractID) (<-chan IntegrityResult, uint64, error) {
+	// lock the contract to ensure it doesn't get modified before the sector
+	// roots are retrieved.
+	contract, unlock, err := cm.LockV2Contract(contractID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to lock contract: %w", err)
+	}
+	defer unlock()
+
+	expectedRoots := contract.Revision.Filesize / rhp2.SectorSize
+
+	roots := cm.getSectorRoots(contractID)
+	if uint64(len(roots)) != expectedRoots {
+		return nil, 0, fmt.Errorf("expected %v sector roots, got %v", expectedRoots, len(roots))
+	} else if calculated := rhp2.MetaRoot(roots); contract.Revision.FileMerkleRoot != calculated {
+		return nil, 0, fmt.Errorf("expected Merkle root %v, got %v", contract.Revision.FileMerkleRoot, calculated)
+	}
+
+	// register an alert to track progress
+	alert := alerts.Alert{
+		ID:       frand.Entropy256(),
+		Severity: alerts.SeverityInfo,
+		Message:  "Checking v2 contract integrity",
+		Data: map[string]any{
+			"contractID": contractID,
+			"checked":    0,
+			"missing":    0,
+			"corrupt":    0,
+			"total":      len(roots),
+		},
+		Timestamp: time.Now(),
+	}
+	cm.alerts.Register(alert)
+
+	results := make(chan IntegrityResult, 1)
+	// start a goroutine to check each sector
+	go func() {
+		defer close(results)
+
+		ctx, done, err := cm.tg.AddContext(ctx)
+		if err != nil {
+			return
+		}
+		defer done()
+
+		var missing, corrupt int
+		log := cm.log.Named("integrityCheck").With(zap.String("contractID", contractID.String()))
+		for i, root := range roots {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			// read each sector from disk and verify its Merkle root
+			sector, err := cm.storage.ReadSector(root)
+			if err != nil { // sector read failed
+				log.Error("missing sector", zap.String("root", root.String()), zap.Error(err))
+				missing++
+				results <- IntegrityResult{ExpectedRoot: root, Error: err}
+			} else if calculated := rhp2.SectorRoot(sector); root != calculated { // sector data corrupt
+				log.Error("corrupt sector", zap.String("root", root.String()), zap.String("actual", calculated.String()))
+				corrupt++
+				results <- IntegrityResult{ExpectedRoot: root, ActualRoot: calculated, Error: errors.New("sector data corrupt")}
+			} else { // sector is valid
+				results <- IntegrityResult{ExpectedRoot: root, ActualRoot: calculated}
+			}
+
+			// update alert
+			alert.Data["checked"] = i + 1
+			alert.Data["missing"] = missing
+			alert.Data["corrupt"] = corrupt
+			cm.alerts.Register(alert)
+			time.Sleep(time.Millisecond) // sleep to allow other transactions to proceed
+		}
+
+		log.Info("integrity check complete", zap.Int("missing", missing), zap.Int("corrupt", corrupt))
+		// update the alert with the final results
+		alert.Message = "Integrity check complete"
+		if corrupt > 0 || missing > 0 {
+			alert.Severity = alerts.SeverityError
+		}
+		cm.alerts.Register(alert)
+	}()
+	return results, uint64(len(roots)), nil
+}

--- a/host/contracts/manager.go
+++ b/host/contracts/manager.go
@@ -119,6 +119,8 @@ func (cm *Manager) V2Contract(id types.FileContractID) (V2Contract, error) {
 	return cm.store.V2Contract(id)
 }
 
+// V2Contracts returns a paginated list of v2 contracts matching the filter and
+// the total number of contracts matching the filter.
 func (cm *Manager) V2Contracts(filter V2ContractFilter) ([]V2Contract, int, error) {
 	return cm.store.V2Contracts(filter)
 }

--- a/host/contracts/manager.go
+++ b/host/contracts/manager.go
@@ -119,6 +119,10 @@ func (cm *Manager) V2Contract(id types.FileContractID) (V2Contract, error) {
 	return cm.store.V2Contract(id)
 }
 
+func (cm *Manager) V2Contracts(filter V2ContractFilter) ([]V2Contract, int, error) {
+	return cm.store.V2Contracts(filter)
+}
+
 // V2FileContractElement returns the chain index and file contract element for the
 // given contract ID.
 func (cm *Manager) V2FileContractElement(id types.FileContractID) (types.ChainIndex, types.V2FileContractElement, error) {
@@ -404,6 +408,16 @@ func NewManager(store ContractStore, storage StorageManager, chain ChainManager,
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sector roots: %w", err)
 	}
+
+	v2Roots, err := store.V2SectorRoots()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get v2 sector roots: %w", err)
+	}
+
+	for id, contractRoots := range v2Roots {
+		roots[id] = contractRoots
+	}
+
 	cm.sectorRoots = roots
 	cm.log.Debug("loaded sector roots", zap.Duration("elapsed", time.Since(start)))
 	return cm, nil

--- a/host/contracts/persist.go
+++ b/host/contracts/persist.go
@@ -16,9 +16,10 @@ type (
 		// ContractChainIndexElement returns the chain index element for the given height.
 		ContractChainIndexElement(types.ChainIndex) (types.ChainIndexElement, error)
 
-		// SectorRoots returns the sector roots for a contract. If limit is 0, all roots
-		// are returned.
+		// SectorRoots returns the sector roots for all contracts.
 		SectorRoots() (map[types.FileContractID][]types.Hash256, error)
+		// V2SectorRoots returns the sector roots for all v2 contracts.
+		V2SectorRoots() (map[types.FileContractID][]types.Hash256, error)
 
 		// Contracts returns a paginated list of contracts sorted by expiration
 		// asc.
@@ -43,6 +44,8 @@ type (
 		V2ContractElement(types.FileContractID) (types.ChainIndex, types.V2FileContractElement, error)
 		// V2Contract returns the v2 contract with the given ID.
 		V2Contract(types.FileContractID) (V2Contract, error)
+		V2Contracts(V2ContractFilter) ([]V2Contract, int, error)
+
 		// AddV2Contract stores the provided contract, should error if the contract
 		// already exists in the store.
 		AddV2Contract(V2Contract, rhp4.TransactionSet) error


### PR DESCRIPTION
This fixes an issue where V2 sector roots were not being properly loaded into the cache at startup and adds the integrity check method for v2 contracts.