### PR TITLE
Fix TestCheckIntegrity NDF

### DIFF
--- a/.changeset/fix_testintegritycheck_ndf.md
+++ b/.changeset/fix_testintegritycheck_ndf.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix TestIntegrityCheck NDF

--- a/host/contracts/integrity_test.go
+++ b/host/contracts/integrity_test.go
@@ -98,17 +98,18 @@ func TestCheckIntegrity(t *testing.T) {
 	}
 
 	var roots []types.Hash256
+	expiration := host.Chain.Tip().Height + 10
 	for range 5 {
 		var sector [proto4.SectorSize]byte
 		frand.Read(sector[:256])
 		root := proto4.SectorRoot(&sector)
-		err := host.Volumes.Write(root, &sector)
-		if err != nil {
+		if err := host.Volumes.StoreSector(root, &sector, expiration); err != nil {
 			t.Fatal(err)
 		}
 		roots = append(roots, root)
 	}
 
+	// add sectors to contract
 	cs := host.Chain.TipState()
 	contract.V2FileContract.RevisionNumber++
 	contract.V2FileContract.Filesize = uint64(len(roots)) * proto4.SectorSize


### PR DESCRIPTION
TestCheckIntegrity is currently failing occasionally on macOS because GitHub's runners are underpowered causing the sector writes to get garbage collected before they are committed to the contract. This change adds the sectors to temp storage first so that they won't be garbage collected before appending them all to the contract.