### PR TITLE
Combine sector update for pruning with fetching prunable sectors

### DIFF
--- a/.changeset/combine_update_and_select_query_when_pruning_sectors_to_force_usage_of_exclusive_database_transaction.md
+++ b/.changeset/combine_update_and_select_query_when_pruning_sectors_to_force_usage_of_exclusive_database_transaction.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Combine update and select query when pruning sectors to force usage of exclusive database transaction

--- a/persist/sqlite/sectors.go
+++ b/persist/sqlite/sectors.go
@@ -280,6 +280,7 @@ func (s *Store) PruneSectors(ctx context.Context, lastAccess time.Time) error {
 		} else if done {
 			return nil
 		}
+		jitterSleep(50 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
It seems like on busy databases, `UPDATE volume_sectors SET sector_id=null WHERE id=$1` fails to upgrade from a shared to an exclusive lock https://github.com/SiaFoundation/hostd/issues/616

To avoid that I'd like to propose combining the select and update into a single query. That way SQLite should be able to figure out that the transaction needs to be exclusive from the very beginning rather than trying to upgrade from a shared to an exclusive lock and failing to do so cause it ends up in a deadlock situation. This way I expect it to correctly make use of the `PENDING` state, block until it can acquire the lock and then do its thing without being starved by other goroutines.