### PR TITLE
Add fallback for Wildcard certificates

### DIFF
--- a/.changeset/added_fallback_support_for_wildcard_certificates.md
+++ b/.changeset/added_fallback_support_for_wildcard_certificates.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Added fallback support for wildcard certificates.

--- a/host/settings/announce.go
+++ b/host/settings/announce.go
@@ -70,6 +70,9 @@ func (m *ConfigManager) rhp4NetAddresses() []chain.NetAddress {
 	if hostname == "" {
 		m.log.Warn("certificate name is empty, skipping RHP4 net address")
 		return protos
+	} else if strings.HasPrefix(hostname, "*") {
+		m.log.Debug("wildcard certificate -- using netaddress as is", zap.String("certHost", hostname), zap.String("netAddress", netAddress))
+		hostname = netAddress
 	}
 	// Add the RHP4 QUIC address using the common name from the certificate
 	// and the RHP4 port.


### PR DESCRIPTION
Adds a fallback to the user's input net address when a wildcard certificate is used for RHP4 QUIC. Fixes #703 