### PR TITLE
Optimistically cache during write rpc

### DIFF
--- a/.changeset/cache_sector_subtrees_to_reduce_disk_io_for_partial_reads.md
+++ b/.changeset/cache_sector_subtrees_to_reduce_disk_io_for_partial_reads.md
@@ -3,3 +3,5 @@ default: minor
 ---
 
 # Cache sector subtrees to reduce disk IO for partial reads.
+
+This change reduces the minimum read size from 4MiB to 4KiB when reading segments of a sector


### PR DESCRIPTION
Previously sector subtrees would only be cached the first time the sector was read from disk. This can still cause large unnecessary disk IO for new sectors. This changes that to cache them in a goroutine during write.