### PR TITLE
Reduce migration time for mostly empty volumes

### DIFF
--- a/.changeset/reduced_migration_time_for_large_mostly_empty_volumes.md
+++ b/.changeset/reduced_migration_time_for_large_mostly_empty_volumes.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Reduced migration time for large mostly empty volumes


### PR DESCRIPTION
This PR fixes a regression with migration time for mostly empty volumes by skipping unused sectors instead of checking each one. This may reintroduce the race condition with unmigrated sectors -- should test thoroughly before release.