### PR TITLE
Add v2 contracts endpoints

### DIFF
--- a/.changeset/add_endpoints_for_querying_v2_contracts.md
+++ b/.changeset/add_endpoints_for_querying_v2_contracts.md
@@ -1,0 +1,35 @@
+---
+default: minor
+---
+
+# Add endpoints for querying V2 contracts
+
+Adds two new endpoints for querying V2 contracts
+
+### `[GET] /v2/contracts/:id`
+
+Returns a single V2 contract by its ID
+
+### `[POST] /v2/contracts`
+
+Queries a list of contracts with optional filtering
+
+**Example request  body**
+```json
+{
+  "statuses": [],
+  "contractIDs": [],
+  "renewedFrom": [],
+  "renewedTo": [],
+  "renterKey": [],
+  "minNegotiationHeight": 0,
+  "maxNegotiationHeight": 0,
+  "minExpirationHeight": 0,
+  "maxExpirationHeight": 0,
+  "limit": 0,
+  "offset": 0,
+  "sortField": "",
+  "sortDesc": false
+}
+```
+

--- a/api/api.go
+++ b/api/api.go
@@ -96,6 +96,9 @@ type (
 		Contracts(filter contracts.ContractFilter) ([]contracts.Contract, int, error)
 		Contract(id types.FileContractID) (contracts.Contract, error)
 
+		V2Contracts(filter contracts.V2ContractFilter) ([]contracts.V2Contract, int, error)
+		V2Contract(id types.FileContractID) (contracts.V2Contract, error)
+
 		// CheckIntegrity checks the integrity of a contract's sector roots on
 		// disk. The result of each sector checked is sent on the returned
 		// channel. Read errors are logged.
@@ -297,5 +300,9 @@ func NewServer(name string, hostKey types.PublicKey, cm ChainManager, s Syncer, 
 		"PUT /webhooks/:id":       a.handlePUTWebhooks,
 		"POST /webhooks/:id/test": a.handlePOSTWebhooksTest,
 		"DELETE /webhooks/:id":    a.handleDELETEWebhooks,
+
+		// v2 contracts
+		"POST /v2/contracts":    a.handlePOSTV2Contracts,
+		"GET /v2/contracts/:id": a.handleGETV2Contract,
 	})
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -6,12 +6,74 @@ import (
 	"testing"
 	"time"
 
+	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/chain"
+	rhp4 "go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/coreutils/syncer"
+	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/hostd/api"
+	"go.sia.tech/hostd/host/contracts"
 	"go.sia.tech/hostd/internal/testutil"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
 )
+
+func formV2Contract(t *testing.T, cm *chain.Manager, c *contracts.Manager, w *wallet.SingleAddressWallet, s *syncer.Syncer, renterKey, hostKey types.PrivateKey, renterFunds, hostFunds types.Currency, duration uint64, broadcast bool) (types.FileContractID, types.V2FileContract) {
+	t.Helper()
+
+	cs := cm.TipState()
+	fc := types.V2FileContract{
+		RevisionNumber:   0,
+		Filesize:         0,
+		Capacity:         0,
+		FileMerkleRoot:   types.Hash256{},
+		ProofHeight:      cs.Index.Height + duration,
+		ExpirationHeight: cs.Index.Height + duration + 10,
+		RenterOutput: types.SiacoinOutput{
+			Value:   renterFunds,
+			Address: w.Address(),
+		},
+		HostOutput: types.SiacoinOutput{
+			Value:   hostFunds,
+			Address: w.Address(),
+		},
+		MissedHostValue: hostFunds,
+		TotalCollateral: hostFunds,
+		RenterPublicKey: renterKey.PublicKey(),
+		HostPublicKey:   hostKey.PublicKey(),
+	}
+	fundAmount := cs.V2FileContractTax(fc).Add(hostFunds).Add(renterFunds)
+	sigHash := cs.ContractSigHash(fc)
+	fc.HostSignature = hostKey.SignHash(sigHash)
+	fc.RenterSignature = renterKey.SignHash(sigHash)
+
+	txn := types.V2Transaction{
+		FileContracts: []types.V2FileContract{fc},
+	}
+
+	basis, toSign, err := w.FundV2Transaction(&txn, fundAmount, false)
+	if err != nil {
+		t.Fatal("failed to fund transaction:", err)
+	}
+	w.SignV2Inputs(&txn, toSign)
+	formationSet := rhp4.TransactionSet{
+		Transactions: []types.V2Transaction{txn},
+		Basis:        basis,
+	}
+
+	if broadcast {
+		if _, err := cm.AddV2PoolTransactions(formationSet.Basis, formationSet.Transactions); err != nil {
+			t.Fatal("failed to add formation set to pool:", err)
+		}
+		s.BroadcastV2TransactionSet(formationSet.Basis, formationSet.Transactions)
+	}
+
+	if err := c.AddV2Contract(formationSet, proto4.Usage{}); err != nil {
+		t.Fatal("failed to add contract:", err)
+	}
+	return txn.V2FileContractID(txn.ID(), 0), fc
+}
 
 func startAPI(t testing.TB, sk types.PrivateKey, host *testutil.HostNode, log *zap.Logger) *api.Client {
 	l, err := net.Listen("tcp", "localhost:0")
@@ -62,5 +124,70 @@ func TestConsensusEndpoints(t *testing.T) {
 		t.Fatal(err)
 	} else if it != tip {
 		t.Fatalf("expected index tip %v, got %v", tip, it)
+	}
+}
+
+func TestV2Contracts(t *testing.T) {
+	log := zap.NewNop()
+	n, genesis := testutil.V2Network()
+	hostKey := types.GeneratePrivateKey()
+	host := testutil.NewHostNode(t, hostKey, n, genesis, log)
+	client := startAPI(t, hostKey, host, log)
+
+	testutil.MineAndSync(t, host, host.Wallet.Address(), 10)
+
+	renterKey := types.GeneratePrivateKey()
+
+	// form a contract
+	contractID, revision := formV2Contract(t, host.Chain, host.Contracts, host.Wallet, host.Syncer, renterKey, hostKey, types.Siacoins(500), types.Siacoins(1000), 10, true)
+
+	assertContract := func(t *testing.T, status contracts.V2ContractStatus) {
+		t.Helper()
+
+		c, err := client.V2Contract(contractID)
+		if err != nil {
+			t.Fatal(err)
+		} else if c.V2FileContract != revision {
+			t.Fatalf("expected contract %v, got %v", revision, c.V2FileContract)
+		} else if c.Status != status {
+			t.Fatalf("expected status %v, got %v", status, c.Status)
+		}
+	}
+
+	assertContract(t, contracts.V2ContractStatusPending)
+	testutil.MineAndSync(t, host, types.VoidAddress, 1)
+	assertContract(t, contracts.V2ContractStatusActive)
+
+	resp, count, err := client.V2Contracts(contracts.V2ContractFilter{})
+	if err != nil {
+		t.Fatal(err)
+	} else if count != 1 {
+		t.Fatalf("expected 1 contract, got %v", count)
+	} else if resp[0].ID != contractID {
+		t.Fatalf("expected contract %v, got %v", contractID, resp[0].ID)
+	}
+
+	// use a filter that doesn't match any contracts
+	resp, count, err = client.V2Contracts(contracts.V2ContractFilter{
+		Statuses: []contracts.V2ContractStatus{contracts.V2ContractStatusRejected},
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if count != 0 {
+		t.Fatalf("expected 0 contracts, got %v", count)
+	} else if len(resp) != 0 {
+		t.Fatalf("expected 0 contracts, got %v", len(resp))
+	}
+
+	// use a filter that matches the contract
+	resp, count, err = client.V2Contracts(contracts.V2ContractFilter{
+		Statuses: []contracts.V2ContractStatus{contracts.V2ContractStatusActive},
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if count != 1 {
+		t.Fatalf("expected 1 contract, got %v", count)
+	} else if resp[0].ID != contractID {
+		t.Fatalf("expected contract %v, got %v", contractID, resp[0].ID)
 	}
 }

--- a/api/client.go
+++ b/api/client.go
@@ -146,6 +146,19 @@ func (c *Client) Contract(id types.FileContractID) (contract contracts.Contract,
 	return
 }
 
+// V2Contracts returns the v2 contracts of the host matching the filter.
+func (c *Client) V2Contracts(filter contracts.V2ContractFilter) ([]contracts.V2Contract, int, error) {
+	var resp V2ContractsResponse
+	err := c.c.POST("/v2/contracts", filter, &resp)
+	return resp.Contracts, resp.Count, err
+}
+
+// V2Contract returns the v2 contract with the specified ID.
+func (c *Client) V2Contract(id types.FileContractID) (contract contracts.V2Contract, err error) {
+	err = c.c.GET("/v2/contracts/"+id.String(), &contract)
+	return
+}
+
 // StartIntegrityCheck scans the volume with the specified ID for consistency errors.
 func (c *Client) StartIntegrityCheck(id types.FileContractID) error {
 	return c.c.PUT(fmt.Sprintf("/contracts/%v/integrity", id), nil)

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -348,6 +348,41 @@ func (a *api) handleGETContract(jc jape.Context) {
 	jc.Encode(contract)
 }
 
+func (a *api) handlePOSTV2Contracts(jc jape.Context) {
+	var filter contracts.V2ContractFilter
+	if err := jc.Decode(&filter); err != nil {
+		return
+	}
+
+	if filter.Limit <= 0 || filter.Limit > 500 {
+		filter.Limit = 500
+	}
+
+	contracts, count, err := a.contracts.V2Contracts(filter)
+	if !a.checkServerError(jc, "failed to get contracts", err) {
+		return
+	}
+	jc.Encode(V2ContractsResponse{
+		Contracts: contracts,
+		Count:     count,
+	})
+}
+
+func (a *api) handleGETV2Contract(jc jape.Context) {
+	var id types.FileContractID
+	if err := jc.DecodeParam("id", &id); err != nil {
+		return
+	}
+	contract, err := a.contracts.V2Contract(id)
+	if errors.Is(err, contracts.ErrNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if !a.checkServerError(jc, "failed to get contract", err) {
+		return
+	}
+	jc.Encode(contract)
+}
+
 func (a *api) handleGETVolume(jc jape.Context) {
 	var id int64
 	if err := jc.DecodeParam("id", &id); err != nil {

--- a/api/types.go
+++ b/api/types.go
@@ -113,6 +113,12 @@ type (
 		Contracts []contracts.Contract `json:"contracts"`
 	}
 
+	// V2ContractsResponse is the response body for the [POST] /v2/contracts endpoint.
+	V2ContractsResponse struct {
+		Count     int                    `json:"count"`
+		Contracts []contracts.V2Contract `json:"contracts"`
+	}
+
 	// WalletResponse is the response body for the [GET] /wallet endpoint.
 	WalletResponse struct {
 		wallet.Balance

--- a/host/contracts/manager.go
+++ b/host/contracts/manager.go
@@ -114,15 +114,15 @@ func (cm *Manager) Contract(id types.FileContractID) (Contract, error) {
 	return cm.store.Contract(id)
 }
 
+// V2Contracts returns a paginated list of contracts matching the filter and the
+// total number of contracts matching the filter.
+func (cm *Manager) V2Contracts(filter V2ContractFilter) ([]V2Contract, int, error) {
+	return cm.store.V2Contracts(filter)
+}
+
 // V2Contract returns the v2 contract with the given ID.
 func (cm *Manager) V2Contract(id types.FileContractID) (V2Contract, error) {
 	return cm.store.V2Contract(id)
-}
-
-// V2Contracts returns a paginated list of v2 contracts matching the filter and
-// the total number of contracts matching the filter.
-func (cm *Manager) V2Contracts(filter V2ContractFilter) ([]V2Contract, int, error) {
-	return cm.store.V2Contracts(filter)
 }
 
 // V2FileContractElement returns the chain index and file contract element for the

--- a/host/contracts/persist.go
+++ b/host/contracts/persist.go
@@ -42,9 +42,11 @@ type (
 
 		// V2ContractElement returns the latest v2 state element with the given ID.
 		V2ContractElement(types.FileContractID) (types.ChainIndex, types.V2FileContractElement, error)
+		// V2Contracts returns a paginated list of v2 contracts sorted by expiration
+		// asc.
+		V2Contracts(V2ContractFilter) ([]V2Contract, int, error)
 		// V2Contract returns the v2 contract with the given ID.
 		V2Contract(types.FileContractID) (V2Contract, error)
-		V2Contracts(V2ContractFilter) ([]V2Contract, int, error)
 
 		// AddV2Contract stores the provided contract, should error if the contract
 		// already exists in the store.


### PR DESCRIPTION
Adds two new endpoints for querying V2 contracts

### `[GET] /v2/contracts/:id`

Returns a single V2 contract by its ID

### `[POST] /v2/contracts`

Queries a list of contracts with optional filtering

**Example request  body**
```json
{
  "statuses": [],
  "contractIDs": [],
  "renewedFrom": [],
  "renewedTo": [],
  "renterKey": [],
  "minNegotiationHeight": 0,
  "maxNegotiationHeight": 0,
  "minExpirationHeight": 0,
  "maxExpirationHeight": 0,
  "limit": 0,
  "offset": 0,
  "sortField": "",
  "sortDesc": false
}
```
