### PR TITLE
Make max collateral a multiplier

### DIFF
--- a/.changeset/changed_max_collateral_to_a_multiplier_to_match_collateral_ie_if_maxcollateralmultiplier_is_100_a_contract_can_have_around_10tib_of_storage.md
+++ b/.changeset/changed_max_collateral_to_a_multiplier_to_match_collateral_ie_if_maxcollateralmultiplier_is_100_a_contract_can_have_around_10tib_of_storage.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Changed max collateral to a multiplier to match collateral. i.e. if `maxCollateralMultiplier` is 10.0, a contract can have around 10TiB of storage.

--- a/api/prometheus.go
+++ b/api/prometheus.go
@@ -121,8 +121,8 @@ func (hs HostSettings) PrometheusMetric() []prometheus.Metric {
 			Value: hs.CollateralMultiplier,
 		},
 		{
-			Name:  "hostd_settings_max_collateral",
-			Value: hs.MaxCollateral.Siacoins(),
+			Name:  "hostd_settings_max_collateral_multiplier",
+			Value: hs.MaxCollateralMultiplier,
 		},
 		{
 			Name:  "hostd_settings_pricetable_validity",

--- a/host/settings/announce.go
+++ b/host/settings/announce.go
@@ -114,7 +114,7 @@ func (m *ConfigManager) Announce() error {
 	if err != nil {
 		m.wallet.ReleaseInputs(nil, []types.V2Transaction{txn})
 		return fmt.Errorf("failed to create transaction set: %w", err)
-	} else if err := m.wallet.BroadcastV2TransactionSet(cs.Index, txnset); err != nil {
+	} else if err := m.wallet.BroadcastV2TransactionSet(basis, txnset); err != nil {
 		m.wallet.ReleaseInputs(nil, []types.V2Transaction{txn})
 		return fmt.Errorf("failed to add transaction to pool: %w", err)
 	}

--- a/host/settings/pin/pin.go
+++ b/host/settings/pin/pin.go
@@ -43,10 +43,6 @@ type (
 		Storage Pin `json:"storage"`
 		Ingress Pin `json:"ingress"`
 		Egress  Pin `json:"egress"`
-
-		// MaxCollateral is the maximum collateral that the host will
-		// accept in the external currency.
-		MaxCollateral Pin `json:"maxCollateral"`
 	}
 
 	// Alerts registers global alerts.
@@ -162,7 +158,7 @@ func (m *Manager) updatePrices(ctx context.Context, force bool) error {
 	}
 
 	// skip updating prices if the pinned settings are zero
-	if !m.settings.Storage.IsPinned() && !m.settings.Ingress.IsPinned() && !m.settings.Egress.IsPinned() && !m.settings.MaxCollateral.IsPinned() {
+	if !m.settings.Storage.IsPinned() && !m.settings.Ingress.IsPinned() && !m.settings.Egress.IsPinned() {
 		return nil
 	}
 
@@ -201,14 +197,6 @@ func (m *Manager) updatePrices(ctx context.Context, force bool) error {
 		settings.EgressPrice = value.Div64(1e12)
 	}
 
-	if m.settings.MaxCollateral.IsPinned() {
-		value, err := ConvertCurrencyToSC(decimal.NewFromFloat(m.settings.MaxCollateral.Value), avgRate)
-		if err != nil {
-			return fmt.Errorf("failed to convert max collateral: %w", err)
-		}
-		settings.MaxCollateral = value
-	}
-
 	if err := m.sm.UpdateSettings(settings); err != nil {
 		return fmt.Errorf("failed to update settings: %w", err)
 	}
@@ -236,8 +224,6 @@ func (m *Manager) Update(ctx context.Context, p PinnedSettings) error {
 		return fmt.Errorf("ingress price must be greater than 0")
 	case p.Egress.Pinned && p.Egress.Value <= 0:
 		return fmt.Errorf("egress price must be greater than 0")
-	case p.MaxCollateral.Pinned && p.MaxCollateral.Value <= 0:
-		return fmt.Errorf("max collateral must be greater than 0")
 	}
 
 	m.mu.Lock()

--- a/host/settings/pin/pin_test.go
+++ b/host/settings/pin/pin_test.go
@@ -67,15 +67,6 @@ func checkSettings(settings settings.Settings, pinned pin.PinnedSettings, expect
 			return fmt.Errorf("expected egress price %d, got %d", egressPrice, settings.EgressPrice)
 		}
 	}
-
-	if pinned.MaxCollateral.IsPinned() {
-		maxCollateral, err := pin.ConvertCurrencyToSC(decimal.NewFromFloat(pinned.MaxCollateral.Value), rate)
-		if err != nil {
-			return fmt.Errorf("failed to convert max collateral: %w", err)
-		} else if !maxCollateral.Equals(settings.MaxCollateral) {
-			return fmt.Errorf("expected max collateral %d, got %d", maxCollateral, settings.MaxCollateral)
-		}
-	}
 	return nil
 }
 
@@ -150,10 +141,6 @@ func TestPinnedFields(t *testing.T) {
 			Pinned: false,
 			Value:  1.0,
 		},
-		MaxCollateral: pin.Pin{
-			Pinned: false,
-			Value:  1.0,
-		},
 	}
 
 	// only storage is pinned
@@ -164,8 +151,6 @@ func TestPinnedFields(t *testing.T) {
 	currentSettings := sm.Settings()
 	if err := checkSettings(currentSettings, pin, 1); err != nil {
 		t.Fatal(err)
-	} else if !currentSettings.MaxCollateral.Equals(initialSettings.MaxCollateral) {
-		t.Fatalf("expected max collateral to be %d, got %d", initialSettings.MaxCollateral, currentSettings.MaxCollateral)
 	} else if !currentSettings.IngressPrice.Equals(initialSettings.IngressPrice) {
 		t.Fatalf("expected ingress price to be %d, got %d", initialSettings.IngressPrice, currentSettings.IngressPrice)
 	} else if !currentSettings.EgressPrice.Equals(initialSettings.EgressPrice) {
@@ -181,8 +166,6 @@ func TestPinnedFields(t *testing.T) {
 	currentSettings = sm.Settings()
 	if err := checkSettings(currentSettings, pin, 1); err != nil {
 		t.Fatal(err)
-	} else if !currentSettings.MaxCollateral.Equals(initialSettings.MaxCollateral) {
-		t.Fatalf("expected max collateral to be %d, got %d", initialSettings.MaxCollateral, currentSettings.MaxCollateral)
 	} else if !currentSettings.EgressPrice.Equals(initialSettings.EgressPrice) {
 		t.Fatalf("expected egress price to be %d, got %d", initialSettings.EgressPrice, currentSettings.EgressPrice)
 	}
@@ -195,16 +178,6 @@ func TestPinnedFields(t *testing.T) {
 
 	currentSettings = sm.Settings()
 	if err := checkSettings(currentSettings, pin, 1); err != nil {
-		t.Fatal(err)
-	} else if !currentSettings.MaxCollateral.Equals(initialSettings.MaxCollateral) {
-		t.Fatalf("expected max collateral to be %d, got %d", initialSettings.MaxCollateral, currentSettings.MaxCollateral)
-	}
-
-	// pin max collateral
-	pin.MaxCollateral.Pinned = true
-	if err := pm.Update(context.Background(), pin); err != nil {
-		t.Fatal(err)
-	} else if err := checkSettings(sm.Settings(), pin, 1); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -248,10 +221,6 @@ func TestAutomaticUpdate(t *testing.T) {
 			Value:  1.0,
 		},
 		Egress: pin.Pin{
-			Pinned: true,
-			Value:  1.0,
-		},
-		MaxCollateral: pin.Pin{
 			Pinned: true,
 			Value:  1.0,
 		},

--- a/internal/integration/rhp/v4/rhp4_test.go
+++ b/internal/integration/rhp/v4/rhp4_test.go
@@ -176,19 +176,22 @@ func TestFormContract(t *testing.T) {
 	testutil.MineAndSync(t, hn, w.Address(), int(n.MaturityDelay+20))
 
 	withTransports(t, hostKey, hn, func(t *testing.T, transport rhp4.TransportClient) {
+		const duration = 50
 		settings, err := rhp4.RPCSettings(context.Background(), transport)
 		if err != nil {
 			t.Fatal(err)
 		}
 
+		renterAllowance := types.Siacoins(100)
+		hostCollateral := settings.Prices.Collateral.Mul64(1 << 40).Mul64(duration) // ensure the host has collateral for 1 TB
+
 		fundAndSign := &fundAndSign{w, renterKey}
-		renterAllowance, hostCollateral := types.Siacoins(100), types.Siacoins(200)
 		result, err := rhp4.RPCFormContract(context.Background(), transport, cm, fundAndSign, cm.TipState(), settings.Prices, hostKey.PublicKey(), settings.WalletAddress, proto4.RPCFormContractParams{
 			RenterPublicKey: renterKey.PublicKey(),
 			RenterAddress:   w.Address(),
 			Allowance:       renterAllowance,
 			Collateral:      hostCollateral,
-			ProofHeight:     cm.Tip().Height + 50,
+			ProofHeight:     cm.Tip().Height + duration,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1267,8 +1267,9 @@ components:
         collateralMultiplier:
           type: number
           format: double
-        maxCollateral:
-          $ref: "#/components/schemas/Currency"
+        maxCollateralMultiplier:
+          type: number
+          format: double
         storagePrice:
           $ref: "#/components/schemas/Currency"
         egressPrice:

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -242,12 +242,12 @@ CREATE TABLE host_settings (
 	contract_price BLOB NOT NULL,
 	base_rpc_price BLOB NOT NULL,
 	sector_access_price BLOB NOT NULL,
-	max_collateral BLOB NOT NULL,
 	storage_price BLOB NOT NULL,
 	egress_price BLOB NOT NULL,
 	ingress_price BLOB NOT NULL,
 	max_account_balance BLOB NOT NULL,
 	collateral_multiplier REAL NOT NULL,
+	max_collateral_multiplier REAL NOT NULL DEFAULT 10.0,
 	max_account_age INTEGER NOT NULL,
 	price_table_validity INTEGER NOT NULL,
 	max_contract_duration INTEGER NOT NULL,
@@ -271,9 +271,7 @@ CREATE TABLE host_pinned_settings (
 	ingress_pinned BOOLEAN NOT NULL,
 	ingress_price REAL NOT NULL,
 	egress_pinned BOOLEAN NOT NULL,
-	egress_price REAL NOT NULL,
-	max_collateral_pinned BOOLEAN NOT NULL,
-	max_collateral REAL NOT NULL
+	egress_price REAL NOT NULL
 );
 
 CREATE TABLE webhooks (

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -12,6 +12,17 @@ import (
 	"go.uber.org/zap"
 )
 
+// migrateVersion46 changes max collateral to be a multiplier of collateral
+// instead of a fixed value.
+func migrateVersion46(tx *txn, _ *zap.Logger) error {
+	const query = `ALTER TABLE host_settings ADD COLUMN max_collateral_multiplier REAL NOT NULL DEFAULT 10.0;
+ALTER TABLE host_settings DROP COLUMN max_collateral;
+ALTER TABLE host_pinned_settings DROP COLUMN max_collateral;
+ALTER TABLE host_pinned_settings DROP COLUMN max_collateral_pinned;`
+	_, err := tx.Exec(query)
+	return err
+}
+
 // migrateVersion45 cleans up unresolved v1 contracts since they will never complete
 // and v1 support has been removed.
 func migrateVersion45(tx *txn, log *zap.Logger) error {
@@ -1161,4 +1172,5 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion43,
 	migrateVersion44,
 	migrateVersion45,
+	migrateVersion46,
 }

--- a/persist/sqlite/settings_test.go
+++ b/persist/sqlite/settings_test.go
@@ -19,34 +19,33 @@ import (
 
 func randomSettings() settings.Settings {
 	return settings.Settings{
-		AcceptingContracts:   frand.Intn(1) == 1,
-		NetAddress:           hex.EncodeToString(frand.Bytes(64)),
-		MaxContractDuration:  uint64(frand.Intn(math.MaxInt)),
-		ContractPrice:        types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
-		BaseRPCPrice:         types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
-		SectorAccessPrice:    types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
-		CollateralMultiplier: frand.Float64(),
-		MaxCollateral:        types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
-		StoragePrice:         types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
-		EgressPrice:          types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
-		IngressPrice:         types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
-		IngressLimit:         uint64(frand.Intn(math.MaxInt)),
-		EgressLimit:          uint64(frand.Intn(math.MaxInt)),
-		MaxRegistryEntries:   uint64(frand.Intn(math.MaxInt)),
-		AccountExpiry:        time.Duration(frand.Intn(math.MaxInt)),
-		PriceTableValidity:   time.Duration(frand.Intn(math.MaxInt)),
-		MaxAccountBalance:    types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
+		AcceptingContracts:      frand.Intn(1) == 1,
+		NetAddress:              hex.EncodeToString(frand.Bytes(64)),
+		MaxContractDuration:     uint64(frand.Intn(math.MaxInt)),
+		ContractPrice:           types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
+		BaseRPCPrice:            types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
+		SectorAccessPrice:       types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
+		CollateralMultiplier:    frand.Float64(),
+		MaxCollateralMultiplier: frand.Float64(),
+		StoragePrice:            types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
+		EgressPrice:             types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
+		IngressPrice:            types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
+		IngressLimit:            uint64(frand.Intn(math.MaxInt)),
+		EgressLimit:             uint64(frand.Intn(math.MaxInt)),
+		MaxRegistryEntries:      uint64(frand.Intn(math.MaxInt)),
+		AccountExpiry:           time.Duration(frand.Intn(math.MaxInt)),
+		PriceTableValidity:      time.Duration(frand.Intn(math.MaxInt)),
+		MaxAccountBalance:       types.NewCurrency(frand.Uint64n(math.MaxUint64), frand.Uint64n(math.MaxUint64)),
 	}
 }
 
 func randomPinnedSettings() pin.PinnedSettings {
 	return pin.PinnedSettings{
-		Currency:      hex.EncodeToString(frand.Bytes(3)),
-		Threshold:     frand.Float64(),
-		Storage:       pin.Pin{Pinned: frand.Intn(1) == 1, Value: frand.Float64()},
-		Ingress:       pin.Pin{Pinned: frand.Intn(1) == 1, Value: frand.Float64()},
-		Egress:        pin.Pin{Pinned: frand.Intn(1) == 1, Value: frand.Float64()},
-		MaxCollateral: pin.Pin{Pinned: frand.Intn(1) == 1, Value: frand.Float64()},
+		Currency:  hex.EncodeToString(frand.Bytes(3)),
+		Threshold: frand.Float64(),
+		Storage:   pin.Pin{Pinned: frand.Intn(1) == 1, Value: frand.Float64()},
+		Ingress:   pin.Pin{Pinned: frand.Intn(1) == 1, Value: frand.Float64()},
+		Egress:    pin.Pin{Pinned: frand.Intn(1) == 1, Value: frand.Float64()},
 	}
 }
 


### PR DESCRIPTION
This version is draft because it will currently fail RHP4 tests because it treats max collateral as a TB/byte/block like storage price and collateral instead of as a fixed absolute value. If we want to continue down this path, we will need to similarly change the RHP4 validation and bump the protocol version.

Alternatively, we can calculate the actual max collateral value as described in the issue and assume `max contract duration`.

Fixes #857 