### PR TITLE
Consider contracts for checkpoint

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -78,6 +78,12 @@ func (e *Explorer) AddressCheckpoint(ctx context.Context, address types.Address)
 	return
 }
 
+// TipHeight returns the chain index at the given height.
+func (e *Explorer) TipHeight(ctx context.Context, height uint64) (index types.ChainIndex, err error) {
+	err = makeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/consensus/tip/%d", e.url, height), nil, &index)
+	return
+}
+
 // New returns a new Explorer client.
 func New(url string) *Explorer {
 	return &Explorer{url: url}


### PR DESCRIPTION
Currently if a host with existing contracts instant syncs, it can leave their contracts in a bad state if the checkpoint is before their first v2 contract. This adjusts the checkpoint based on the negotiation height of the first active or pending contract.