### PR TITLE
contracts,sqlite: simplify sector management

### DIFF
--- a/.changeset/simplified_v1_contract_sectors_management.md
+++ b/.changeset/simplified_v1_contract_sectors_management.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Simplified V1 contract sectors management
+
+Changes sector updates for V1 contracts to match the behavior from V2. The new behavior diffs the old and new sector roots and updates the changed indices in the database rather than relying on replaying the sector changes. This is slightly slower on large contracts due to needing to calculate the diff of each index, but it is significantly simpler and less prone to edge cases.

--- a/host/contracts/persist.go
+++ b/host/contracts/persist.go
@@ -34,7 +34,7 @@ type (
 		RenewContract(renewal SignedRevision, existing SignedRevision, formationSet []types.Transaction, lockedCollateral types.Currency, clearingUsage, initialUsage Usage, negotationHeight uint64) error
 		// ReviseContract atomically updates a contract and its associated
 		// sector roots.
-		ReviseContract(revision SignedRevision, oldRoots []types.Hash256, usage Usage, sectorChanges []SectorChange) error
+		ReviseContract(revision SignedRevision, oldRoots, newRoots []types.Hash256, usage Usage) error
 
 		// ExpireContractSectors removes sector roots for any contracts that are
 		// rejected or past their proof window.

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -765,15 +765,9 @@ func TestPrune(t *testing.T) {
 	}
 
 	addSectorsToContract := func(t *testing.T, c *contracts.SignedRevision, sectors []types.Hash256) {
-		// append the contract sectors to the contract
-		var changes []contracts.SectorChange
-		for _, root := range sectors {
-			changes = append(changes, contracts.SectorChange{
-				Root:   root,
-				Action: contracts.SectorActionAppend,
-			})
-		}
-		err = db.ReviseContract(*c, []types.Hash256{}, contracts.Usage{}, changes)
+		t.Helper()
+
+		err = db.ReviseContract(*c, []types.Hash256{}, sectors, contracts.Usage{})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Changes sector updates for V1 contracts to match the behavior from V2. The new behavior diffs the old and new sector roots and updates the changed indices in the database rather than relying on replaying the sector changes. This is slightly slower on large contracts due to needing to loop over each indices to calculate the diff, but it is less prone to edge cases.