### PR TITLE
Include QUIC protocol in host announcement

### DIFF
--- a/.changeset/include_quic_in_host_announcement_if_configured.md
+++ b/.changeset/include_quic_in_host_announcement_if_configured.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Include QUIC in host announcement if configured.

--- a/host/settings/announce.go
+++ b/host/settings/announce.go
@@ -43,7 +43,7 @@ func (m *ConfigManager) rhp4NetAddresses() []chain.NetAddress {
 	if err != nil {
 		m.log.Error("failed to get certificate for RHP4 net address", zap.Error(err))
 		return protos
-	} else if cert == nil {
+	} else if cert == nil || len(cert.Certificate) == 0 {
 		m.log.Warn("no certificate found for RHP4 net address, skipping")
 		return protos
 	}

--- a/host/settings/announce.go
+++ b/host/settings/announce.go
@@ -9,6 +9,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.uber.org/zap"
 )
@@ -25,8 +26,40 @@ func (m *ConfigManager) rhp2NetAddress() string {
 	return net.JoinHostPort(m.Settings().NetAddress, strconv.Itoa(int(m.rhp2Port)))
 }
 
-func (m *ConfigManager) rhp4NetAddress() string {
-	return net.JoinHostPort(m.Settings().NetAddress, strconv.Itoa(int(m.rhp4Port)))
+func (m *ConfigManager) rhp4NetAddresses() []chain.NetAddress {
+	netAddress := m.Settings().NetAddress
+	rhp4SiaMuxAddress := net.JoinHostPort(netAddress, strconv.Itoa(int(m.rhp4Port)))
+
+	protos := []chain.NetAddress{
+		{Protocol: siamux.Protocol, Address: rhp4SiaMuxAddress},
+	}
+
+	if m.certs == nil {
+		return protos
+	}
+
+	cert, err := m.certs.GetCertificate(nil)
+	if err != nil {
+		m.log.Error("failed to get certificate for RHP4 net address", zap.Error(err))
+		return protos
+	} else if cert == nil {
+		m.log.Warn("no certificate found for RHP4 net address, skipping")
+		return protos
+	} else if cert.Leaf == nil {
+		m.log.Warn("certificate leaf is nil, skipping RHP4 net address")
+		return protos
+	} else if cert.Leaf.Subject.CommonName == "" {
+		m.log.Warn("certificate common name is empty, skipping RHP4 net address")
+		return protos
+	}
+	// Add the RHP4 QUIC address using the common name from the certificate
+	// and the RHP4 port.
+	rhp4QuicAddress := net.JoinHostPort(cert.Leaf.Subject.CommonName, strconv.Itoa(int(m.rhp4Port)))
+	protos = append(protos, chain.NetAddress{
+		Protocol: quic.Protocol,
+		Address:  rhp4QuicAddress,
+	})
+	return protos
 }
 
 // Announce announces the host to the network
@@ -74,12 +107,7 @@ func (m *ConfigManager) Announce() error {
 		// create a v2 transaction with an announcement
 		txn := types.V2Transaction{
 			Attestations: []types.Attestation{
-				chain.V2HostAnnouncement{
-					{
-						Protocol: siamux.Protocol,
-						Address:  m.rhp4NetAddress(),
-					},
-				}.ToAttestation(cs, m.hostKey),
+				chain.V2HostAnnouncement(m.rhp4NetAddresses()).ToAttestation(cs, m.hostKey),
 			},
 			MinerFee: minerFee,
 		}

--- a/host/settings/options.go
+++ b/host/settings/options.go
@@ -73,6 +73,14 @@ func WithRHP4Port(port uint16) Option {
 	}
 }
 
+// WithCertificates gets the TLS certificates the host
+// should use for RHP4 over QUIC.
+func WithCertificates(certs Certificates) Option {
+	return func(c *ConfigManager) {
+		c.certs = certs
+	}
+}
+
 // WithExplorer sets the explorer for the settings manager.
 func WithExplorer(explorer Explorer) Option {
 	return func(c *ConfigManager) {

--- a/host/settings/settings.go
+++ b/host/settings/settings.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"math"
@@ -87,6 +88,12 @@ type (
 		Usage() (used, total uint64, _ error)
 	}
 
+	// Certificates provides TLS certificates for the host
+	// to use when serving RHP4 over QUIC.
+	Certificates interface {
+		GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
+	}
+
 	// A Wallet manages Siacoins and funds transactions
 	Wallet interface {
 		Address() types.Address
@@ -161,6 +168,7 @@ type (
 		storage  Storage
 		wallet   Wallet
 		explorer Explorer
+		certs    Certificates
 
 		mu         sync.Mutex // guards the following fields
 		settings   Settings   // in-memory cache of the host's settings

--- a/host/settings/troubleshoot.go
+++ b/host/settings/troubleshoot.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"go.sia.tech/coreutils/chain"
-	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.sia.tech/hostd/v2/alerts"
 	"go.sia.tech/hostd/v2/explorer"
 	"lukechampine.com/frand"
@@ -39,20 +37,11 @@ func (cm *ConfigManager) TestConnection(ctx context.Context) (explorer.TestResul
 	if rhp2NetAddress == "" {
 		return explorer.TestResult{}, false, errors.New("rhp2 net address is empty")
 	}
-	rhp4NetAddress := cm.rhp4NetAddress()
-	if rhp4NetAddress == "" {
-		return explorer.TestResult{}, false, errors.New("rhp4 net address is empty")
-	}
 
 	result, err := cm.explorer.TestConnection(ctx, explorer.Host{
-		PublicKey:      cm.hostKey.PublicKey(),
-		RHP2NetAddress: rhp2NetAddress,
-		RHP4NetAddresses: []chain.NetAddress{
-			{
-				Protocol: siamux.Protocol,
-				Address:  rhp4NetAddress,
-			},
-		},
+		PublicKey:        cm.hostKey.PublicKey(),
+		RHP2NetAddress:   rhp2NetAddress,
+		RHP4NetAddresses: cm.rhp4NetAddresses(),
 	})
 	if err != nil {
 		return explorer.TestResult{}, false, fmt.Errorf("failed to test connection: %w", err)

--- a/host/settings/update.go
+++ b/host/settings/update.go
@@ -5,7 +5,6 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
-	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.uber.org/zap"
 )
 
@@ -143,12 +142,7 @@ func (m *ConfigManager) ProcessActions(index types.ChainIndex) error {
 
 		nextHeight := announceIndex.Height + m.announceInterval
 		h := types.NewHasher()
-		types.EncodeSlice(h.E, chain.V2HostAnnouncement{
-			{
-				Protocol: siamux.Protocol,
-				Address:  m.rhp4NetAddress(),
-			},
-		})
+		types.EncodeSlice(h.E, m.rhp4NetAddresses())
 		if err := h.E.Flush(); err != nil {
 			return fmt.Errorf("failed to hash v2 announcement: %w", err)
 		}


### PR DESCRIPTION
Adds the QUIC protocol to the V2 host announcement if a certificate is configured. It uses the common name from the certificate for the address and the configured RHP4 port.