### PR TITLE
fix alerts panic

### DIFF
--- a/.changeset/fixes_a_panic_when_encoding_the_alerts_array_during_high_frequency_alert_registrations.md
+++ b/.changeset/fixes_a_panic_when_encoding_the_alerts_array_during_high_frequency_alert_registrations.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed a panic when encoding the alerts array during high frequency updates

--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -148,7 +148,8 @@ func (m *Manager) Active() []Alert {
 		return alerts[i].Timestamp.After(alerts[j].Timestamp)
 	})
 	// Perform a JSON round-trip to create a deep copy of the Data field.
-	// This avoids concurrent map access issues.
+	// This avoids concurrent map access issues and ensures nested reference
+	// types are also copied.
 	buf, err := json.Marshal(alerts)
 	if err != nil {
 		panic(fmt.Errorf("failed to marshal alerts: %v", err)) // developer error

--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -126,8 +126,10 @@ func (m *Manager) Register(a Alert) {
 		panic("cannot register alert with zero timestamp") // developer error
 	}
 
-	if err := m.events.BroadcastEvent("alert", "alerts."+a.Severity.String(), a); err != nil {
-		m.log.Error("failed to broadcast alert", zap.Error(err))
+	if m.events != nil {
+		if err := m.events.BroadcastEvent("alert", "alerts."+a.Severity.String(), a); err != nil {
+			m.log.Error("failed to broadcast alert", zap.Error(err))
+		}
 	}
 
 	m.mu.Lock()

--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -71,9 +71,11 @@ type (
 // DeepCopy creates a deep copy of the alert. It is used to ensure that the
 // alert data map is not modified after it is returned by Alerts.
 func (a Alert) DeepCopy() Alert {
-	data := make(map[string]any, len(a.Data))
-	maps.Copy(data, a.Data)
-	a.Data = data
+	if a.Data != nil {
+		data := make(map[string]any, len(a.Data))
+		maps.Copy(data, a.Data)
+		a.Data = data
+	}
 	return a
 }
 

--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -72,7 +72,7 @@ type (
 // alert data map is not modified after it is returned by Alerts.
 func (a Alert) DeepCopy() Alert {
 	data := make(map[string]any, len(a.Data))
-	maps.Copy(a.Data, data)
+	maps.Copy(data, a.Data)
 	a.Data = data
 	return a
 }

--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -2,6 +2,7 @@ package alerts
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -66,6 +67,15 @@ type (
 		alerts map[types.Hash256]Alert
 	}
 )
+
+// DeepCopy creates a deep copy of the alert. It is used to ensure that the
+// alert data map is not modified after it is returned by Alerts.
+func (a Alert) DeepCopy() Alert {
+	data := make(map[string]any, len(a.Data))
+	maps.Copy(a.Data, data)
+	a.Data = data
+	return a
+}
 
 var _ Alerter = (*Manager)(nil)
 
@@ -141,7 +151,7 @@ func (m *Manager) Active() []Alert {
 
 	alerts := make([]Alert, 0, len(m.alerts))
 	for _, a := range m.alerts {
-		alerts = append(alerts, a)
+		alerts = append(alerts, a.DeepCopy())
 	}
 	sort.Slice(alerts, func(i, j int) bool {
 		return alerts[i].Timestamp.After(alerts[j].Timestamp)

--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -147,6 +147,8 @@ func (m *Manager) Active() []Alert {
 	sort.Slice(alerts, func(i, j int) bool {
 		return alerts[i].Timestamp.After(alerts[j].Timestamp)
 	})
+	// Perform a JSON round-trip to create a deep copy of the Data field.
+	// This avoids concurrent map access issues.
 	buf, err := json.Marshal(alerts)
 	if err != nil {
 		panic(fmt.Errorf("failed to marshal alerts: %v", err)) // developer error

--- a/alerts/alerts_test.go
+++ b/alerts/alerts_test.go
@@ -12,12 +12,9 @@ func TestAlerts(t *testing.T) {
 	m := NewManager()
 
 	expectedAlert := Alert{
-		ID:       frand.Entropy256(),
-		Severity: SeverityCritical,
-		Message:  "foo",
-		Data: map[string]any{
-			"bar": "baz",
-		},
+		ID:        frand.Entropy256(),
+		Severity:  SeverityCritical,
+		Message:   "foo",
 		Timestamp: time.Now(),
 	}
 	// register the alert
@@ -30,7 +27,21 @@ func TestAlerts(t *testing.T) {
 	}
 
 	// update the alert
-	expectedAlert.Data["bar"] = "qux"
+	expectedAlert.Data = map[string]any{
+		"bar": "baz",
+	}
+	m.Register(expectedAlert)
+	alerts = m.Active()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	} else if !reflect.DeepEqual(alerts[0], expectedAlert) {
+		t.Fatalf("expected alert %v, got %v", expectedAlert, alerts[0])
+	}
+
+	// update the alert
+	expectedAlert.Data = map[string]any{
+		"baz": "qux",
+	}
 	m.Register(expectedAlert)
 	alerts = m.Active()
 	if len(alerts) != 1 {

--- a/alerts/alerts_test.go
+++ b/alerts/alerts_test.go
@@ -15,7 +15,7 @@ func TestAlerts(t *testing.T) {
 		ID:        frand.Entropy256(),
 		Severity:  SeverityCritical,
 		Message:   "foo",
-		Timestamp: time.Now(),
+		Timestamp: time.Now().Truncate(time.Millisecond), // json rounds to milliseconds
 	}
 	// register the alert
 	m.Register(expectedAlert)

--- a/alerts/alerts_test.go
+++ b/alerts/alerts_test.go
@@ -1,7 +1,8 @@
 package alerts
 
 import (
-	"reflect"
+	"bytes"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -15,45 +16,49 @@ func TestAlerts(t *testing.T) {
 		ID:        frand.Entropy256(),
 		Severity:  SeverityCritical,
 		Message:   "foo",
-		Timestamp: time.Now().Truncate(time.Millisecond), // json rounds to milliseconds
+		Timestamp: time.Now(),
 	}
+
+	assertAlert := func() {
+		t.Helper()
+
+		alerts := m.Active()
+		if len(alerts) != 1 {
+			t.Fatalf("expected 1 alert, got %d", len(alerts))
+		}
+		ab, err := json.Marshal(alerts[0])
+		if err != nil {
+			t.Fatalf("failed to marshal alert: %v", err)
+		}
+		bb, err := json.Marshal(expectedAlert)
+		if err != nil {
+			t.Fatalf("failed to marshal expected alert: %v", err)
+		} else if !bytes.Equal(ab, bb) {
+			t.Fatalf("expected alert %s, got %s", string(bb), string(ab))
+		}
+	}
+
 	// register the alert
 	m.Register(expectedAlert)
-	alerts := m.Active()
-	if len(alerts) != 1 {
-		t.Fatalf("expected 1 alert, got %d", len(alerts))
-	} else if !reflect.DeepEqual(alerts[0], expectedAlert) {
-		t.Fatalf("expected alert %v, got %v", expectedAlert, alerts[0])
-	}
+	assertAlert()
 
 	// update the alert
 	expectedAlert.Data = map[string]any{
 		"bar": "baz",
 	}
 	m.Register(expectedAlert)
-	alerts = m.Active()
-	if len(alerts) != 1 {
-		t.Fatalf("expected 1 alert, got %d", len(alerts))
-	} else if !reflect.DeepEqual(alerts[0], expectedAlert) {
-		t.Fatalf("expected alert %v, got %v", expectedAlert, alerts[0])
-	}
+	assertAlert()
 
 	// update the alert
 	expectedAlert.Data = map[string]any{
 		"baz": "qux",
 	}
 	m.Register(expectedAlert)
-	alerts = m.Active()
-	if len(alerts) != 1 {
-		t.Fatalf("expected 1 alert, got %d", len(alerts))
-	} else if !reflect.DeepEqual(alerts[0], expectedAlert) {
-		t.Fatalf("expected alert %v, got %v", expectedAlert, alerts[0])
-	}
+	assertAlert()
 
 	// dismiss the alert
 	m.Dismiss(expectedAlert.ID)
-	alerts = m.Active()
-	if len(alerts) != 0 {
+	if alerts := m.Active(); len(alerts) != 0 {
 		t.Fatalf("expected 0 alerts, got %d", len(alerts))
 	}
 }

--- a/alerts/alerts_test.go
+++ b/alerts/alerts_test.go
@@ -1,0 +1,48 @@
+package alerts
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"lukechampine.com/frand"
+)
+
+func TestAlerts(t *testing.T) {
+	m := NewManager()
+
+	expectedAlert := Alert{
+		ID:       frand.Entropy256(),
+		Severity: SeverityCritical,
+		Message:  "foo",
+		Data: map[string]any{
+			"bar": "baz",
+		},
+		Timestamp: time.Now(),
+	}
+	// register the alert
+	m.Register(expectedAlert)
+	alerts := m.Active()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	} else if !reflect.DeepEqual(alerts[0], expectedAlert) {
+		t.Fatalf("expected alert %v, got %v", expectedAlert, alerts[0])
+	}
+
+	// update the alert
+	expectedAlert.Data["bar"] = "qux"
+	m.Register(expectedAlert)
+	alerts = m.Active()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	} else if !reflect.DeepEqual(alerts[0], expectedAlert) {
+		t.Fatalf("expected alert %v, got %v", expectedAlert, alerts[0])
+	}
+
+	// dismiss the alert
+	m.Dismiss(expectedAlert.ID)
+	alerts = m.Active()
+	if len(alerts) != 0 {
+		t.Fatalf("expected 0 alerts, got %d", len(alerts))
+	}
+}


### PR DESCRIPTION
Fixes a panic when encoding the alerts array during high frequency updates. Honestly surprised we haven't run into this before.

```
fatal error: concurrent map iteration and map write
goroutine 13842512 [running]:
internal/runtime/maps.fatal({0x10d45e2?, 0x475113?})
	runtime/panic.go:1058 +0x18
internal/runtime/maps.(*Iter).Next(0xc00a9ced50?)
	internal/runtime/maps/table.go:683 +0x86
reflect.mapIterNext(0xf6e640?)
	reflect/map_swiss.go:203 +0x13
reflect.(*MapIter).Next(0xc001728fd0)
	reflect/map_swiss.go:358 +0x3e
encoding/json.mapEncoder.encode({0x15?}, 0xc000132940, {0xf9e080?, 0xc001e8efb0?, 0xc001e8efb0?}, {0x7?, 0x0?})
	encoding/json/encode.go:768 +0x329
encoding/json.structEncoder.encode({{{0xc0048ec008, 0x5, 0x8}, 0xc00602a7b0, 0xc00602a7e0}}, 0xc000132940, {0x10313c0?, 0xc001e8ef78?, 0xc001729338?}, {0x0, ...})
	encoding/json/encode.go:727 +0x30a
encoding/json.arrayEncoder.encode({0xc001729320?}, 0xc000132940, {0xf78140?, 0xc00a519560?, 0x0?}, {0x30?, 0x93?})
	encoding/json/encode.go:870 +0xcf
encoding/json.sliceEncoder.encode({0x4170d4?}, 0xc000132940, {0xf78140?, 0xc00a519560?, 0xf78140?}, {0x3d?, 0x60?})
	encoding/json/encode.go:843 +0x335
encoding/json.(*encodeState).reflectValue(0xc000132940, {0xf78140?, 0xc00a519560?, 0xc0017294f8?}, {0xc0?, 0xc3?})
	encoding/json/encode.go:333 +0x73
encoding/json.(*encodeState).marshal(0xc001e8ef78?, {0xf78140?, 0xc00a519560?}, {0x28?, 0x4f?})
	encoding/json/encode.go:309 +0xb2
encoding/json.(*Encoder).Encode(0xc001729638, {0xf78140, 0xc00a519560})
	encoding/json/stream.go:210 +0xd0
go.sia.tech/jape.Context.Encode({{0x1a20e00, 0xc009cc1500}, 0xc00a659040, {0x0, 0x0, 0x0}}, {0xf78140, 0xc00a519560})
	go.sia.tech/jape@v0.13.1/server.go:57 +0x32b
go.sia.tech/hostd/v2/api.(*api).writeResponse(0xc00621c000, {{0x1a20e00, 0xc009cc1500}, 0xc00a659040, {0x0, 0x0, 0x0}}, {0xf78140, 0xc00a519560})
	go.sia.tech/hostd/v2/api/endpoints.go:66 +0x16e
go.sia.tech/hostd/v2/api.(*api).handleGETAlerts(0xc00621c000, {{0x1a20e00, 0xc009cc1500}, 0xc00a659040, {0x0, 0x0, 0x0}})
	go.sia.tech/hostd/v2/api/endpoints.go:155 +0x86
go.sia.tech/jape.Mux.adaptor.func1({0x1a20e00?, 0xc009cc1500?}, 0xc00a510dc8?, {0x0?, 0x18?, 0xc007780008?})
	go.sia.tech/jape@v0.13.1/server.go:171 +0x52
github.com/julienschmidt/httprouter.(*Router).ServeHTTP(0xc005f4e240, {0x1a20e00, 0xc009cc1500}, 0xc00a659040)
	github.com/julienschmidt/httprouter@v1.3.0/router.go:387 +0x7cb
main.runRootCmd.runRootCmd.BasicAuth.func41.func42({0x1a20e00, 0xc009cc1500}, 0xc00a659040)
	go.sia.tech/jape@v0.13.1/server.go:230 +0x99
net/http.HandlerFunc.ServeHTTP(0xc001729b10?, {0x1a20e00?, 0xc009cc1500?}, 0x47cff2?)
	net/http/server.go:2294 +0x29
main.webRouter.ServeHTTP({{0x1a19f20?, 0xc0004f2a20?}, {0x1a185e0?, 0xc0004f2360?}}, {0x1a20e00?, 0xc009cc1500?}, 0x1?)
	go.sia.tech/hostd/v2/cmd/hostd/web.go:18 +0xd8
net/http.serverHandler.ServeHTTP({0xc002680720?}, {0x1a20e00?, 0xc009cc1500?}, 0x6?)
	net/http/server.go:3301 +0x8e
net/http.(*conn).serve(0xc00583e000, {0x1a23638, 0xc0136a7dd0})
	net/http/server.go:2102 +0x625
created by net/http.(*Server).Serve in goroutine 228
	net/http/server.go:3454 +0x485
goroutine 1 [chan receive, 2594 minutes]:
main.runRootCmd({_, _}, {{0x0, 0x0}, {0xc00049a1f0, 0xe}, {0xc0004f0050, 0x46}, 0x0, {{0xc00049a257, ...}, ...}, ...}, ...)
	go.sia.tech/hostd/v2/cmd/hostd/run.go:531 +0x60c5
main.main()
	go.sia.tech/hostd/v2/cmd/hostd/main.go:534 +0x2239
goroutine 5 [syscall, 3292 minutes]:
os/signal.signal_recv()
```