### PR TITLE
Fix reissue

### DIFF
--- a/.changeset/fixed_an_issue_with_nomad_reissuing_certificates_on_startup.md
+++ b/.changeset/fixed_an_issue_with_nomad_reissuing_certificates_on_startup.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed an issue with nomad reissuing certificates on startup.


### PR DESCRIPTION
Fixes an issue where `hostd` would always refresh a nomad certificate on startup.