### PR TITLE
Reset chain state on instant sync

### DIFF
--- a/cmd/hostd/run.go
+++ b/cmd/hostd/run.go
@@ -304,7 +304,9 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 		}
 		log.Debug("retrieved checkpoint")
 
-		if err := store.SetCheckpoint(checkpoint); err != nil {
+		if err := store.ResetChainState(); err != nil {
+			return fmt.Errorf("failed to reset chain state: %w", err)
+		} else if err := store.SetCheckpoint(checkpoint); err != nil {
 			return fmt.Errorf("failed to set checkpoint in store: %w", err)
 		}
 


### PR DESCRIPTION
Fixes a potential edge case when instant syncing an existing node that causes a panic by removing any existing state elements.

```
panic: runtime error: slice bounds out of range [27:10]

goroutine 196 [running]:
go.sia.tech/core/consensus.updateProof(0x0?, 0xac7858?)
	go.sia.tech/core@v0.19.0/consensus/merkle.go:445 +0x2f1
go.sia.tech/core/consensus.(*elementApplyUpdate).updateElementProof(0xc000ac7980, 0xc004182028)
	go.sia.tech/core@v0.19.0/consensus/merkle.go:465 +0x77
go.sia.tech/core/consensus.ApplyUpdate.UpdateElementProof(...)
	go.sia.tech/core@v0.19.0/consensus/application.go:778
go.sia.tech/hostd/v2/persist/sqlite.(*updateTx).UpdateChainIndexElementProofs(0xc0045e2050, {0x1d24920, 0xc002bb6808})
	go.sia.tech/hostd/v2/persist/sqlite/consensus.go:238 +0x9d
go.sia.tech/hostd/v2/host/contracts.(*Manager).UpdateChainState(0xc000154000, {0x7fee70600b98, 0xc0045e2050}, {0x0, 0x0, 0x7feec143c108?}, {0xc005dca000, 0x64, 0xc0045e2050?})
	go.sia.tech/hostd/v2/host/contracts/update.go:480 +0xa8b
go.sia.tech/hostd/v2/index.(*Manager).syncDB.func1({0x1d38050, 0xc0045e2050})
	go.sia.tech/hostd/v2/index/update.go:60 +0x165
go.sia.tech/hostd/v2/persist/sqlite.(*Store).UpdateChainState.func1(0xc0045e2030)
	go.sia.tech/hostd/v2/persist/sqlite/consensus.go:504 +0x5c
go.sia.tech/hostd/v2/persist/sqlite.doTransaction(0xc000d7ad00?, 0xc000d7ad80, 0xc000acc878)
	go.sia.tech/hostd/v2/persist/sqlite/store.go:113 +0x17f
go.sia.tech/hostd/v2/persist/sqlite.(*Store).transaction(0xc00049a140, 0xc000acc878)
	go.sia.tech/hostd/v2/persist/sqlite/store.go:51 +0x485
go.sia.tech/hostd/v2/persist/sqlite.(*Store).UpdateChainState(0x87c23?, 0x200000000000000?)
	go.sia.tech/hostd/v2/persist/sqlite/consensus.go:503 +0x29
go.sia.tech/hostd/v2/index.(*Manager).syncDB(0xc00043e0a0, {0x1d2fdb0, 0xc00012a000})
	go.sia.tech/hostd/v2/index/update.go:57 +0x297
go.sia.tech/hostd/v2/index.NewManager.func2()
	go.sia.tech/hostd/v2/index/manager.go:153 +0x248
created by go.sia.tech/hostd/v2/index.NewManager in goroutine 1
	go.sia.tech/hostd/v2/index/manager.go:138 +0x4cb
```

note: I'm not going to add a changeset since this is a failure in a newly added feature.