### PR TITLE
Update README with QUIC settings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ services:
     ports:
       - 127.0.0.1:9980:9980/tcp
       - 9981-9984:9981-9984/tcp
+      - 9984:9984/udp
     volumes:
       - hostd-data:/data
       - /storage:/storage

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ The default config path can be changed using the `HOSTD_CONFIG_FILE` environment
 + `9981` - Sia consensus
 + `9982` - RHP2
 + `9983` - RHP3
-+ `9984` - RHP4
++ `9984` - RHP4 (Note: TCP and UDP ports for SiaMux and Quic protocols respectively)
+
+### RHP4 - QUIC HTTP3 over UDP
+RHP4 has two transport methods, SiaMux (using TCP) and QUIC (using UDP). QUIC protocol uses TLS as its security layer. To support QUIC, ensure that you are applying a valid certificate and private key that match the hosts address into the config file below. 
 
 ### Example Config File
 
@@ -76,6 +79,9 @@ rhp4:
       address: :9984
     - protocol: quic # quic, quic4, quic6
       address: :9984
+  quic:
+    certPath: '/path/certs/certchain.crt' # Certificate chain file
+    keyPath: '/path/private/keyfile.key' # Certificate private keyfile 
 log:
   level: info # global log level
   stdout:


### PR DESCRIPTION
Updates README referencing UDP settings where appropriate and listing certPath and keyPath hostd configuration settings to allow QUIC connections to work. 
NOTE: a valid certificate and keyfile that matches the ClientHello (the hostname hostd reports) is needed to make QUIC connections.