### PR TITLE
Write permissions for openapi sync

### DIFF
--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -1,7 +1,7 @@
 name: Sync OpenAPI Versions
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:


### PR DESCRIPTION
Needed due to [this](https://github.com/SiaFoundation/workflows/blob/8a0a491a22271d67452103684699cfb2d4aaa56e/.github/workflows/sync-openapi-version.yml#L16)