### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -1290,12 +1290,11 @@ func BenchmarkNewVolume(b *testing.B) {
 	}
 	defer vm.Close()
 
-	b.ResetTimer()
 	b.ReportMetric(float64(sectors), "sectors")
 	b.SetBytes(sectors * proto4.SectorSize)
 
 	result := make(chan error, 1)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		volumeFilePath := filepath.Join(b.TempDir(), "hostdata.dat")
 		_, err = vm.AddVolume(context.Background(), volumeFilePath, sectors, result)
 		if err != nil {


### PR DESCRIPTION
These changes use b.Loop() to simplify the code and improve performance
Supported by Go Team, more info: https://go.dev/blog/testing-b-loop 


The time spent reduced from 113 seconds to 40 seconds.

Before:

```shell
 go test -run=^$ -bench=. ./host/storage                 
goos: darwin
goarch: arm64
pkg: go.sia.tech/hostd/v2/host/storage
cpu: Apple M4
BenchmarkVolumeManagerWrite-10    	     291	  11018505 ns/op	 380.66 MB/s	 4209097 B/op	     243 allocs/op
--- BENCH: BenchmarkVolumeManagerWrite-10
    logger.go:146: 2025-12-02T14:05:50.835+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeManagerWrite2110768909/001/hostd.db"}
    logger.go:146: 2025-12-02T14:05:50.837+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 1, "current": 0}
    logger.go:146: 2025-12-02T14:05:50.845+0800	DEBUG	volumes	wrote sector	{"root": "08c977f29686a2990c0380840fc811844c2853a8a1785cbbe4a5fa54676defb6", "volume": 1, "index": 0, "elapsed": "861.875µs"}
    logger.go:146: 2025-12-02T14:05:50.885+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeManagerWrite1918091699/003/hostd.db"}
    logger.go:146: 2025-12-02T14:05:50.886+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 33, "current": 0}
    logger.go:146: 2025-12-02T14:05:51.013+0800	DEBUG	volumes	wrote sector	{"root": "af71db78bf36c0d276656bc39c8cc2c1ad6631d86652c9d0dbd5eea741dc1900", "volume": 1, "index": 0, "elapsed": "674.583µs"}
    logger.go:146: 2025-12-02T14:05:51.014+0800	DEBUG	volumes	wrote sector	{"root": "c8de9b88e6bca52bcef31f7940b2bafd02af48dc299d81edd0ba628b19608a20", "volume": 1, "index": 1, "elapsed": "740.625µs"}
    logger.go:146: 2025-12-02T14:05:51.017+0800	DEBUG	volumes	wrote sector	{"root": "9c7bf6bd651d76b20096cacf6c2523c4625a28b890443b1f964d034353b14a26", "volume": 1, "index": 2, "elapsed": "1.904958ms"}
    logger.go:146: 2025-12-02T14:05:51.022+0800	DEBUG	volumes	wrote sector	{"root": "d1831b5d5656d52332b3a04866d81d3e66a994f09e57a7ce1b20ac1d793eebc0", "volume": 1, "index": 3, "elapsed": "3.09875ms"}
    logger.go:146: 2025-12-02T14:05:51.025+0800	DEBUG	volumes	wrote sector	{"root": "a159f619335cc06c1b0f577aef6b2868a0d8df0964aff1f5d8a9ea4a09844dd3", "volume": 1, "index": 4, "elapsed": "1.952875ms"}
	... [output truncated]
BenchmarkNewVolume-10             	     248	   4810012 ns/op	87199.44 MB/s	       100.0 sectors
--- BENCH: BenchmarkNewVolume-10
    logger.go:146: 2025-12-02T14:05:55.970+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkNewVolume4017660232/001/hostd.db"}
    logger.go:146: 2025-12-02T14:05:55.970+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 100, "current": 0}
    logger.go:146: 2025-12-02T14:05:55.972+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 100, "current": 64}
    logger.go:146: 2025-12-02T14:05:55.997+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkNewVolume4218463617/003/hostd.db"}
    logger.go:146: 2025-12-02T14:05:55.998+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 100, "current": 0}
    logger.go:146: 2025-12-02T14:05:55.999+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 100, "current": 64}
    logger.go:146: 2025-12-02T14:05:56.001+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 2, "start": 0, "end": 100, "current": 0}
    logger.go:146: 2025-12-02T14:05:56.002+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 2, "start": 0, "end": 100, "current": 64}
    logger.go:146: 2025-12-02T14:05:56.005+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 3, "start": 0, "end": 100, "current": 0}
    logger.go:146: 2025-12-02T14:05:56.006+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 3, "start": 0, "end": 100, "current": 64}
	... [output truncated]
BenchmarkVolumeManagerRead-10     	     972	   7109178 ns/op	 589.98 MB/s	 4201748 B/op	     107 allocs/op
--- BENCH: BenchmarkVolumeManagerRead-10
    logger.go:146: 2025-12-02T14:05:57.517+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeManagerRead3140823464/001/hostd.db"}
    logger.go:146: 2025-12-02T14:05:57.519+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 1, "current": 0}
    logger.go:146: 2025-12-02T14:05:57.525+0800	DEBUG	volumes	wrote sector	{"root": "369206a82fc3c7769418696c6172ffdf18c7c91353b8ca54808e8d6a0dd08b1c", "volume": 1, "index": 0, "elapsed": "592.541µs"}
    logger.go:146: 2025-12-02T14:05:57.550+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeManagerRead860202920/003/hostd.db"}
    logger.go:146: 2025-12-02T14:05:57.551+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 72, "current": 0}
    logger.go:146: 2025-12-02T14:05:57.552+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 72, "current": 64}
    logger.go:146: 2025-12-02T14:05:57.558+0800	DEBUG	volumes	wrote sector	{"root": "7e54f8bd89d9f0c40564b1255e4d805ecd4afb35f22b14f2c43af18eff834ee2", "volume": 1, "index": 0, "elapsed": "583.666µs"}
    logger.go:146: 2025-12-02T14:05:57.562+0800	DEBUG	volumes	wrote sector	{"root": "680ca3450c88c3f1647f088b705b5c4db57a17c20b2d879075c5dbbef1f21405", "volume": 1, "index": 1, "elapsed": "671.792µs"}
    logger.go:146: 2025-12-02T14:05:57.567+0800	DEBUG	volumes	wrote sector	{"root": "fbb4501e203946e91daec12876f569395afbcdc1b3f723124a4d9efe3a946ba5", "volume": 1, "index": 2, "elapsed": "953.834µs"}
    logger.go:146: 2025-12-02T14:05:57.573+0800	DEBUG	volumes	wrote sector	{"root": "c2190ba89508289b2be885d1692f14909c38d5a5ac03eaedf0b821dcc555e10d", "volume": 1, "index": 3, "elapsed": "684.25µs"}
	... [output truncated]
BenchmarkVolumeRemove-10          	       9	 114777907 ns/op	  36.54 MB/s	 4219105 B/op	     439 allocs/op
--- BENCH: BenchmarkVolumeRemove-10
    logger.go:146: 2025-12-02T14:07:37.983+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeRemove500854621/001/hostd.db"}
    logger.go:146: 2025-12-02T14:07:37.984+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 1, "current": 0}
    logger.go:146: 2025-12-02T14:07:37.991+0800	DEBUG	volumes	wrote sector	{"root": "501b97cd608fb118746efb3ab256d78ecc5ebad2587061b400447a696f9acbbc", "volume": 1, "index": 0, "elapsed": "337.291µs"}
    logger.go:146: 2025-12-02T14:07:37.992+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 2, "start": 0, "end": 1, "current": 0}
    logger.go:146: 2025-12-02T14:07:38.008+0800	DEBUG	sqlite.migrate	migrated sector	{"startIndex": 0, "fromIndex": 0, "fromVolume": 1, "toIndex": 0, "toVolume": 2, "root": "501b97cd608fb118746efb3ab256d78ecc5ebad2587061b400447a696f9acbbc"}
    logger.go:146: 2025-12-02T14:07:38.066+0800	DEBUG	sqlite.RemoveVolume	removed volume sectors	{"volume": 1, "force": false, "batch": 0, "removed": 1, "lost": 0}
    logger.go:146: 2025-12-02T14:07:38.142+0800	DEBUG	sqlite.RemoveVolume	removed volume sectors	{"volume": 1, "force": false, "batch": 1, "removed": 0, "lost": 0}
    logger.go:146: 2025-12-02T14:07:38.535+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeRemove301779401/004/hostd.db"}
    logger.go:146: 2025-12-02T14:07:38.538+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 2, "current": 0}
    logger.go:146: 2025-12-02T14:07:38.546+0800	DEBUG	volumes	wrote sector	{"root": "15efa009045c69167c21a5a60168765b1feddac4a73e90a94c91d75e5e5a856d", "volume": 1, "index": 0, "elapsed": "501.833µs"}
	... [output truncated]
PASS
ok  	go.sia.tech/hostd/v2/host/storage	113.012s
```

After:

```shell
  go test -run=^$ -bench=. ./host/storage           
goos: darwin
goarch: arm64
pkg: go.sia.tech/hostd/v2/host/storage
cpu: Apple M4
BenchmarkVolumeManagerWrite-10    	     160	   6979683 ns/op	 600.93 MB/s	 4209109 B/op	     242 allocs/op
--- BENCH: BenchmarkVolumeManagerWrite-10
    logger.go:146: 2025-12-02T14:03:26.294+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeManagerWrite448245110/001/hostd.db"}
    logger.go:146: 2025-12-02T14:03:26.295+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 1, "current": 0}
    logger.go:146: 2025-12-02T14:03:26.305+0800	DEBUG	volumes	wrote sector	{"root": "4e6bd7689d3339f614e2c0fb00489c68a90e352947259f6f4037125d6ab9b942", "volume": 1, "index": 0, "elapsed": "1.291417ms"}
    logger.go:146: 2025-12-02T14:03:26.330+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeManagerWrite920832468/003/hostd.db"}
    logger.go:146: 2025-12-02T14:03:26.331+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 52, "current": 0}
    logger.go:146: 2025-12-02T14:03:26.538+0800	DEBUG	volumes	wrote sector	{"root": "e99e88feb121e75b189d31bfe8766841356c30f2e67a0065bce9ebc2d1e9ebb7", "volume": 1, "index": 0, "elapsed": "852.667µs"}
    logger.go:146: 2025-12-02T14:03:26.540+0800	DEBUG	volumes	wrote sector	{"root": "783964efd830b4764f730e2337968970304cc6835409fa39702cdceff0d0a3c5", "volume": 1, "index": 1, "elapsed": "844.958µs"}
    logger.go:146: 2025-12-02T14:03:26.545+0800	DEBUG	volumes	wrote sector	{"root": "4f4c790c319c33422822f0e8c26cb769af644e9f2597305bcdc528aa0f7418de", "volume": 1, "index": 2, "elapsed": "4.479084ms"}
    logger.go:146: 2025-12-02T14:03:26.555+0800	DEBUG	volumes	wrote sector	{"root": "87247787b5173405c324a95e4f061a1dfd34b930215bf16699b70f313efc81d5", "volume": 1, "index": 3, "elapsed": "9.584834ms"}
    logger.go:146: 2025-12-02T14:03:26.562+0800	DEBUG	volumes	wrote sector	{"root": "9c40c8639356a3ae88f406e10440e86157192e4dce8fe0a8dee428caef707575", "volume": 1, "index": 4, "elapsed": "6.18125ms"}
	... [output truncated]
BenchmarkNewVolume-10             	     314	   4408931 ns/op	95131.99 MB/s
--- BENCH: BenchmarkNewVolume-10
    logger.go:146: 2025-12-02T14:03:29.998+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkNewVolume2641622462/001/hostd.db"}
    logger.go:146: 2025-12-02T14:03:29.998+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 100, "current": 0}
    logger.go:146: 2025-12-02T14:03:30.000+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 100, "current": 64}
    logger.go:146: 2025-12-02T14:03:30.002+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 2, "start": 0, "end": 100, "current": 0}
    logger.go:146: 2025-12-02T14:03:30.003+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 2, "start": 0, "end": 100, "current": 64}
    logger.go:146: 2025-12-02T14:03:30.005+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 3, "start": 0, "end": 100, "current": 0}
    logger.go:146: 2025-12-02T14:03:30.006+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 3, "start": 0, "end": 100, "current": 64}
    logger.go:146: 2025-12-02T14:03:30.008+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 4, "start": 0, "end": 100, "current": 0}
    logger.go:146: 2025-12-02T14:03:30.010+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 4, "start": 0, "end": 100, "current": 64}
    logger.go:146: 2025-12-02T14:03:30.011+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 5, "start": 0, "end": 100, "current": 0}
	... [output truncated]
BenchmarkVolumeManagerRead-10     	
     662	   6311608 ns/op	 664.54 MB/s	 4201745 B/op	     107 allocs/op
--- BENCH: BenchmarkVolumeManagerRead-10
    logger.go:146: 2025-12-02T14:03:31.436+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeManagerRead2057148405/001/hostd.db"}
    logger.go:146: 2025-12-02T14:03:31.437+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 1, "current": 0}
    logger.go:146: 2025-12-02T14:03:31.442+0800	DEBUG	volumes	wrote sector	{"root": "5bf3dcf2fbe96ce74f1c1360265eb062e6a90fcabb916c5ea869115816e491be", "volume": 1, "index": 0, "elapsed": "390.458µs"}
    logger.go:146: 2025-12-02T14:03:31.463+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeManagerRead55583470/003/hostd.db"}
    logger.go:146: 2025-12-02T14:03:31.464+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 72, "current": 0}
    logger.go:146: 2025-12-02T14:03:31.465+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 72, "current": 64}
    logger.go:146: 2025-12-02T14:03:31.472+0800	DEBUG	volumes	wrote sector	{"root": "3653daf08350f0f5207f84c325812908320b0f9770efbfd5e7d7a0cf1a9402ea", "volume": 1, "index": 0, "elapsed": "641.791µs"}
    logger.go:146: 2025-12-02T14:03:31.478+0800	DEBUG	volumes	wrote sector	{"root": "d87edf355f1e563d80a4b9af82a2b7dc1825323c72bcf4fe2b1ed60edf4286a1", "volume": 1, "index": 1, "elapsed": "635.375µs"}
    logger.go:146: 2025-12-02T14:03:31.484+0800	DEBUG	volumes	wrote sector	{"root": "6938ba4743871ad835e9cd4604f5c21cbd29c4abd5ced6fc559412d88f6cf44d", "volume": 1, "index": 2, "elapsed": "1.835375ms"}
    logger.go:146: 2025-12-02T14:03:31.489+0800	DEBUG	volumes	wrote sector	{"root": "b63b16a3945c6b9f6b1ca636d684c1657c1c777ee1ea27c6ede73510e7176cbd", "volume": 1, "index": 3, "elapsed": "767µs"}
	... [output truncated]
BenchmarkVolumeRemove-10          	      12	  93295240 ns/op	  44.96 MB/s	 4216980 B/op	     415 allocs/op
--- BENCH: BenchmarkVolumeRemove-10
    logger.go:146: 2025-12-02T14:04:01.935+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeRemove2884677431/001/hostd.db"}
    logger.go:146: 2025-12-02T14:04:01.936+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 1, "current": 0}
    logger.go:146: 2025-12-02T14:04:01.943+0800	DEBUG	volumes	wrote sector	{"root": "f193906e2111d503c88b41a875d382d7f3b0c7b421b1943e08ed2a6394b40e95", "volume": 1, "index": 0, "elapsed": "1.318917ms"}
    logger.go:146: 2025-12-02T14:04:01.943+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 2, "start": 0, "end": 1, "current": 0}
    logger.go:146: 2025-12-02T14:04:01.978+0800	DEBUG	sqlite.migrate	migrated sector	{"startIndex": 0, "fromIndex": 0, "fromVolume": 1, "toIndex": 0, "toVolume": 2, "root": "f193906e2111d503c88b41a875d382d7f3b0c7b421b1943e08ed2a6394b40e95"}
    logger.go:146: 2025-12-02T14:04:02.037+0800	DEBUG	sqlite.RemoveVolume	removed volume sectors	{"volume": 1, "force": false, "batch": 0, "removed": 1, "lost": 0}
    logger.go:146: 2025-12-02T14:04:02.090+0800	DEBUG	sqlite.RemoveVolume	removed volume sectors	{"volume": 1, "force": false, "batch": 1, "removed": 0, "lost": 0}
    logger.go:146: 2025-12-02T14:04:02.131+0800	DEBUG	sqlite	database initialized	{"sqliteVersion": "3.50.4", "schemaVersion": 45, "path": "/var/folders/tq/m955dwkd1519phkp2hwpv9_80000gn/T/BenchmarkVolumeRemove3977465515/004/hostd.db"}
    logger.go:146: 2025-12-02T14:04:02.132+0800	DEBUG	volumes.grow	expanded volume	{"volumeID": 1, "start": 0, "end": 6, "current": 0}
    logger.go:146: 2025-12-02T14:04:02.139+0800	DEBUG	volumes	wrote sector	{"root": "9d44be156c3cd0cb147d19d024f8bb711479f17ffdc7fd52ae4d535b58ae3373", "volume": 1, "index": 0, "elapsed": "437.083µs"}
	... [output truncated]
PASS
ok  	go.sia.tech/hostd/v2/host/storage	40.820s
```



