### PR TITLE
Include test results in API response

### DIFF
--- a/.changeset/added_endpoint_to_check_the_hosts_connectivity.md
+++ b/.changeset/added_endpoint_to_check_the_hosts_connectivity.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Added `[PUT] /api/system/connect/test` to trigger a test of the host's connectivity.

--- a/api/api.go
+++ b/api/api.go
@@ -54,7 +54,7 @@ type (
 
 		UpdateDDNS(force bool) error
 
-		TestConnection(context.Context) (bool, error)
+		TestConnection(context.Context) (explorer.TestResult, bool, error)
 	}
 
 	// An Index persists updates from the blockchain to a store

--- a/api/client.go
+++ b/api/client.go
@@ -11,6 +11,7 @@ import (
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/wallet"
+	"go.sia.tech/hostd/v2/explorer"
 	"go.sia.tech/hostd/v2/host/contracts"
 	"go.sia.tech/hostd/v2/host/metrics"
 	"go.sia.tech/hostd/v2/host/settings"
@@ -311,8 +312,8 @@ func (c *Client) WebHooks() (hooks []webhooks.Webhook, err error) {
 // TestConnection starts an external connection test to the host. This is used to
 // test the host's connectivity to the network and its ability to accept
 // connections from renters.
-func (c *Client) TestConnection() (err error) {
-	err = c.c.PUT(context.Background(), "/system/connect/test", nil)
+func (c *Client) TestConnection() (res explorer.TestResult, err error) {
+	err = c.c.PUT(context.Background(), "/system/connect/test", &res)
 	return
 }
 

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -735,15 +735,12 @@ func (a *api) handleDELETEWebhooks(jc jape.Context) {
 }
 
 func (a *api) handlePUTSystemConnectTest(jc jape.Context) {
-	ok, err := a.settings.TestConnection(jc.Request.Context())
+	result, _, err := a.settings.TestConnection(jc.Request.Context())
 	if err != nil {
 		jc.Error(err, http.StatusInternalServerError)
 		return
-	} else if !ok {
-		jc.Error(errors.New("connection test failed"), http.StatusInternalServerError)
-		return
 	}
-	jc.Encode(nil)
+	jc.Encode(result)
 }
 
 func parseLimitParams(jc jape.Context, defaultLimit, maxLimit int) (limit, offset int) {

--- a/host/settings/settings.go
+++ b/host/settings/settings.go
@@ -499,11 +499,11 @@ func NewConfigManager(hostKey types.PrivateKey, store Store, cm ChainManager, s 
 					continue
 				}
 
-				ok, err := m.TestConnection(context.Background())
+				result, ok, err := m.TestConnection(context.Background())
 				if err != nil {
 					m.log.Error("failed to test connection", zap.Error(err))
 				} else {
-					m.log.Debug("connection test result", zap.Bool("ok", ok))
+					m.log.Debug("connection test result", zap.Bool("ok", ok), zap.Any("result", result))
 				}
 
 				if !ok {


### PR DESCRIPTION
Changes the response of `[PUT] /system/connect/test` to include the full test results