### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/host/storage/storage.go
+++ b/host/storage/storage.go
@@ -221,10 +221,7 @@ func (vm *VolumeManager) growVolume(ctx context.Context, id int64, volume *volum
 		default:
 		}
 
-		target := current + resizeBatchSize
-		if target > newMaxSectors {
-			target = newMaxSectors
-		}
+		target := min(current+resizeBatchSize, newMaxSectors)
 
 		// truncate the file and add the indices to the volume store. resize is
 		// done in chunks to prevent holding a lock for too long and to allow
@@ -299,10 +296,7 @@ func (vm *VolumeManager) shrinkVolume(ctx context.Context, id int64, volume *vol
 		}
 		var target uint64
 		if current > resizeBatchSize {
-			target = current - resizeBatchSize
-			if target < newMaxSectors {
-				target = newMaxSectors
-			}
+			target = max(current-resizeBatchSize, newMaxSectors)
 		} else {
 			target = newMaxSectors
 		}

--- a/persist/sqlite/store.go
+++ b/persist/sqlite/store.go
@@ -57,10 +57,7 @@ func (s *Store) transaction(fn func(*txn) error) error {
 			break
 		}
 		// exponential backoff
-		sleep := time.Duration(math.Pow(factor, float64(attempt))) * time.Millisecond
-		if sleep > maxBackoff {
-			sleep = maxBackoff
-		}
+		sleep := min(time.Duration(math.Pow(factor, float64(attempt)))*time.Millisecond, maxBackoff)
 		log.Debug("database locked", zap.Duration("elapsed", time.Since(attemptStart)), zap.Duration("totalElapsed", time.Since(start)), zap.Stack("stack"), zap.Duration("retry", sleep))
 		jitterSleep(sleep)
 	}

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -963,10 +963,7 @@ func BenchmarkStoreSector(b *testing.B) {
 		minSectors           = 20 * sectorsPerTiB
 	)
 
-	sectors := minSectors
-	if sectors < uint64(b.N) {
-		sectors = uint64(b.N)
-	}
+	sectors := max(minSectors, uint64(b.N))
 
 	log := zaptest.NewLogger(b)
 	db, err := OpenDatabase(filepath.Join(b.TempDir(), "test.db"), log)
@@ -1048,10 +1045,7 @@ func BenchmarkReadSector(b *testing.B) {
 		minSectors           = 20 * sectorsPerTiB
 	)
 
-	sectors := minSectors
-	if sectors < uint64(b.N) {
-		sectors = uint64(b.N)
-	}
+	sectors := max(minSectors, uint64(b.N))
 
 	log := zaptest.NewLogger(b)
 	db, err := OpenDatabase(filepath.Join(b.TempDir(), "test.db"), log)


### PR DESCRIPTION

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.