### PR TITLE
Prevent "database is locked"

### DIFF
--- a/.changeset/limit_the_number_of_parallel_sqlite_connections_to_1_to_prevent_database_is_locked_errors.md
+++ b/.changeset/limit_the_number_of_parallel_sqlite_connections_to_1_to_prevent_database_is_locked_errors.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Limit the number of parallel SQLite connections to 1 to prevent "database is locked" errors.

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -528,8 +528,8 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 	checkRootConsistency := func(t *testing.T, expected []types.Hash256) {
 		t.Helper()
 
-		err := db.transaction(func(*txn) error {
-			stmt, err := db.db.Prepare(`SELECT ss.sector_root FROM stored_sectors ss
+		err := db.transaction(func(tx *txn) error {
+			stmt, err := tx.Prepare(`SELECT ss.sector_root FROM stored_sectors ss
 INNER JOIN contract_v2_sector_roots csr ON (ss.id = csr.sector_id)
 INNER JOIN contracts_v2 c ON (csr.contract_id = c.id)
 WHERE c.contract_id=$1 AND csr.root_index= $2`)

--- a/persist/sqlite/store.go
+++ b/persist/sqlite/store.go
@@ -321,6 +321,11 @@ func OpenDatabase(fp string, log *zap.Logger) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+
+	// set the number of open connections to 1 to prevent "database is locked"
+	// errors
+	db.SetMaxOpenConns(1)
+
 	store := &Store{
 		db:  db,
 		log: log,

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -904,7 +904,7 @@ func BenchmarkVolumeShrink(b *testing.B) {
 	}
 
 	// grow the volume to b.N sectors
-	if err := db.GrowVolume(volumeID, uint64(b.N)); err != nil {
+	if err := db.GrowVolume(volumeID, uint64(b.N+1)); err != nil {
 		b.Fatal(err)
 	}
 
@@ -913,7 +913,7 @@ func BenchmarkVolumeShrink(b *testing.B) {
 	b.ReportMetric(float64(b.N), "sectors")
 
 	// remove all sectors from the volume
-	if err := db.ShrinkVolume(volumeID, 0); err != nil {
+	if err := db.ShrinkVolume(volumeID, 1); err != nil {
 		b.Fatal(err)
 	}
 }


### PR DESCRIPTION
This should effectively get rid of the `database is locked` error by preventing parallel connections. It's like wrapping a mutex around every database interaction and seems to be the recommended way of doing this.

The benchmarks seem to be mostly unaffected which makes sense considering that they are single-threaded. To see how it performs in practice we'll need to run it on a used host.


Going through https://sqlite.org/faq.html#q6 lead me to https://sqlite.org/threadsafe.html and it seems like it's generally recommended to use the `SQLITE_CONFIG_SINGLETHREAD` threading mode if locking isn't required to speed up performance. However, I haven't been able to figure out how to do that from the Go driver.

Closes https://github.com/SiaFoundation/hostd/issues/643

The before and after results of the existing benchmarks:

Before:
```
goos: darwin
goarch: arm64
pkg: go.sia.tech/hostd/v2/persist/sqlite
cpu: Apple M2 Pro
BenchmarkTrimSectors
BenchmarkTrimSectors-12        	  217003	      5595 ns/op	    217003 sectors	    1843 B/op	      50 allocs/op
BenchmarkV2AppendSectors
BenchmarkV2AppendSectors-12    	  170421	     12802 ns/op	    170421 sectors	    2800 B/op	      43 allocs/op
BenchmarkV2TrimSectors
BenchmarkV2TrimSectors-12      	 1356486	       949.9 ns/op	   1356486 sectors	       0 B/op	       0 allocs/op
BenchmarkVolumeGrow
BenchmarkVolumeGrow-12         	  407421	      3158 ns/op	    407421 sectors	     224 B/op	       8 allocs/op
BenchmarkVolumeShrink
BenchmarkVolumeShrink-12       	  716907	      1891 ns/op	    716907 sectors	       0 B/op	       0 allocs/op
BenchmarkVolumeMigrate
BenchmarkVolumeMigrate-12      	      18	  64587782 ns/op	        18.00 sectors	   11207 B/op	     298 allocs/op
BenchmarkStoreSector
BenchmarkStoreSector-12        	    7747	    160465 ns/op	      7747 sectors	    9243 B/op	     225 allocs/op
BenchmarkReadSector
BenchmarkReadSector-12         	   35526	     31730 ns/op	     35526 sectors	    4782 B/op	      94 allocs/op
PASS
ok  	go.sia.tech/hostd/v2/persist/sqlite	953.837s
```

After:
```
goos: darwin
goarch: arm64
pkg: go.sia.tech/hostd/v2/persist/sqlite
cpu: Apple M2 Pro
BenchmarkTrimSectors
BenchmarkTrimSectors-12        	  235959	      5596 ns/op	    235959 sectors	    1843 B/op	      50 allocs/op
BenchmarkV2AppendSectors
BenchmarkV2AppendSectors-12    	  175136	     12997 ns/op	    175136 sectors	    2800 B/op	      43 allocs/op
BenchmarkV2TrimSectors
BenchmarkV2TrimSectors-12      	 1344559	       934.5 ns/op	   1344559 sectors	       0 B/op	       0 allocs/op
BenchmarkVolumeGrow
BenchmarkVolumeGrow-12         	  410400	      3112 ns/op	    410400 sectors	     224 B/op	       8 allocs/op
BenchmarkVolumeShrink
BenchmarkVolumeShrink-12       	  724045	      1898 ns/op	    724045 sectors	       0 B/op	       0 allocs/op
BenchmarkVolumeMigrate
BenchmarkVolumeMigrate-12      	      18	  66599769 ns/op	        18.00 sectors	   11230 B/op	     298 allocs/op
BenchmarkStoreSector
BenchmarkStoreSector-12        	    7740	    154748 ns/op	      7740 sectors	    9240 B/op	     225 allocs/op
BenchmarkReadSector
BenchmarkReadSector-12         	   35342	     31820 ns/op	     35342 sectors	    4783 B/op	      94 allocs/op
PASS
ok  	go.sia.tech/hostd/v2/persist/sqlite	970.016s
```