### PR TITLE
Fix backup endpoint lockups

### DIFF
--- a/.changeset/fixed_an_issue_with_the_backup_api_locking_up_the_host.md
+++ b/.changeset/fixed_an_issue_with_the_backup_api_locking_up_the_host.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed an issue with the backup endpoint locking up the host.

--- a/persist/sqlite/store_test.go
+++ b/persist/sqlite/store_test.go
@@ -174,7 +174,7 @@ func TestBackup(t *testing.T) {
 
 	t.Run("Store.Backup", func(t *testing.T) {
 		destPath := filepath.Join(t.TempDir(), "backup.db")
-		if err := Backup(context.Background(), srcPath, destPath); err != nil {
+		if err := db.Backup(context.Background(), destPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -183,7 +183,7 @@ func TestBackup(t *testing.T) {
 
 	t.Run("Backup", func(t *testing.T) {
 		destPath := filepath.Join(t.TempDir(), "backup.db")
-		if err := db.Backup(context.Background(), destPath); err != nil {
+		if err := Backup(context.Background(), srcPath, destPath); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
The open database sets max open conns to 1. This causes the backup API to lockup the host and never complete. This PR fixes that by opening a new read only conn to the database for the backup to use.