### PR TITLE
sqlite: remove jitter sleep and transaction retries

### DIFF
--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -548,7 +548,6 @@ func (s *Store) ExpireContractSectors(height uint64) error {
 			return nil
 		}
 		log.Debug("removed sectors", zap.Int("expired", expired), zap.Int("batch", i))
-		jitterSleep(50 * time.Millisecond) // allow other transactions to run
 	}
 }
 
@@ -565,7 +564,6 @@ func (s *Store) ExpireV2ContractSectors(height uint64) error {
 			return nil
 		}
 		log.Debug("removed sectors", zap.Int("expired", expired), zap.Int("batch", i))
-		jitterSleep(50 * time.Millisecond) // allow other transactions to run
 	}
 }
 

--- a/persist/sqlite/sectors.go
+++ b/persist/sqlite/sectors.go
@@ -157,7 +157,6 @@ func (s *Store) ExpireTempSectors(height uint64) error {
 			return nil
 		}
 		log.Debug("expired temp sectors", zap.Int("expired", expired), zap.Stringers("removed", removed), zap.Int("batch", i))
-		jitterSleep(50 * time.Millisecond) // allow other transactions to run
 	}
 }
 
@@ -280,7 +279,6 @@ func (s *Store) PruneSectors(ctx context.Context, lastAccess time.Time) error {
 		} else if done {
 			return nil
 		}
-		jitterSleep(50 * time.Millisecond)
 	}
 }
 

--- a/persist/sqlite/sql.go
+++ b/persist/sqlite/sql.go
@@ -3,7 +3,6 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -183,11 +182,6 @@ func setDBVersion(tx *txn, version int64) error {
 	const query = `UPDATE global_settings SET db_version=$1 RETURNING id;`
 	var dbID int64
 	return tx.QueryRow(query, version).Scan(&dbID)
-}
-
-// jitterSleep sleeps for a random duration between t and t*1.5.
-func jitterSleep(t time.Duration) {
-	time.Sleep(t + time.Duration(rand.Int63n(int64(t/2))))
 }
 
 func queryPlaceHolders(n int) string {

--- a/persist/sqlite/store_test.go
+++ b/persist/sqlite/store_test.go
@@ -2,119 +2,13 @@ package sqlite
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"reflect"
 	"testing"
-	"time"
 
-	"github.com/mattn/go-sqlite3"
 	"go.sia.tech/hostd/v2/host/settings"
 	"go.uber.org/zap/zaptest"
 )
-
-func TestTransactionRetry(t *testing.T) {
-	t.Skip("This test is flaky and needs to be fixed")
-
-	t.Run("transaction retry", func(t *testing.T) {
-		log := zaptest.NewLogger(t)
-		db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-
-		err = db.transaction(func(tx *txn) error { return nil }) // start a new empty transaction, should succeed immediately
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		ch := make(chan struct{}, 1) // channel to synchronize the transaction goroutine
-
-		// start a transaction in a goroutine and hold it open for 5 seconds
-		// this should allow for the next transaction to be retried a few times
-		go func() {
-			err := db.transaction(func(tx *txn) error {
-				_, err := tx.Exec(`UPDATE global_settings SET host_key=?`, `foo`) // upgrade the transaction to an exclusive lock;
-				if err != nil {
-					return err
-				}
-				ch <- struct{}{}
-				time.Sleep(500 * time.Millisecond)
-				return nil
-			})
-			if err != nil {
-				panic(err)
-			}
-			ch <- struct{}{}
-		}()
-
-		<-ch // wait for the transaction to start
-
-		err = db.transaction(func(tx *txn) error {
-			_, err = tx.Exec(`UPDATE global_settings SET host_key=?`, `bar`) // should fail and be retried
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		<-ch // wait for the transaction to finish
-	})
-
-	t.Run("transaction timeout", func(t *testing.T) {
-		log := zaptest.NewLogger(t)
-		db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-
-		err = db.transaction(func(tx *txn) error { return nil }) // start a new empty transaction, should succeed immediately
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		ch := make(chan struct{}, 1) // channel to synchronize the transaction goroutine
-
-		go func() {
-			err := db.transaction(func(tx *txn) error {
-				_, err := tx.Exec(`UPDATE global_settings SET host_key=?`, `foo`) // upgrade the transaction to an exclusive lock;
-				if err != nil {
-					return err
-				}
-				ch <- struct{}{}
-				time.Sleep(5 * time.Second)
-				return nil
-			})
-			if err != nil {
-				panic(err)
-			}
-			ch <- struct{}{}
-		}()
-
-		<-ch // wait for the transaction to start
-
-		err = db.transaction(func(tx *txn) error {
-			_, err := tx.Exec(`UPDATE global_settings SET host_key=?`, `bar`) // should fail and be retried
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-
-		// verify the returned error is the busy error
-		var sqliteErr sqlite3.Error
-		if !errors.As(err, &sqliteErr) || sqliteErr.Code != sqlite3.ErrBusy {
-			t.Fatalf("expected busy error, got %v", err)
-		}
-
-		<-ch // wait for the transaction to finish
-	})
-}
 
 func TestBackup(t *testing.T) {
 	srcPath := filepath.Join(t.TempDir(), "test.db")

--- a/persist/sqlite/volumes.go
+++ b/persist/sqlite/volumes.go
@@ -304,8 +304,6 @@ LIMIT 1;`
 		} else if done {
 			return
 		}
-		// allow other transactions to run
-		jitterSleep(50 * time.Millisecond) // maximum of 48000 sectors per hour
 	}
 }
 
@@ -335,7 +333,6 @@ func (s *Store) RemoveVolume(id int64, force bool) error {
 		} else if removed == 0 {
 			break
 		}
-		jitterSleep(50 * time.Millisecond)
 	}
 
 	return s.transaction(func(tx *txn) error {


### PR DESCRIPTION
Now that the database is limited to a single conn there is no need to retry transactions.