### PR TITLE
Constant time contract renewals and refreshes

### DIFF
--- a/.changeset/contract_renewals_and_refreshes_are_now_constant_time_and_do_not_need_to_lock_the_database_for_a_significant_amount_of_time.md
+++ b/.changeset/contract_renewals_and_refreshes_are_now_constant_time_and_do_not_need_to_lock_the_database_for_a_significant_amount_of_time.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Contract renewals and refreshes are now constant time and do not need duplicate sector roots

--- a/host/contracts/manager.go
+++ b/host/contracts/manager.go
@@ -3,7 +3,6 @@ package contracts
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"math"
 	"sync"
 	"time"
@@ -331,7 +330,7 @@ func (cm *Manager) RenewV2Contract(renewal rhp4.TransactionSet, usage proto4.Usa
 		Usage:             usage,
 	}
 
-	if err := cm.store.RenewV2Contract(contract, renewal, existingID, existingRoots); err != nil {
+	if err := cm.store.RenewV2Contract(contract, renewal, existingID); err != nil {
 		return err
 	}
 	cm.setSectorRoots(contract.ID, existingRoots)
@@ -387,17 +386,11 @@ func NewManager(store ContractStore, storage StorageManager, chain ChainManager,
 	}
 
 	start := time.Now()
-	roots, err := store.SectorRoots()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get sector roots: %w", err)
-	}
 
-	v2Roots, err := store.V2SectorRoots()
+	roots, err := store.V2SectorRoots()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get v2 sector roots: %w", err)
 	}
-
-	maps.Copy(roots, v2Roots)
 
 	cm.sectorRoots = roots
 	cm.log.Debug("loaded sector roots", zap.Duration("elapsed", time.Since(start)))

--- a/host/contracts/manager_test.go
+++ b/host/contracts/manager_test.go
@@ -1837,6 +1837,67 @@ func TestV2SectorRootConsistency(t *testing.T) {
 		_ = renewalFC
 	})
 
+	t.Run("renewal replaces inherited sector", func(t *testing.T) {
+		// form contract with sectors, renew, then replace an inherited
+		// sector on the renewal. The replaced sector should be returned
+		// correctly, not the old one from the previous revision.
+		contractID, fc := formV2Contract(t, node.Chain, node.Contracts, node.Wallet, renterKey, hostKey, types.Siacoins(10), types.Siacoins(20), 10, true)
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		var roots []types.Hash256
+		for range 3 {
+			fc, roots = appendSector(t, contractID, fc, roots)
+		}
+		assertRoots(t, contractID, roots)
+		assertDBRoots(t, contractID, roots)
+
+		renewalID, renewalFC, renewalTxnSet, renewalUsage := renewContract(t, contractID, fc, types.ZeroCurrency, types.Siacoins(2))
+		if _, err := node.Chain.AddV2PoolTransactions(renewalTxnSet.Basis, renewalTxnSet.Transactions); err != nil {
+			t.Fatal(err)
+		} else if err := node.Contracts.RenewV2Contract(renewalTxnSet, renewalUsage); err != nil {
+			t.Fatal(err)
+		}
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		// replace sector at index 0 on the renewal
+		var replacementSector [proto4.SectorSize]byte
+		frand.Read(replacementSector[:])
+		replacementRoot := proto4.SectorRoot(&replacementSector)
+		if err := node.Volumes.StoreSector(replacementRoot, &replacementSector, 1); err != nil {
+			t.Fatal(err)
+		}
+
+		roots[0] = replacementRoot
+		renewalFC.Filesize = proto4.SectorSize * uint64(len(roots))
+		renewalFC.Capacity = proto4.SectorSize * uint64(len(roots))
+		renewalFC.FileMerkleRoot = proto4.MetaRoot(roots)
+		renewalFC.RevisionNumber++
+		cost, collateral := types.Siacoins(1), types.Siacoins(2)
+		renewalFC.RenterOutput.Value = renewalFC.RenterOutput.Value.Sub(cost)
+		renewalFC.HostOutput.Value = renewalFC.HostOutput.Value.Add(cost)
+		renewalFC.MissedHostValue = renewalFC.MissedHostValue.Sub(collateral)
+		sigHash := node.Chain.TipState().ContractSigHash(renewalFC)
+		renewalFC.HostSignature = hostKey.SignHash(sigHash)
+		renewalFC.RenterSignature = renterKey.SignHash(sigHash)
+		if err := node.Contracts.ReviseV2Contract(renewalID, renewalFC, roots, proto4.Usage{
+			Storage:          cost,
+			RiskedCollateral: collateral,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		assertRoots(t, renewalID, roots)
+		assertDBRoots(t, renewalID, roots)
+
+		// expire everything
+		renewal, err := node.Contracts.V2Contract(renewalID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		testutil.MineAndSync(t, node, types.VoidAddress, int(renewal.ExpirationHeight-node.Chain.Tip().Height)+1)
+		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+	})
+
 	t.Run("empty contract no sectors", func(t *testing.T) {
 		// form and confirm a contract with no sectors, then expire it.
 		// Roots should always be empty.

--- a/host/contracts/manager_test.go
+++ b/host/contracts/manager_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -92,66 +91,6 @@ func mineEmptyBlock(state consensus.State, minerAddr types.Address) types.Block 
 		panic(fmt.Sprintf("failed to mine empty block at height %d", state.Index.Height+1))
 	}
 	return b
-}
-
-func TestContractLockUnlock(t *testing.T) {
-	hostKey := types.NewPrivateKeyFromSeed(frand.Bytes(32))
-	renterKey := types.NewPrivateKeyFromSeed(frand.Bytes(32))
-
-	log := zaptest.NewLogger(t)
-	network, genesis := testutil.V1Network()
-	node := testutil.NewHostNode(t, hostKey, network, genesis, log)
-
-	contractUnlockConditions := types.UnlockConditions{
-		PublicKeys: []types.UnlockKey{
-			renterKey.PublicKey().UnlockKey(),
-			hostKey.PublicKey().UnlockKey(),
-		},
-		SignaturesRequired: 2,
-	}
-	rev := contracts.SignedRevision{
-		Revision: types.FileContractRevision{
-			FileContract: types.FileContract{
-				UnlockHash:  contractUnlockConditions.UnlockHash(),
-				WindowStart: 100,
-				WindowEnd:   200,
-			},
-			ParentID:         frand.Entropy256(),
-			UnlockConditions: contractUnlockConditions,
-		},
-	}
-
-	if err := node.Contracts.AddContract(rev, []types.Transaction{}, types.ZeroCurrency, contracts.Usage{}); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := node.Contracts.Lock(context.Background(), rev.Revision.ParentID); err != nil {
-		t.Fatal(err)
-	}
-
-	err := func() error {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		_, err := node.Contracts.Lock(ctx, rev.Revision.ParentID)
-		return err
-	}()
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatal("expected context deadline exceeded, got", err)
-	}
-
-	node.Contracts.Unlock(rev.Revision.ParentID)
-
-	var wg sync.WaitGroup
-	for range 50 {
-		wg.Go(func() {
-			if _, err := node.Contracts.Lock(context.Background(), rev.Revision.ParentID); err != nil {
-				t.Error(err)
-			}
-			time.Sleep(100 * time.Millisecond)
-			node.Contracts.Unlock(rev.Revision.ParentID)
-		})
-	}
-	wg.Wait()
 }
 
 func TestV2ContractLifecycle(t *testing.T) {
@@ -518,9 +457,8 @@ func TestV2ContractLifecycle(t *testing.T) {
 		assertContractStatus(t, renewalID, contracts.V2ContractStatusPending)
 		assertContractStatus(t, contractID, contracts.V2ContractStatusActive)
 		assertContractMetrics(t, types.Siacoins(20), usage.RiskedCollateral)
-		// renewed contracts temporarily double the contract sectors
-		// until the reorg buffer is hit
-		assertStorageMetrics(t, 2, 1)
+		// renewed contracts use the same sectors as the original contract
+		assertStorageMetrics(t, 1, 1)
 
 		// try to revise the original contract before the renewal is confirmed
 		err = node.Contracts.ReviseV2Contract(contractID, fc, []types.Hash256{}, proto4.Usage{})
@@ -538,7 +476,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		// metrics should reflect the new contract, but storage should
 		// not change due to the reorg buffer
 		assertContractMetrics(t, types.Siacoins(22), renewal.RiskedCollateral())
-		assertStorageMetrics(t, 2, 1)
+		assertStorageMetrics(t, 1, 1)
 
 		// try to revise the original contract after the renewal is confirmed
 		err = node.Contracts.ReviseV2Contract(contractID, fc, []types.Hash256{}, proto4.Usage{})
@@ -841,12 +779,12 @@ func TestV2ContractLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// contract sectors should temporarily double
+		// renewed contracts share the same sector roots
 		expectedStatuses[contracts.V2ContractStatusPending]++
 		assertContractStatus(t, contractID, contracts.V2ContractStatusActive)
 		assertContractStatus(t, renewalID, contracts.V2ContractStatusPending)
 		assertContractMetrics(t, fc.TotalCollateral, usage.RiskedCollateral)
-		assertStorageMetrics(t, 2, 1)
+		assertStorageMetrics(t, 1, 1)
 
 		// append a sector to the renewal
 		appendSector(t, renewalID, renewal, roots, false)
@@ -855,7 +793,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		// collateral metrics won't change since the renewed contract is not
 		// active
 		assertContractMetrics(t, fc.TotalCollateral, usage.RiskedCollateral)
-		assertStorageMetrics(t, 3, 2)
+		assertStorageMetrics(t, 2, 2)
 
 		// mine until the renewed contract is rejected
 		// only contract status metrics should change
@@ -925,12 +863,12 @@ func TestV2ContractLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// contract sectors should temporarily double
+		// renewed contracts share the same sector roots
 		expectedStatuses[contracts.V2ContractStatusPending]++
 		assertContractStatus(t, contractID, contracts.V2ContractStatusActive)
 		assertContractStatus(t, renewalID, contracts.V2ContractStatusPending)
 		assertContractMetrics(t, fc.TotalCollateral, appendSectorUsage.RiskedCollateral)
-		assertStorageMetrics(t, 2, 1)
+		assertStorageMetrics(t, 1, 1)
 
 		// mine until the renewed contract is rejected
 		// only contract status metrics should change
@@ -951,12 +889,12 @@ func TestV2ContractLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// contract sectors should temporarily double
+		// renewed contracts share the same sector roots
 		expectedStatuses[contracts.V2ContractStatusPending]++
 		assertContractStatus(t, contractID, contracts.V2ContractStatusActive)
 		assertContractStatus(t, renewalID, contracts.V2ContractStatusPending)
 		assertContractMetrics(t, fc.TotalCollateral, appendSectorUsage.RiskedCollateral)
-		assertStorageMetrics(t, 2, 1)
+		assertStorageMetrics(t, 1, 1)
 
 		// mine to confirm the renewal
 		testutil.MineAndSync(t, node, types.VoidAddress, 1)
@@ -965,7 +903,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		assertContractStatus(t, contractID, contracts.V2ContractStatusRenewed)
 		assertContractStatus(t, renewalID, contracts.V2ContractStatusActive)
 		assertContractMetrics(t, renewal.TotalCollateral, renewalUsage.RiskedCollateral)
-		assertStorageMetrics(t, 2, 1)
+		assertStorageMetrics(t, 1, 1)
 
 		// mine until the original contract sectors are garbage collected
 		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
@@ -1499,4 +1437,443 @@ func TestChainIndexElementsDeepReorg(t *testing.T) {
 		t.Fatal(err)
 	}
 	testutil.WaitForSync(t, n2.Chain, h1.Indexer)
+}
+
+func TestV2SectorRootConsistency(t *testing.T) {
+	hostKey, renterKey := types.GeneratePrivateKey(), types.GeneratePrivateKey()
+
+	dir := t.TempDir()
+	log := zaptest.NewLogger(t)
+
+	network, genesis := testutil.V2Network()
+	node := testutil.NewHostNode(t, hostKey, network, genesis, log)
+
+	result := make(chan error, 1)
+	if _, err := node.Volumes.AddVolume(context.Background(), filepath.Join(dir, "data.dat"), 64, result); err != nil {
+		t.Fatal(err)
+	} else if err := <-result; err != nil {
+		t.Fatal(err)
+	}
+
+	// fund the wallet
+	testutil.MineAndSync(t, node, node.Wallet.Address(), int(network.MaturityDelay+5))
+
+	renewContract := func(t *testing.T, contractID types.FileContractID, fc types.V2FileContract, renterAllowance, collateral types.Currency) (types.FileContractID, types.V2FileContract, rhp4.TransactionSet, proto4.Usage) {
+		t.Helper()
+
+		cm := node.Chain
+		con := node.Contracts
+		w := node.Wallet
+		cs := cm.TipState()
+
+		renewal := types.V2FileContractRenewal{
+			NewContract: types.V2FileContract{
+				RevisionNumber:   0,
+				Filesize:         fc.Filesize,
+				Capacity:         fc.Capacity,
+				FileMerkleRoot:   fc.FileMerkleRoot,
+				ProofHeight:      fc.ProofHeight + 30,
+				ExpirationHeight: fc.ExpirationHeight + 30,
+				RenterOutput: types.SiacoinOutput{
+					Address: fc.RenterOutput.Address,
+					Value:   fc.RenterOutput.Value.Add(renterAllowance),
+				},
+				HostOutput: types.SiacoinOutput{
+					Address: fc.HostOutput.Address,
+					Value:   fc.HostOutput.Value.Add(collateral),
+				},
+				MissedHostValue: fc.MissedHostValue.Add(collateral),
+				TotalCollateral: fc.TotalCollateral.Add(collateral),
+				RenterPublicKey: renterKey.PublicKey(),
+				HostPublicKey:   hostKey.PublicKey(),
+			},
+			HostRollover:   fc.HostOutput.Value,
+			RenterRollover: fc.RenterOutput.Value,
+		}
+		renewalSigHash := cs.RenewalSigHash(renewal)
+		renewal.HostSignature = hostKey.SignHash(renewalSigHash)
+		renewal.RenterSignature = renterKey.SignHash(renewalSigHash)
+		contractSigHash := cs.ContractSigHash(renewal.NewContract)
+		renewal.NewContract.HostSignature = hostKey.SignHash(contractSigHash)
+		renewal.NewContract.RenterSignature = renterKey.SignHash(contractSigHash)
+
+		_, fce, err := con.V2FileContractElement(contractID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fundAmount := cs.V2FileContractTax(renewal.NewContract).Add(collateral).Add(renterAllowance)
+		renewalTxn := types.V2Transaction{
+			FileContractResolutions: []types.V2FileContractResolution{
+				{
+					Parent:     fce,
+					Resolution: &renewal,
+				},
+			},
+		}
+		basis, toSign, err := w.FundV2Transaction(&renewalTxn, fundAmount, false)
+		if err != nil {
+			t.Fatal("failed to fund transaction:", err)
+		}
+		w.SignV2Inputs(&renewalTxn, toSign)
+		return contractID.V2RenewalID(), renewal.NewContract, rhp4.TransactionSet{
+				Basis:        basis,
+				Transactions: []types.V2Transaction{renewalTxn},
+			}, proto4.Usage{
+				RiskedCollateral: renewal.NewContract.RiskedCollateral(),
+			}
+	}
+
+	appendSector := func(t *testing.T, contractID types.FileContractID, fc types.V2FileContract, roots []types.Hash256) (types.V2FileContract, []types.Hash256) {
+		t.Helper()
+
+		var sector [proto4.SectorSize]byte
+		frand.Read(sector[:])
+		root := proto4.SectorRoot(&sector)
+		roots = append(roots, root)
+
+		if err := node.Volumes.StoreSector(root, &sector, 1); err != nil {
+			t.Fatal(err)
+		}
+
+		fc.Filesize = proto4.SectorSize * uint64(len(roots))
+		fc.Capacity = proto4.SectorSize * uint64(len(roots))
+		fc.FileMerkleRoot = proto4.MetaRoot(roots)
+		fc.RevisionNumber++
+		cost, collateral := types.Siacoins(1), types.Siacoins(2)
+		fc.RenterOutput.Value = fc.RenterOutput.Value.Sub(cost)
+		fc.HostOutput.Value = fc.HostOutput.Value.Add(cost)
+		fc.MissedHostValue = fc.MissedHostValue.Sub(collateral)
+		sigHash := node.Chain.TipState().ContractSigHash(fc)
+		fc.HostSignature = hostKey.SignHash(sigHash)
+		fc.RenterSignature = renterKey.SignHash(sigHash)
+
+		usage := proto4.Usage{
+			Storage:          cost,
+			RiskedCollateral: collateral,
+		}
+		if err := node.Contracts.ReviseV2Contract(contractID, fc, roots, usage); err != nil {
+			t.Fatal(err)
+		}
+		return fc, roots
+	}
+
+	assertRoots := func(t *testing.T, contractID types.FileContractID, expected []types.Hash256) {
+		t.Helper()
+
+		actual := node.Contracts.SectorRoots(contractID)
+		if len(actual) != len(expected) {
+			t.Fatalf("expected %v roots, got %v", len(expected), len(actual))
+		}
+		for i := range expected {
+			if actual[i] != expected[i] {
+				t.Fatalf("root %v: expected %v, got %v", i, expected[i], actual[i])
+			}
+		}
+	}
+
+	assertDBRoots := func(t *testing.T, contractID types.FileContractID, expected []types.Hash256) {
+		t.Helper()
+
+		dbRoots, err := node.Store.V2SectorRoots()
+		if err != nil {
+			t.Fatal("failed to load sector roots:", err)
+		}
+		actual := dbRoots[contractID]
+		if len(actual) != len(expected) {
+			t.Fatalf("expected %v db roots, got %v", len(expected), len(actual))
+		}
+		for i := range expected {
+			if actual[i] != expected[i] {
+				t.Fatalf("db root %v: expected %v, got %v", i, expected[i], actual[i])
+			}
+		}
+	}
+
+	t.Run("basic contract", func(t *testing.T) {
+		contractID, fc := formV2Contract(t, node.Chain, node.Contracts, node.Wallet, renterKey, hostKey, types.Siacoins(10), types.Siacoins(20), 10, true)
+		assertRoots(t, contractID, nil)
+		assertDBRoots(t, contractID, nil)
+
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		var roots []types.Hash256
+		for range 3 {
+			fc, roots = appendSector(t, contractID, fc, roots)
+			assertRoots(t, contractID, roots)
+			assertDBRoots(t, contractID, roots)
+		}
+
+		testutil.MineAndSync(t, node, types.VoidAddress, int(fc.ExpirationHeight-node.Chain.Tip().Height)+1)
+		assertRoots(t, contractID, roots)
+
+		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+	})
+
+	t.Run("renewal inherits roots", func(t *testing.T) {
+		contractID, fc := formV2Contract(t, node.Chain, node.Contracts, node.Wallet, renterKey, hostKey, types.Siacoins(10), types.Siacoins(20), 10, true)
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		var roots []types.Hash256
+		for range 2 {
+			fc, roots = appendSector(t, contractID, fc, roots)
+		}
+		assertRoots(t, contractID, roots)
+		assertDBRoots(t, contractID, roots)
+
+		renewalID, _, renewalTxnSet, renewalUsage := renewContract(t, contractID, fc, types.ZeroCurrency, types.Siacoins(2))
+		if _, err := node.Chain.AddV2PoolTransactions(renewalTxnSet.Basis, renewalTxnSet.Transactions); err != nil {
+			t.Fatal(err)
+		} else if err := node.Contracts.RenewV2Contract(renewalTxnSet, renewalUsage); err != nil {
+			t.Fatal(err)
+		}
+
+		assertRoots(t, renewalID, roots)
+		assertDBRoots(t, renewalID, roots)
+		assertRoots(t, contractID, roots)
+		assertDBRoots(t, contractID, roots)
+
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+		assertRoots(t, renewalID, roots)
+		assertDBRoots(t, renewalID, roots)
+
+		renewal, err := node.Contracts.V2Contract(renewalID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		testutil.MineAndSync(t, node, types.VoidAddress, int(renewal.ExpirationHeight-node.Chain.Tip().Height)+1)
+		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+	})
+
+	t.Run("chained renewals", func(t *testing.T) {
+		contractID, fc := formV2Contract(t, node.Chain, node.Contracts, node.Wallet, renterKey, hostKey, types.Siacoins(10), types.Siacoins(20), 10, true)
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		var roots []types.Hash256
+		fc, roots = appendSector(t, contractID, fc, roots)
+		assertRoots(t, contractID, roots)
+
+		renewalID1, renewalFC1, renewalTxnSet1, renewalUsage1 := renewContract(t, contractID, fc, types.ZeroCurrency, types.Siacoins(2))
+		if _, err := node.Chain.AddV2PoolTransactions(renewalTxnSet1.Basis, renewalTxnSet1.Transactions); err != nil {
+			t.Fatal(err)
+		} else if err := node.Contracts.RenewV2Contract(renewalTxnSet1, renewalUsage1); err != nil {
+			t.Fatal(err)
+		}
+		assertRoots(t, renewalID1, roots)
+		assertDBRoots(t, renewalID1, roots)
+
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		renewalFC1, roots = appendSector(t, renewalID1, renewalFC1, roots)
+		assertRoots(t, renewalID1, roots)
+		assertDBRoots(t, renewalID1, roots)
+
+		renewalID2, _, renewalTxnSet2, renewalUsage2 := renewContract(t, renewalID1, renewalFC1, types.ZeroCurrency, types.Siacoins(2))
+		if _, err := node.Chain.AddV2PoolTransactions(renewalTxnSet2.Basis, renewalTxnSet2.Transactions); err != nil {
+			t.Fatal(err)
+		} else if err := node.Contracts.RenewV2Contract(renewalTxnSet2, renewalUsage2); err != nil {
+			t.Fatal(err)
+		}
+
+		assertRoots(t, renewalID2, roots)
+		assertDBRoots(t, renewalID2, roots)
+		assertDBRoots(t, renewalID1, roots)
+
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		renewal2, err := node.Contracts.V2Contract(renewalID2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertRoots(t, renewalID2, roots)
+		assertDBRoots(t, renewalID2, roots)
+		assertDBRoots(t, renewalID1, nil)
+
+		testutil.MineAndSync(t, node, types.VoidAddress, int(renewal2.ExpirationHeight-node.Chain.Tip().Height)+1)
+		assertDBRoots(t, renewalID1, nil)
+		assertDBRoots(t, renewalID2, nil)
+	})
+
+	t.Run("rejected contract", func(t *testing.T) {
+		cm := node.Chain
+		w := node.Wallet
+
+		renterFunds, hostFunds := types.Siacoins(10), types.Siacoins(20)
+		cs := cm.TipState()
+		fc := types.V2FileContract{
+			RevisionNumber:   0,
+			Filesize:         0,
+			ProofHeight:      cs.Index.Height + 10,
+			ExpirationHeight: cs.Index.Height + 20,
+			RenterOutput:     types.SiacoinOutput{Value: renterFunds, Address: w.Address()},
+			HostOutput:       types.SiacoinOutput{Value: hostFunds, Address: w.Address()},
+			MissedHostValue:  hostFunds,
+			TotalCollateral:  hostFunds,
+			RenterPublicKey:  renterKey.PublicKey(),
+			HostPublicKey:    hostKey.PublicKey(),
+		}
+		fundAmount := cs.V2FileContractTax(fc).Add(hostFunds).Add(renterFunds)
+		sigHash := cs.ContractSigHash(fc)
+		fc.HostSignature = hostKey.SignHash(sigHash)
+		fc.RenterSignature = renterKey.SignHash(sigHash)
+
+		txn := types.V2Transaction{FileContracts: []types.V2FileContract{fc}}
+		basis, toSign, err := w.FundV2Transaction(&txn, fundAmount, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.SignV2Inputs(&txn, toSign)
+		formationSet := rhp4.TransactionSet{
+			Transactions: []types.V2Transaction{txn},
+			Basis:        basis,
+		}
+		contractID := txn.V2FileContractID(txn.ID(), 0)
+		formationSet.Transactions[0].SiacoinInputs[0].SatisfiedPolicy.Signatures[0] = types.Signature{}
+
+		if err := node.Contracts.AddV2Contract(formationSet, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+
+		assertRoots(t, contractID, nil)
+		assertDBRoots(t, contractID, nil)
+
+		testutil.MineAndSync(t, node, types.VoidAddress, 20)
+
+		contract, err := node.Contracts.V2Contract(contractID)
+		if err != nil {
+			t.Fatal(err)
+		} else if contract.Status != contracts.V2ContractStatusRejected {
+			t.Fatalf("expected rejected, got %v", contract.Status)
+		}
+
+		dbRoots, err := node.Store.V2SectorRoots()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := dbRoots[contractID]; ok {
+			t.Fatal("rejected contract should not have roots in V2SectorRoots")
+		}
+	})
+
+	t.Run("renewal with expired original", func(t *testing.T) {
+		// form, add sectors, renew, then expire the original through the
+		// reorg buffer. The renewal's roots should survive.
+		contractID, fc := formV2Contract(t, node.Chain, node.Contracts, node.Wallet, renterKey, hostKey, types.Siacoins(10), types.Siacoins(20), 10, true)
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		var roots []types.Hash256
+		fc, roots = appendSector(t, contractID, fc, roots)
+
+		renewalID, renewalFC, renewalTxnSet, renewalUsage := renewContract(t, contractID, fc, types.ZeroCurrency, types.Siacoins(2))
+		if _, err := node.Chain.AddV2PoolTransactions(renewalTxnSet.Basis, renewalTxnSet.Transactions); err != nil {
+			t.Fatal(err)
+		} else if err := node.Contracts.RenewV2Contract(renewalTxnSet, renewalUsage); err != nil {
+			t.Fatal(err)
+		}
+
+		// confirm the renewal
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		// mine through the reorg buffer to expire original contract's sectors
+		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+
+		// renewal should still have roots after original is cleaned up
+		assertRoots(t, renewalID, roots)
+		assertDBRoots(t, renewalID, roots)
+
+		// add a new sector to the renewal
+		renewalFC, roots = appendSector(t, renewalID, renewalFC, roots)
+		assertRoots(t, renewalID, roots)
+		assertDBRoots(t, renewalID, roots)
+
+		// expire everything
+		renewal, err := node.Contracts.V2Contract(renewalID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		testutil.MineAndSync(t, node, types.VoidAddress, int(renewal.ExpirationHeight-node.Chain.Tip().Height)+1)
+		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+
+		_ = renewalFC
+	})
+
+	t.Run("renewal adds sectors", func(t *testing.T) {
+		// form contract with a sector, renew, then add sectors to the
+		// renewal. Both inherited and new sectors should be consistent.
+		contractID, fc := formV2Contract(t, node.Chain, node.Contracts, node.Wallet, renterKey, hostKey, types.Siacoins(10), types.Siacoins(20), 10, true)
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		var roots []types.Hash256
+		fc, roots = appendSector(t, contractID, fc, roots)
+
+		renewalID, renewalFC, renewalTxnSet, renewalUsage := renewContract(t, contractID, fc, types.ZeroCurrency, types.Siacoins(2))
+		if _, err := node.Chain.AddV2PoolTransactions(renewalTxnSet.Basis, renewalTxnSet.Transactions); err != nil {
+			t.Fatal(err)
+		} else if err := node.Contracts.RenewV2Contract(renewalTxnSet, renewalUsage); err != nil {
+			t.Fatal(err)
+		}
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		// add multiple sectors to the renewal
+		for range 3 {
+			renewalFC, roots = appendSector(t, renewalID, renewalFC, roots)
+		}
+
+		// all 4 sectors should be present (1 inherited + 3 new)
+		if len(roots) != 4 {
+			t.Fatalf("expected 4 roots, got %v", len(roots))
+		}
+		assertRoots(t, renewalID, roots)
+		assertDBRoots(t, renewalID, roots)
+
+		// expire everything
+		renewal, err := node.Contracts.V2Contract(renewalID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		testutil.MineAndSync(t, node, types.VoidAddress, int(renewal.ExpirationHeight-node.Chain.Tip().Height)+1)
+		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+
+		_ = renewalFC
+	})
+
+	t.Run("empty contract no sectors", func(t *testing.T) {
+		// form and confirm a contract with no sectors, then expire it.
+		// Roots should always be empty.
+		contractID, fc := formV2Contract(t, node.Chain, node.Contracts, node.Wallet, renterKey, hostKey, types.Siacoins(10), types.Siacoins(20), 10, true)
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		assertRoots(t, contractID, nil)
+		assertDBRoots(t, contractID, nil)
+
+		testutil.MineAndSync(t, node, types.VoidAddress, int(fc.ExpirationHeight-node.Chain.Tip().Height)+1)
+		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+	})
+
+	t.Run("empty renewal inherits empty", func(t *testing.T) {
+		// renew a contract that has no sectors. Both should have empty roots.
+		contractID, fc := formV2Contract(t, node.Chain, node.Contracts, node.Wallet, renterKey, hostKey, types.Siacoins(10), types.Siacoins(20), 10, true)
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		renewalID, _, renewalTxnSet, renewalUsage := renewContract(t, contractID, fc, types.ZeroCurrency, types.Siacoins(2))
+		if _, err := node.Chain.AddV2PoolTransactions(renewalTxnSet.Basis, renewalTxnSet.Transactions); err != nil {
+			t.Fatal(err)
+		} else if err := node.Contracts.RenewV2Contract(renewalTxnSet, renewalUsage); err != nil {
+			t.Fatal(err)
+		}
+
+		assertRoots(t, contractID, nil)
+		assertRoots(t, renewalID, nil)
+		assertDBRoots(t, contractID, nil)
+		assertDBRoots(t, renewalID, nil)
+
+		// confirm and expire
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+		renewal, err := node.Contracts.V2Contract(renewalID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		testutil.MineAndSync(t, node, types.VoidAddress, int(renewal.ExpirationHeight-node.Chain.Tip().Height)+1)
+		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+	})
 }

--- a/host/contracts/manager_test.go
+++ b/host/contracts/manager_test.go
@@ -1,10 +1,12 @@
 package contracts_test
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -366,7 +368,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 
 		// metrics should not have been updated, contract is still pending
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		// mine to confirm the contract
 		testutil.MineAndSync(t, node, types.VoidAddress, 1)
@@ -381,7 +383,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		expectedStatuses[contracts.V2ContractStatusSuccessful]++
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
 		// sector metrics should not change due to the reorg buffer
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		// mine through the reorg buffer so the sectors will be garbage
 		// collected
@@ -399,7 +401,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		fc, _, usage := appendSector(t, contractID, fc, nil, true)
 		// metrics should not have been updated, contract is still pending
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		// mine to confirm the contract
 		testutil.MineAndSync(t, node, types.VoidAddress, 1)
@@ -414,7 +416,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		expectedStatuses[contracts.V2ContractStatusFailed]++
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
 		// storage metrics will not change due to the reorg buffer
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		// mine through the reorg buffer so the sectors will be
 		// garbage collected
@@ -496,7 +498,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		assertContractStatus(t, renewalID, contracts.V2ContractStatusSuccessful)
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
 		// storage metrics will not change due to the reorg buffer
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		// mine through the reorg buffer so all the storage will be garbage
 		// collected
@@ -726,7 +728,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		// after confirmation.
 		assertContractStatus(t, contractID, contracts.V2ContractStatusPending)
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		// mine until the contract is rejected
 		testutil.MineAndSync(t, node, types.VoidAddress, 20)
@@ -761,7 +763,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		// after confirmation.
 		assertContractStatus(t, contractID, contracts.V2ContractStatusPending)
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		// mine to confirm the contract
 		testutil.MineAndSync(t, node, types.VoidAddress, 1)
@@ -793,7 +795,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		// collateral metrics won't change since the renewed contract is not
 		// active
 		assertContractMetrics(t, fc.TotalCollateral, usage.RiskedCollateral)
-		assertStorageMetrics(t, 2, 2)
+		assertStorageMetrics(t, 1, 2)
 
 		// mine until the renewed contract is rejected
 		// only contract status metrics should change
@@ -814,7 +816,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		assertContractStatus(t, renewalID, contracts.V2ContractStatusRejected)
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
 		// storage metrics won't be garbage collected for 6 blocks
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
 		assertStorageMetrics(t, 0, 0)
@@ -845,7 +847,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		// after confirmation.
 		assertContractStatus(t, contractID, contracts.V2ContractStatusPending)
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		// mine to confirm the contract
 		testutil.MineAndSync(t, node, types.VoidAddress, 1)
@@ -917,7 +919,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		assertContractStatus(t, renewalID, contracts.V2ContractStatusSuccessful)
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
 		// storage metrics won't be garbage collected for 6 blocks
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
 		assertStorageMetrics(t, 0, 0)
@@ -1258,7 +1260,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		expectedStatuses[contracts.V2ContractStatusPending]++
 		assertContractStatus(t, contractID, contracts.V2ContractStatusPending)
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 
 		// prepare blocks to revert the contract formation
 		revertState := node.Chain.TipState()
@@ -1285,7 +1287,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		expectedStatuses[contracts.V2ContractStatusPending]++
 		assertContractStatus(t, contractID, contracts.V2ContractStatusPending)
 		assertContractMetrics(t, types.ZeroCurrency, types.ZeroCurrency)
-		assertStorageMetrics(t, 1, 1)
+		assertStorageMetrics(t, 0, 1)
 	})
 }
 
@@ -1534,6 +1536,68 @@ func TestV2SectorRootConsistency(t *testing.T) {
 
 		if err := node.Volumes.StoreSector(root, &sector, 1); err != nil {
 			t.Fatal(err)
+		}
+
+		fc.Filesize = proto4.SectorSize * uint64(len(roots))
+		fc.Capacity = proto4.SectorSize * uint64(len(roots))
+		fc.FileMerkleRoot = proto4.MetaRoot(roots)
+		fc.RevisionNumber++
+		cost, collateral := types.Siacoins(1), types.Siacoins(2)
+		fc.RenterOutput.Value = fc.RenterOutput.Value.Sub(cost)
+		fc.HostOutput.Value = fc.HostOutput.Value.Add(cost)
+		fc.MissedHostValue = fc.MissedHostValue.Sub(collateral)
+		sigHash := node.Chain.TipState().ContractSigHash(fc)
+		fc.HostSignature = hostKey.SignHash(sigHash)
+		fc.RenterSignature = renterKey.SignHash(sigHash)
+
+		usage := proto4.Usage{
+			Storage:          cost,
+			RiskedCollateral: collateral,
+		}
+		if err := node.Contracts.ReviseV2Contract(contractID, fc, roots, usage); err != nil {
+			t.Fatal(err)
+		}
+		return fc, roots
+	}
+
+	deleteSectors := func(t *testing.T, contractID types.FileContractID, fc types.V2FileContract, roots []types.Hash256, indices []uint64) (types.V2FileContract, []types.Hash256) {
+		t.Helper()
+
+		// normalize indices by sorting and deduplicating them
+		// in descending order this mirrors the swap and trim
+		// logic used by renters.
+		slices.SortFunc(indices, func(a, b uint64) int {
+			return cmp.Compare(b, a) // descending
+		})
+		indices = slices.Compact(indices)
+
+		// ensure the roots at the specified indices are
+		// actually removed and the others kept.
+		kept := make(map[types.Hash256]struct{})
+		deleted := make(map[types.Hash256]struct{})
+		roots = slices.Clone(roots)
+		for _, n := range indices {
+			deleted[roots[n]] = struct{}{}
+		}
+		for _, root := range roots {
+			if _, ok := deleted[root]; ok {
+				continue
+			}
+			kept[root] = struct{}{}
+		}
+		for i, n := range indices {
+			roots[n] = roots[len(roots)-1-i]
+		}
+		roots = roots[:len(roots)-len(indices)]
+
+		for _, root := range roots {
+			if _, ok := deleted[root]; ok {
+				t.Fatalf("root %v was supposed to be deleted but is still present", root)
+			}
+			delete(kept, root)
+		}
+		if len(kept) != 0 {
+			t.Fatalf("some roots were supposed to be kept but are missing: %v", kept)
 		}
 
 		fc.Filesize = proto4.SectorSize * uint64(len(roots))
@@ -1896,6 +1960,91 @@ func TestV2SectorRootConsistency(t *testing.T) {
 		}
 		testutil.MineAndSync(t, node, types.VoidAddress, int(renewal.ExpirationHeight-node.Chain.Tip().Height)+1)
 		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+	})
+
+	t.Run("delete sectors from contract", func(t *testing.T) {
+		contractID, fc := formV2Contract(t, node.Chain, node.Contracts, node.Wallet, renterKey, hostKey, types.Siacoins(100), types.Siacoins(200), 10, true)
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		var roots []types.Hash256
+		for range 10 {
+			fc, roots = appendSector(t, contractID, fc, roots)
+		}
+		assertRoots(t, contractID, roots)
+		assertDBRoots(t, contractID, roots)
+
+		fc, roots = deleteSectors(t, contractID, fc, roots, []uint64{1, 3, 5, 7, 9})
+		assertRoots(t, contractID, roots)
+		assertDBRoots(t, contractID, roots)
+
+		testutil.MineAndSync(t, node, types.VoidAddress, int(fc.ExpirationHeight-node.Chain.Tip().Height)+1)
+		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+		assertDBRoots(t, contractID, nil)
+		// note: the roots cache is not cleared on expiry so not checked here
+	})
+
+	t.Run("delete sectors from renewal chain", func(t *testing.T) {
+		contractID, fc := formV2Contract(t, node.Chain, node.Contracts, node.Wallet, renterKey, hostKey, types.Siacoins(100), types.Siacoins(200), 10, true)
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+
+		// add sectors to the original contract
+		var roots []types.Hash256
+		for range 10 {
+			fc, roots = appendSector(t, contractID, fc, roots)
+		}
+		assertRoots(t, contractID, roots)
+
+		// delete one sector before renewing
+		fc, roots = deleteSectors(t, contractID, fc, roots, []uint64{2})
+		assertRoots(t, contractID, roots)
+		assertDBRoots(t, contractID, roots)
+
+		// renew the contract — renewal inherits remaining roots
+		renewalID, renewalFC, renewalTxnSet, renewalUsage := renewContract(t, contractID, fc, types.ZeroCurrency, types.Siacoins(2))
+		if _, err := node.Chain.AddV2PoolTransactions(renewalTxnSet.Basis, renewalTxnSet.Transactions); err != nil {
+			t.Fatal(err)
+		} else if err := node.Contracts.RenewV2Contract(renewalTxnSet, renewalUsage); err != nil {
+			t.Fatal(err)
+		}
+
+		// append a sector to the new contract after renewal
+		renewalFC, renewalRoots := appendSector(t, renewalID, renewalFC, roots)
+		// original contract should still have its roots, renewal should have inherited + new root
+		assertRoots(t, contractID, roots)
+		assertDBRoots(t, contractID, roots)
+		assertRoots(t, renewalID, renewalRoots)
+		assertDBRoots(t, renewalID, renewalRoots)
+
+		// original contract's roots should be cleaned up after renewal is confirmed
+		testutil.MineAndSync(t, node, types.VoidAddress, 1)
+		assertDBRoots(t, contractID, nil) // note: roots is not checked because it doesn't get cleared on expiration.
+		assertRoots(t, renewalID, renewalRoots)
+		assertDBRoots(t, renewalID, renewalRoots)
+
+		for range 3 {
+			renewalFC, renewalRoots = appendSector(t, renewalID, renewalFC, renewalRoots)
+		}
+		assertRoots(t, renewalID, renewalRoots)
+		assertDBRoots(t, renewalID, renewalRoots)
+
+		renewalFC, renewalRoots = deleteSectors(t, renewalID, renewalFC, renewalRoots, []uint64{1, 3, 5, 7, 9, 11})
+		assertRoots(t, renewalID, renewalRoots)
+		assertDBRoots(t, renewalID, renewalRoots)
+
+		// delete all remaining sectors
+		indices := make([]uint64, len(renewalRoots))
+		for i := range indices {
+			indices[i] = uint64(i)
+		}
+		renewalFC, renewalRoots = deleteSectors(t, renewalID, renewalFC, renewalRoots, indices)
+		assertRoots(t, renewalID, nil)
+		assertDBRoots(t, renewalID, nil)
+
+		// expire everything
+		testutil.MineAndSync(t, node, types.VoidAddress, int(renewalFC.ExpirationHeight-node.Chain.Tip().Height)+1)
+		testutil.MineAndSync(t, node, types.VoidAddress, contracts.ReorgBuffer+1)
+		assertDBRoots(t, renewalID, nil)
+		assertDBRoots(t, contractID, nil)
 	})
 
 	t.Run("empty contract no sectors", func(t *testing.T) {

--- a/host/contracts/persist.go
+++ b/host/contracts/persist.go
@@ -14,8 +14,6 @@ type (
 		// given index.
 		ContractActions(index types.ChainIndex, revisionBroadcastHeight uint64) (LifecycleActions, error)
 
-		// SectorRoots returns the sector roots for all contracts.
-		SectorRoots() (map[types.FileContractID][]types.Hash256, error)
 		// V2SectorRoots returns the sector roots for all v2 contracts.
 		V2SectorRoots() (map[types.FileContractID][]types.Hash256, error)
 
@@ -51,7 +49,7 @@ type (
 		AddV2Contract(V2Contract, rhp4.TransactionSet) error
 		// RenewV2Contract renews a contract. It is expected that the existing
 		// contract will be cleared.
-		RenewV2Contract(renewal V2Contract, renewalSet rhp4.TransactionSet, renewedID types.FileContractID, roots []types.Hash256) error
+		RenewV2Contract(renewal V2Contract, renewalSet rhp4.TransactionSet, renewedID types.FileContractID) error
 		// ReviseV2Contract atomically updates a contract and its associated
 		// sector roots.
 		ReviseV2Contract(id types.FileContractID, revision types.V2FileContract, oldRoots, newRoots []types.Hash256, usage proto4.Usage) error

--- a/host/contracts/persist.go
+++ b/host/contracts/persist.go
@@ -32,10 +32,6 @@ type (
 		// sector roots.
 		ReviseContract(revision SignedRevision, oldRoots, newRoots []types.Hash256, usage Usage) error
 
-		// ExpireContractSectors removes sector roots for any contracts that are
-		// rejected or past their proof window.
-		ExpireContractSectors(height uint64) error
-
 		// V2ContractElement returns the latest v2 state element with the given ID.
 		V2ContractElement(types.FileContractID) (types.ChainIndex, types.V2FileContractElement, error)
 		// V2Contracts returns a paginated list of v2 contracts sorted by expiration

--- a/host/contracts/update.go
+++ b/host/contracts/update.go
@@ -335,9 +335,7 @@ func (cm *Manager) ProcessActions(index types.ChainIndex) error {
 	expireHeight := index.Height - ReorgBuffer
 
 	// 6 block buffer for reorg protection
-	if err := cm.store.ExpireContractSectors(expireHeight); err != nil {
-		return fmt.Errorf("failed to expire contract sectors: %w", err)
-	} else if err := cm.store.ExpireV2ContractSectors(expireHeight); err != nil {
+	if err := cm.store.ExpireV2ContractSectors(expireHeight); err != nil {
 		return fmt.Errorf("failed to expire v2 contract sectors: %w", err)
 	}
 	return nil

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -35,6 +35,7 @@ type (
 		RenewedFromID    int64
 		LockedCollateral types.Currency
 		Usage            proto4.Usage
+		Revision         types.V2FileContract
 		Status           contracts.V2ContractStatus
 	}
 
@@ -680,7 +681,7 @@ WHERE contract_id=?`)
 // getV2ContractStateStmt helper to get the current state of a v2 contract.
 func getV2ContractStateStmt(tx *txn) (func(contractID types.FileContractID) (v2ContractState, error), func() error, error) {
 	stmt, err := tx.Prepare(`SELECT id, renewed_from, locked_collateral, risked_collateral, rpc_revenue, storage_revenue,
-ingress_revenue, egress_revenue, contract_status
+ingress_revenue, egress_revenue, raw_revision, contract_status
 FROM contracts_v2
 WHERE contract_id=?`)
 	if err != nil {
@@ -691,7 +692,7 @@ WHERE contract_id=?`)
 		err = stmt.QueryRow(encode(contractID)).Scan(&state.ID, decodeNullable(&state.RenewedFromID),
 			decode(&state.LockedCollateral), decode(&state.Usage.RiskedCollateral), decode(&state.Usage.RPC),
 			decode(&state.Usage.Storage), decode(&state.Usage.Ingress), decode(&state.Usage.Egress),
-			&state.Status)
+			decode(&state.Revision), &state.Status)
 		return
 	}, stmt.Close, nil
 }
@@ -1369,6 +1370,8 @@ func applyV2ContractFormation(tx *txn, index types.ChainIndex, confirmed []types
 			return fmt.Errorf("failed to update potential revenue metrics: %w", err)
 		} else if err := updateV2StatusMetrics(state.Status, contracts.V2ContractStatusActive, incrementNumericStat); err != nil {
 			return fmt.Errorf("failed to update contract metrics: %w", err)
+		} else if err := incrementNumericStat(metricContractSectors, int64(state.Revision.Filesize/proto4.SectorSize), time.Now()); err != nil {
+			return fmt.Errorf("failed to update contract sectors metric: %w", err)
 		}
 	}
 	return nil
@@ -1451,6 +1454,8 @@ func revertV2ContractFormation(tx *txn, reverted []types.V2FileContractElement) 
 			return fmt.Errorf("failed to update collateral metrics: %w", err)
 		} else if err := updateV2PotentialRevenueMetrics(state.Usage, true, incrementCurrencyStat); err != nil {
 			return fmt.Errorf("failed to update potential revenue metrics: %w", err)
+		} else if err := incrementNumericStat(metricContractSectors, -int64(state.Revision.Filesize/proto4.SectorSize), time.Now()); err != nil {
+			return fmt.Errorf("failed to update contract sectors metric: %w", err)
 		}
 	}
 	return nil
@@ -1550,6 +1555,8 @@ func applySuccessfulV2Contracts(tx *txn, index types.ChainIndex, status contract
 				return fmt.Errorf("failed to update potential revenue metrics: %w", err)
 			} else if err := updateCollateralMetrics(state.LockedCollateral, state.Usage.RiskedCollateral, true, incrementCurrencyStat); err != nil {
 				return fmt.Errorf("failed to update collateral metrics: %w", err)
+			} else if err := incrementNumericStat(metricContractSectors, -int64(state.Revision.Filesize/proto4.SectorSize), time.Now()); err != nil {
+				return fmt.Errorf("failed to update contract sectors metric: %w", err)
 			}
 		case contracts.V2ContractStatusFailed:
 			if err := updateV2EarnedRevenueMetrics(state.Usage, false, incrementCurrencyStat); err != nil {
@@ -1634,6 +1641,8 @@ func applyFailedV2Contracts(tx *txn, index types.ChainIndex, failed []types.File
 				return fmt.Errorf("failed to update potential revenue metrics: %w", err)
 			} else if err := updateCollateralMetrics(state.LockedCollateral, state.Usage.RiskedCollateral, true, incrementCurrencyStat); err != nil {
 				return fmt.Errorf("failed to update collateral metrics: %w", err)
+			} else if err := incrementNumericStat(metricContractSectors, -int64(state.Revision.Filesize/proto4.SectorSize), time.Now()); err != nil {
+				return fmt.Errorf("failed to update contract sectors metric: %w", err)
 			}
 		case contracts.V2ContractStatusSuccessful, contracts.V2ContractStatusRenewed:
 			// if the contract is successful or renewed, subtract the usage from
@@ -1715,6 +1724,8 @@ func revertSuccessfulV2Contracts(tx *txn, status contracts.V2ContractStatus, suc
 			return fmt.Errorf("failed to update earned revenue metrics: %w", err)
 		} else if err := updateCollateralMetrics(state.LockedCollateral, state.Usage.RiskedCollateral, false, incrementCurrencyStat); err != nil {
 			return fmt.Errorf("failed to update collateral metrics: %w", err)
+		} else if err := incrementNumericStat(metricContractSectors, int64(state.Revision.Filesize/proto4.SectorSize), time.Now()); err != nil {
+			return fmt.Errorf("failed to update contract sectors metric: %w", err)
 		}
 	}
 	return nil
@@ -1785,6 +1796,8 @@ func revertFailedV2Contracts(tx *txn, failed []types.FileContractID) error {
 			return fmt.Errorf("failed to update potential revenue metrics: %w", err)
 		} else if err := updateCollateralMetrics(state.LockedCollateral, state.Usage.RiskedCollateral, false, incrementCurrencyStat); err != nil {
 			return fmt.Errorf("failed to update collateral metrics: %w", err)
+		} else if err := incrementNumericStat(metricContractSectors, int64(state.Revision.Filesize/proto4.SectorSize), time.Now()); err != nil {
+			return fmt.Errorf("failed to update contract sectors metric: %w", err)
 		}
 	}
 	return nil

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -24,11 +24,6 @@ func (s *Store) batchExpireV2ContractSectors(height uint64) (expired int, err er
 			return fmt.Errorf("failed to delete contract sectors: %w", err)
 		}
 		expired = len(sectorIDs)
-
-		// decrement the contract metrics
-		if err := incrementNumericStat(tx, metricContractSectors, -len(sectorIDs), time.Now()); err != nil {
-			return fmt.Errorf("failed to decrement contract sectors: %w", err)
-		}
 		return nil
 	})
 	return
@@ -948,13 +943,9 @@ func resetRejectedV2Contract(tx *txn, contractID types.FileContractID) error {
 	// note: this should already be handled, but there is a small race where
 	// not all of the sectors may be cleaned up before the renter tries to
 	// renew. Instead of failing, it is preferred to clean up the remaining roots.
-	res, err := tx.Exec(`DELETE FROM contract_v2_sector_roots WHERE contract_v2_roots_map_id=$1 AND contract_v2_roots_map_revision_number=$2;`, contractMapID, contractMapRevisionNumber)
+	_, err = tx.Exec(`DELETE FROM contract_v2_sector_roots WHERE contract_v2_roots_map_id=$1 AND contract_v2_roots_map_revision_number=$2;`, contractMapID, contractMapRevisionNumber)
 	if err != nil {
 		return fmt.Errorf("failed to delete rejected contract sectors: %w", err)
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get affected rows: %w", err)
 	}
 
 	if _, err = tx.Exec(`DELETE FROM contracts_v2 WHERE id=$1;`, dbID); err != nil {
@@ -963,9 +954,7 @@ func resetRejectedV2Contract(tx *txn, contractID types.FileContractID) error {
 		return fmt.Errorf("failed to delete rejected contract roots map: %w", err)
 	}
 
-	if err := incrementNumericStat(metricContractSectors, -n, time.Now()); err != nil {
-		return fmt.Errorf("failed to decrement contract sectors: %w", err)
-	} else if err := incrementNumericStat(metricRejectedContracts, -1, time.Now()); err != nil {
+	if err := incrementNumericStat(metricRejectedContracts, -1, time.Now()); err != nil {
 		return fmt.Errorf("failed to update rejected contracts metric: %w", err)
 	}
 	return nil
@@ -1177,9 +1166,16 @@ func updateV2ContractSectors(tx *txn, contractDBID int64, oldRoots, newRoots []t
 		}
 	}
 
-	delta := len(newRoots) - len(oldRoots)
-	if err := incrementNumericStat(tx, metricContractSectors, delta, time.Now()); err != nil {
-		return fmt.Errorf("failed to update contract sectors: %w", err)
+	var status contracts.V2ContractStatus
+	if err := tx.QueryRow(`SELECT contract_status FROM contracts_v2 WHERE id=$1`, contractDBID).Scan(&status); err != nil {
+		return fmt.Errorf("failed to get contract status: %w", err)
+	}
+
+	if status == contracts.V2ContractStatusActive {
+		delta := len(newRoots) - len(oldRoots)
+		if err := incrementNumericStat(tx, metricContractSectors, delta, time.Now()); err != nil {
+			return fmt.Errorf("failed to update contract sectors: %w", err)
+		}
 	}
 	return nil
 }

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -462,12 +462,6 @@ func (s *Store) ContractActions(index types.ChainIndex, revisionBroadcastHeight 
 	return
 }
 
-// ExpireContractSectors expires all sectors that are no longer covered by an
-// active contract.
-func (s *Store) ExpireContractSectors(height uint64) error {
-	return nil // TODO: remove
-}
-
 // ExpireV2ContractSectors expires all sectors that are no longer covered by an
 // active contract.
 func (s *Store) ExpireV2ContractSectors(height uint64) error {

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -17,7 +17,7 @@ import (
 
 var _ contracts.ContractStore = (*Store)(nil)
 
-func (s *Store) batchExpireV2ContractSectors(height uint64) (expired int, err error) {
+func (s *Store) batchExpireV2ContractSectors(height uint64) (expired int64, err error) {
 	err = s.transaction(func(tx *txn) (err error) {
 		expired, err = deleteExpiredV2ContractSectors(tx, height)
 		if err != nil {
@@ -468,7 +468,7 @@ func (s *Store) ExpireV2ContractSectors(height uint64) error {
 		} else if expired == 0 {
 			return nil
 		}
-		log.Debug("removed sectors", zap.Int("expired", expired), zap.Int("batch", i))
+		log.Debug("removed sectors", zap.Int64("expired", expired), zap.Int("batch", i))
 		jitterSleep(50 * time.Millisecond) // allow other transactions to run
 	}
 }
@@ -489,7 +489,7 @@ func getContract(tx *txn, contractID int64) (contracts.Contract, error) {
 	return contract, err
 }
 
-func deleteExpiredV2ContractSectors(tx *txn, height uint64) (deleted int, err error) {
+func deleteExpiredV2ContractSectors(tx *txn, height uint64) (int64, error) {
 	// delete roots where the contract at that (map_id, revision_number) is
 	// expired and no active higher-revision contract depends on them
 	const expiredQuery = `DELETE FROM contract_v2_sector_roots
@@ -516,7 +516,6 @@ LIMIT $3);`
 	if err != nil {
 		return 0, err
 	}
-	deleted = int(expired)
 
 	// delete roots that have been superseded by a replacement at a higher
 	// revision for the same root_index. These are from expired contracts
@@ -543,7 +542,7 @@ LIMIT $3)`
 	if err != nil {
 		return 0, err
 	}
-	return deleted + int(superseded), nil
+	return expired + superseded, nil
 }
 
 // updateResolvedV2Contract clears a contract and returns its ID

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -19,11 +19,10 @@ var _ contracts.ContractStore = (*Store)(nil)
 
 func (s *Store) batchExpireV2ContractSectors(height uint64) (expired int, err error) {
 	err = s.transaction(func(tx *txn) (err error) {
-		sectorIDs, err := deleteExpiredV2ContractSectors(tx, height)
+		expired, err = deleteExpiredV2ContractSectors(tx, height)
 		if err != nil {
 			return fmt.Errorf("failed to delete contract sectors: %w", err)
 		}
-		expired = len(sectorIDs)
 		return nil
 	})
 	return
@@ -490,7 +489,7 @@ func getContract(tx *txn, contractID int64) (contracts.Contract, error) {
 	return contract, err
 }
 
-func deleteExpiredV2ContractSectors(tx *txn, height uint64) (sectorIDs []int64, err error) {
+func deleteExpiredV2ContractSectors(tx *txn, height uint64) (deleted int, err error) {
 	// delete roots where the contract at that (map_id, revision_number) is
 	// expired and no active higher-revision contract depends on them
 	const expiredQuery = `DELETE FROM contract_v2_sector_roots
@@ -506,37 +505,22 @@ AND NOT EXISTS (
 	AND c2.contract_v2_roots_map_revision_number > csr.contract_v2_roots_map_revision_number
 	AND (c2.resolution_height IS NULL OR c2.resolution_height >= $1)
 	AND c2.contract_status != $2
+	AND csr.root_index < c2.sector_count
 )
-LIMIT $3)
-RETURNING sector_id;`
-	rows, err := tx.Query(expiredQuery, height, contracts.V2ContractStatusRejected, sqlSectorBatchSize)
+LIMIT $3);`
+	res, err := tx.Exec(expiredQuery, height, contracts.V2ContractStatusRejected, sqlSectorBatchSize)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		sectorIDs = append(sectorIDs, id)
+	expired, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	if len(sectorIDs) >= sqlSectorBatchSize {
-		return sectorIDs, nil
-	}
+	deleted = int(expired)
 
 	// delete roots that have been superseded by a replacement at a higher
 	// revision for the same root_index. These are from expired contracts
 	// that have an active higher-revision contract in the same renewal chain.
-	//
-	// Superseded rows are not included in the returned sectorIDs because
-	// they should not affect the contract sectors metric. When a sector
-	// is replaced at a higher revision, the delta is 0, so deleting the
-	// old row should not decrement the metric.
 	const supersededQuery = `DELETE FROM contract_v2_sector_roots
 WHERE id IN (SELECT csr.id FROM contract_v2_sector_roots csr
 INNER JOIN contracts_v2 c ON (
@@ -551,8 +535,15 @@ AND EXISTS (
 	AND csr2.root_index = csr.root_index
 )
 LIMIT $3)`
-	_, err = tx.Exec(supersededQuery, height, contracts.V2ContractStatusRejected, sqlSectorBatchSize-len(sectorIDs))
-	return sectorIDs, err
+	res, err = tx.Exec(supersededQuery, height, contracts.V2ContractStatusRejected, sqlSectorBatchSize)
+	if err != nil {
+		return 0, err
+	}
+	superseded, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return deleted + int(superseded), nil
 }
 
 // updateResolvedV2Contract clears a contract and returns its ID
@@ -944,8 +935,8 @@ func v2ContractRoots(tx *txn, contractMapID, contractMapRevision int64, maxSecto
 func insertV2Contract(tx *txn, contract contracts.V2Contract, mapID, mapRevisionNumber int64, formationSet rhp4.TransactionSet) (dbID int64, err error) {
 	const query = `INSERT INTO contracts_v2 (contract_id, renter_id, locked_collateral, rpc_revenue, storage_revenue, ingress_revenue,
 egress_revenue, account_funding, risked_collateral, revision_number, negotiation_height, proof_height, expiration_height, formation_txn_set,
-formation_txn_set_basis, raw_revision, contract_status, contract_v2_roots_map_id, contract_v2_roots_map_revision_number) VALUES
- ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) RETURNING id;`
+formation_txn_set_basis, raw_revision, contract_status, sector_count, contract_v2_roots_map_id, contract_v2_roots_map_revision_number) VALUES
+ ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) RETURNING id;`
 
 	renterID, err := renterDBID(tx, contract.RenterPublicKey)
 	if err != nil {
@@ -970,6 +961,7 @@ formation_txn_set_basis, raw_revision, contract_status, contract_v2_roots_map_id
 		encode(formationSet.Basis),
 		encode(contract.V2FileContract),
 		contracts.V2ContractStatusPending,
+		contract.V2FileContract.Filesize/proto4.SectorSize,
 		mapID,
 		mapRevisionNumber,
 	).Scan(&dbID)
@@ -1069,7 +1061,7 @@ func reviseV2Contract(tx *txn, id types.FileContractID, revision types.V2FileCon
 		return 0, fmt.Errorf("revision number went backwards: existing=%d revised=%d", existingRevision, revision.RevisionNumber)
 	}
 
-	if _, err := tx.Exec(`UPDATE contracts_v2 SET raw_revision=?, revision_number=? WHERE id=?`, encode(revision), encode(revision.RevisionNumber), contractDBID); err != nil {
+	if _, err := tx.Exec(`UPDATE contracts_v2 SET raw_revision=?, revision_number=?, sector_count=? WHERE id=?`, encode(revision), encode(revision.RevisionNumber), revision.Filesize/proto4.SectorSize, contractDBID); err != nil {
 		return 0, fmt.Errorf("failed to update contract: %w", err)
 	} else if err := updateV2ContractUsage(tx, contractDBID, usage); err != nil {
 		return 0, fmt.Errorf("failed to update contract usage: %w", err)

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -499,7 +499,7 @@ INNER JOIN contracts_v2 c ON (
 	c.contract_v2_roots_map_id = csr.contract_v2_roots_map_id
 	AND c.contract_v2_roots_map_revision_number = csr.contract_v2_roots_map_revision_number
 )
-WHERE (c.resolution_height IS NOT NULL AND c.resolution_height < $1 OR c.contract_status = $2)
+WHERE ((c.resolution_height IS NOT NULL AND c.resolution_height < $1) OR c.contract_status = $2)
 AND NOT EXISTS (
 	SELECT 1 FROM contracts_v2 c2
 	WHERE c2.contract_v2_roots_map_id = csr.contract_v2_roots_map_id
@@ -529,48 +529,9 @@ RETURNING sector_id;`
 		return sectorIDs, nil
 	}
 
-	// find expired (map_id, revision_number) pairs that have an active
-	// higher-revision contract. These roots may have been superseded by
-	// a replacement at a higher revision and can be garbage collected.
-	const expiredPairsQuery = `SELECT c.contract_v2_roots_map_id, c.contract_v2_roots_map_revision_number
-FROM contracts_v2 c
-WHERE (c.resolution_height IS NOT NULL AND c.resolution_height < $1 OR c.contract_status = $2)
-AND EXISTS (
-	SELECT 1 FROM contracts_v2 c2
-	WHERE c2.contract_v2_roots_map_id = c.contract_v2_roots_map_id
-	AND c2.contract_v2_roots_map_revision_number > c.contract_v2_roots_map_revision_number
-	AND (c2.resolution_height IS NULL OR c2.resolution_height >= $1)
-	AND c2.contract_status != $2
-)`
-	pairRows, err := tx.Query(expiredPairsQuery, height, contracts.V2ContractStatusRejected)
-	if err != nil {
-		return nil, err
-	}
-	defer pairRows.Close()
-
-	type mapPair struct {
-		mapID    int64
-		revision int64
-	}
-	var pairs []mapPair
-	for pairRows.Next() {
-		var p mapPair
-		if err := pairRows.Scan(&p.mapID, &p.revision); err != nil {
-			return nil, err
-		}
-		pairs = append(pairs, p)
-	}
-	if err := pairRows.Err(); err != nil {
-		return nil, err
-	}
-
-	if len(pairs) == 0 {
-		return sectorIDs, nil
-	}
-
-	// for each expired pair, delete roots that have been superseded by a
-	// replacement at a higher revision for the same root_index. This is
-	// scoped to a single map_id so the query is efficient.
+	// delete roots that have been superseded by a replacement at a higher
+	// revision for the same root_index. These are from expired contracts
+	// that have an active higher-revision contract in the same renewal chain.
 	//
 	// Superseded rows are not included in the returned sectorIDs because
 	// they should not affect the contract sectors metric. When a sector
@@ -578,8 +539,11 @@ AND EXISTS (
 	// old row should not decrement the metric.
 	const supersededQuery = `DELETE FROM contract_v2_sector_roots
 WHERE id IN (SELECT csr.id FROM contract_v2_sector_roots csr
-WHERE csr.contract_v2_roots_map_id = $1
-AND csr.contract_v2_roots_map_revision_number = $2
+INNER JOIN contracts_v2 c ON (
+	c.contract_v2_roots_map_id = csr.contract_v2_roots_map_id
+	AND c.contract_v2_roots_map_revision_number = csr.contract_v2_roots_map_revision_number
+)
+WHERE ((c.resolution_height IS NOT NULL AND c.resolution_height < $1) OR c.contract_status = $2)
 AND EXISTS (
 	SELECT 1 FROM contract_v2_sector_roots csr2
 	WHERE csr2.contract_v2_roots_map_id = csr.contract_v2_roots_map_id
@@ -587,22 +551,8 @@ AND EXISTS (
 	AND csr2.root_index = csr.root_index
 )
 LIMIT $3)`
-	supersededStmt, err := tx.Prepare(supersededQuery)
-	if err != nil {
-		return nil, err
-	}
-	defer supersededStmt.Close()
-
-	remaining := sqlSectorBatchSize - len(sectorIDs)
-	for _, p := range pairs {
-		if remaining <= 0 {
-			break
-		}
-		if _, err := supersededStmt.Exec(p.mapID, p.revision, remaining); err != nil {
-			return nil, err
-		}
-	}
-	return sectorIDs, nil
+	_, err = tx.Exec(supersededQuery, height, contracts.V2ContractStatusRejected, sqlSectorBatchSize-len(sectorIDs))
+	return sectorIDs, err
 }
 
 // updateResolvedV2Contract clears a contract and returns its ID

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -391,11 +391,11 @@ func (s *Store) V2SectorRoots() (roots map[types.FileContractID][]types.Hash256,
 	err = s.transaction(func(tx *txn) error {
 		const contractsQuery = `SELECT contract_id, raw_revision, contract_v2_roots_map_id, contract_v2_roots_map_revision_number FROM contracts_v2
 WHERE contract_status <> $1 AND resolution_height IS NULL;`
-		contractRows, err := tx.Query(contractsQuery, contracts.V2ContractStatusRejected)
+		rows, err := tx.Query(contractsQuery, contracts.V2ContractStatusRejected)
 		if err != nil {
 			return err
 		}
-		defer contractRows.Close()
+		defer rows.Close()
 
 		type contractRef struct {
 			id        types.FileContractID
@@ -404,58 +404,27 @@ WHERE contract_status <> $1 AND resolution_height IS NULL;`
 			mapRevNum int64
 		}
 		var contracts []contractRef
-		for contractRows.Next() {
+		for rows.Next() {
 			var ref contractRef
 			var fc types.V2FileContract
-			if err := contractRows.Scan(decode(&ref.id), decode(&fc), &ref.mapID, &ref.mapRevNum); err != nil {
+			if err := rows.Scan(decode(&ref.id), decode(&fc), &ref.mapID, &ref.mapRevNum); err != nil {
 				return fmt.Errorf("failed to scan contract: %w", err)
 			}
 			ref.sectors = fc.Filesize / proto4.SectorSize
 			contracts = append(contracts, ref)
 		}
-		if err := contractRows.Err(); err != nil {
-			return err
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to iterate contracts: %w", err)
+		} else if err := rows.Close(); err != nil {
+			return fmt.Errorf("failed to close contract rows: %w", err)
 		}
-
-		// for each root_index, select the root from the latest map revision
-		// that is <= the contract map revision number.
-		const rootsQuery = `SELECT sector_root FROM (
-    SELECT s.sector_root, MAX(cr.contract_v2_roots_map_revision_number)
-    FROM contract_v2_sector_roots cr
-    INNER JOIN stored_sectors s ON (cr.sector_id = s.id)
-    WHERE cr.contract_v2_roots_map_id = $1
-    AND cr.contract_v2_roots_map_revision_number <= $2
-    AND cr.root_index < $3
-    GROUP BY cr.root_index
-    ORDER BY cr.root_index ASC
-);`
-
-		rootsStmt, err := tx.Prepare(rootsQuery)
-		if err != nil {
-			return fmt.Errorf("failed to prepare roots query: %w", err)
-		}
-		defer rootsStmt.Close()
 
 		roots = make(map[types.FileContractID][]types.Hash256)
 		for _, ref := range contracts {
-			rows, err := rootsStmt.Query(ref.mapID, ref.mapRevNum, ref.sectors)
+			roots[ref.id], err = v2ContractRoots(tx, ref.mapID, ref.mapRevNum, ref.sectors)
 			if err != nil {
-				return fmt.Errorf("failed to query roots for contract %v: %w", ref.id, err)
+				return fmt.Errorf("failed to get roots for contract %v: %w", ref.id, err)
 			}
-
-			for rows.Next() {
-				var root types.Hash256
-				if err := rows.Scan(decode(&root)); err != nil {
-					rows.Close()
-					return fmt.Errorf("failed to scan sector root: %w", err)
-				}
-				roots[ref.id] = append(roots[ref.id], root)
-			}
-			if err := rows.Err(); err != nil {
-				rows.Close()
-				return err
-			}
-			rows.Close()
 		}
 		return nil
 	})
@@ -1008,6 +977,38 @@ func resetRejectedV2Contract(tx *txn, contractID types.FileContractID) error {
 	return nil
 }
 
+func v2ContractRoots(tx *txn, contractMapID, contractMapRevision int64, maxSectors uint64) (roots []types.Hash256, err error) {
+	const rootsQuery = `SELECT sector_root FROM (
+    SELECT s.sector_root, MAX(cr.contract_v2_roots_map_revision_number)
+    FROM contract_v2_sector_roots cr
+    INNER JOIN stored_sectors s ON (cr.sector_id = s.id)
+    WHERE cr.contract_v2_roots_map_id = $1
+    AND cr.contract_v2_roots_map_revision_number <= $2
+    AND cr.root_index < $3
+    GROUP BY cr.root_index
+    ORDER BY cr.root_index ASC
+);`
+
+	rows, err := tx.Query(rootsQuery, contractMapID, contractMapRevision, maxSectors)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query roots for map %v: %w", contractMapID, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var root types.Hash256
+		if err := rows.Scan(decode(&root)); err != nil {
+
+			return nil, fmt.Errorf("failed to scan sector root: %w", err)
+		}
+		roots = append(roots, root)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate sector roots: %w", err)
+	}
+	return
+}
+
 func insertV2Contract(tx *txn, contract contracts.V2Contract, mapID, mapRevisionNumber int64, formationSet rhp4.TransactionSet) (dbID int64, err error) {
 	const query = `INSERT INTO contracts_v2 (contract_id, renter_id, locked_collateral, rpc_revenue, storage_revenue, ingress_revenue,
 egress_revenue, account_funding, risked_collateral, revision_number, negotiation_height, proof_height, expiration_height, formation_txn_set,
@@ -1173,6 +1174,13 @@ func updateV2ContractSectors(tx *txn, contractDBID int64, oldRoots, newRoots []t
 			return fmt.Errorf("failed to get sector ID: %w", err)
 		} else if _, err := updateRootStmt.Exec(contractMapID, contractMapRevisionID, newSectorID, i); err != nil {
 			return fmt.Errorf("failed to update sector root: %w", err)
+		}
+	}
+
+	if len(newRoots) < len(oldRoots) {
+		_, err := tx.Exec(`DELETE FROM contract_v2_sector_roots WHERE contract_v2_roots_map_id=$1 AND contract_v2_roots_map_revision_number=$2 AND root_index >= $3`, contractMapID, contractMapRevisionID, len(newRoots))
+		if err != nil {
+			return fmt.Errorf("failed to remove old roots: %w", err)
 		}
 	}
 

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -17,23 +17,6 @@ import (
 
 var _ contracts.ContractStore = (*Store)(nil)
 
-func (s *Store) batchExpireContractSectors(height uint64) (expired int, err error) {
-	err = s.transaction(func(tx *txn) (err error) {
-		sectorIDs, err := deleteExpiredContractSectors(tx, height)
-		if err != nil {
-			return fmt.Errorf("failed to delete contract sectors: %w", err)
-		}
-		expired = len(sectorIDs)
-
-		// decrement the contract metrics
-		if err := incrementNumericStat(tx, metricContractSectors, -len(sectorIDs), time.Now()); err != nil {
-			return fmt.Errorf("failed to decrement contract sectors: %w", err)
-		}
-		return nil
-	})
-	return
-}
-
 func (s *Store) batchExpireV2ContractSectors(height uint64) (expired int, err error) {
 	err = s.transaction(func(tx *txn) (err error) {
 		sectorIDs, err := deleteExpiredV2ContractSectors(tx, height)
@@ -241,7 +224,18 @@ LEFT JOIN contracts_v2 rf ON (c.renewed_from=rf.id) %s`, whereClause)
 // AddV2Contract adds a new contract to the database.
 func (s *Store) AddV2Contract(contract contracts.V2Contract, formationSet rhp4.TransactionSet) error {
 	return s.transaction(func(tx *txn) error {
-		_, err := insertV2Contract(tx, contract, formationSet)
+		if err := resetRejectedV2Contract(tx, contract.ID); err != nil {
+			return fmt.Errorf("failed to reset rejected contract: %w", err)
+		}
+
+		var mapID, mapRevisionNumber int64
+		err := tx.QueryRow(`INSERT INTO contract_v2_roots_map (id, revision_number) VALUES (
+		(SELECT COALESCE(MAX(id), 0) + 1 FROM contract_v2_roots_map),
+		0) RETURNING id, revision_number;`).Scan(&mapID, &mapRevisionNumber)
+		if err != nil {
+			return fmt.Errorf("failed to insert contract v2 roots map: %w", err)
+		}
+		_, err = insertV2Contract(tx, contract, mapID, mapRevisionNumber, formationSet)
 		return err
 	})
 }
@@ -250,15 +244,33 @@ func (s *Store) AddV2Contract(contract contracts.V2Contract, formationSet rhp4.T
 // contract's renewed_from field. The old contract's sector roots are
 // copied to the new contract. The status of the old contract should continue
 // to be active until the renewal is confirmed
-func (s *Store) RenewV2Contract(renewal contracts.V2Contract, renewalSet rhp4.TransactionSet, renewedID types.FileContractID, roots []types.Hash256) error {
+func (s *Store) RenewV2Contract(renewal contracts.V2Contract, renewalSet rhp4.TransactionSet, renewedID types.FileContractID) error {
 	return s.transaction(func(tx *txn) error {
+		if err := resetRejectedV2Contract(tx, renewal.ID); err != nil {
+			return fmt.Errorf("failed to reset rejected contract: %w", err)
+		}
+
+		// get the old contract's database ID, roots map ID, and roots map revision number
+		var clearedDBID, clearedMapID, clearedRevisionNumber int64
+		err := tx.QueryRow(`SELECT id, contract_v2_roots_map_id, contract_v2_roots_map_revision_number FROM contracts_v2 WHERE contract_id=$1;`, encode(renewedID)).Scan(&clearedDBID, &clearedMapID, &clearedRevisionNumber)
+		if err != nil {
+			return fmt.Errorf("failed to get renewed contract: %w", err)
+		}
+
+		renewedMapID := clearedMapID
+		renewedRevisionNumber := clearedRevisionNumber + 1
+		_, err = tx.Exec(`INSERT INTO contract_v2_roots_map (id, revision_number) VALUES ($1, $2);`, renewedMapID, renewedRevisionNumber)
+		if err != nil {
+			return fmt.Errorf("failed to insert contract v2 roots map: %w", err)
+		}
+
 		// add the new contract
-		renewedDBID, err := insertV2Contract(tx, renewal, renewalSet)
+		renewedDBID, err := insertV2Contract(tx, renewal, renewedMapID, renewedRevisionNumber, renewalSet)
 		if err != nil {
 			return fmt.Errorf("failed to insert renewed contract: %w", err)
 		}
 
-		clearedDBID, err := updateResolvedV2Contract(tx, renewedID, renewedDBID)
+		_, err = updateResolvedV2Contract(tx, renewedID, renewedDBID)
 		if err != nil {
 			return fmt.Errorf("failed to resolve existing contract: %w", err)
 		}
@@ -267,26 +279,6 @@ func (s *Store) RenewV2Contract(renewal contracts.V2Contract, renewalSet rhp4.Tr
 		err = tx.QueryRow(`UPDATE contracts_v2 SET renewed_from=$1 WHERE id=$2 RETURNING id;`, clearedDBID, renewedDBID).Scan(&renewedDBID)
 		if err != nil {
 			return fmt.Errorf("failed to update renewed contract: %w", err)
-		}
-
-		if len(roots) == 0 {
-			return nil
-		}
-
-		res, err := tx.Exec(`INSERT INTO contract_v2_sector_roots (contract_id, sector_id, root_index) SELECT $1, sector_id, root_index FROM contract_v2_sector_roots WHERE contract_id=$2`, renewedDBID, clearedDBID)
-		if err != nil {
-			return fmt.Errorf("failed to copy sector roots: %w", err)
-		} else if n, err := res.RowsAffected(); err != nil {
-			return fmt.Errorf("failed to get affected rows: %w", err)
-		} else if n != int64(len(roots)) {
-			// Should never happen; it would signal an inconsistency
-			// between the roots on disk and the roots in memory.
-			// It is preferable to not let the contract be renewed
-			// since the roots passed in are validated in the contract
-			// manager to match the contract's merkle root.
-			return fmt.Errorf("not all sector roots were copied")
-		} else if err := incrementNumericStat(tx, metricContractSectors, len(roots), time.Now()); err != nil {
-			return fmt.Errorf("failed to update contract sectors: %w", err)
 		}
 		return nil
 	})
@@ -394,60 +386,78 @@ func (s *Store) ReviseContract(revision contracts.SignedRevision, oldRoots, newR
 	})
 }
 
-// SectorRoots returns the sector roots for all contracts.
-func (s *Store) SectorRoots() (roots map[types.FileContractID][]types.Hash256, err error) {
-	err = s.transaction(func(tx *txn) error {
-		const query = `SELECT s.sector_root, c.contract_id FROM contract_sector_roots cr
-INNER JOIN stored_sectors s ON (cr.sector_id = s.id)
-INNER JOIN contracts c ON (cr.contract_id = c.id)
-ORDER BY cr.contract_id, cr.root_index ASC;`
-
-		rows, err := tx.Query(query)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-
-		roots = make(map[types.FileContractID][]types.Hash256)
-		for rows.Next() {
-			var contractID types.FileContractID
-			var root types.Hash256
-
-			if err := rows.Scan(decode(&root), decode(&contractID)); err != nil {
-				return fmt.Errorf("failed to scan sector root: %w", err)
-			}
-			roots[contractID] = append(roots[contractID], root)
-		}
-		return rows.Err()
-	})
-	return
-}
-
-// V2SectorRoots returns the sector roots for all v2 contracts.
+// V2SectorRoots returns the sector roots for all active v2 contracts.
 func (s *Store) V2SectorRoots() (roots map[types.FileContractID][]types.Hash256, err error) {
 	err = s.transaction(func(tx *txn) error {
-		const query = `SELECT s.sector_root, c.contract_id FROM contract_v2_sector_roots cr
-INNER JOIN stored_sectors s ON (cr.sector_id = s.id)
-INNER JOIN contracts_v2 c ON (cr.contract_id = c.id)
-ORDER BY cr.contract_id, cr.root_index ASC;`
-
-		rows, err := tx.Query(query)
+		const contractsQuery = `SELECT contract_id, raw_revision, contract_v2_roots_map_id, contract_v2_roots_map_revision_number FROM contracts_v2
+WHERE contract_status <> $1 AND resolution_height IS NULL;`
+		contractRows, err := tx.Query(contractsQuery, contracts.V2ContractStatusRejected)
 		if err != nil {
 			return err
 		}
-		defer rows.Close()
+		defer contractRows.Close()
+
+		type contractRef struct {
+			id        types.FileContractID
+			sectors   uint64
+			mapID     int64
+			mapRevNum int64
+		}
+		var contracts []contractRef
+		for contractRows.Next() {
+			var ref contractRef
+			var fc types.V2FileContract
+			if err := contractRows.Scan(decode(&ref.id), decode(&fc), &ref.mapID, &ref.mapRevNum); err != nil {
+				return fmt.Errorf("failed to scan contract: %w", err)
+			}
+			ref.sectors = fc.Filesize / proto4.SectorSize
+			contracts = append(contracts, ref)
+		}
+		if err := contractRows.Err(); err != nil {
+			return err
+		}
+
+		// for each root_index, select the root from the latest map revision
+		// that is <= the contract map revision number.
+		const rootsQuery = `SELECT sector_root FROM (
+    SELECT s.sector_root, MAX(cr.contract_v2_roots_map_revision_number)
+    FROM contract_v2_sector_roots cr
+    INNER JOIN stored_sectors s ON (cr.sector_id = s.id)
+    WHERE cr.contract_v2_roots_map_id = $1
+    AND cr.contract_v2_roots_map_revision_number <= $2
+    AND cr.root_index < $3
+    GROUP BY cr.root_index
+    ORDER BY cr.root_index ASC
+);`
+
+		rootsStmt, err := tx.Prepare(rootsQuery)
+		if err != nil {
+			return fmt.Errorf("failed to prepare roots query: %w", err)
+		}
+		defer rootsStmt.Close()
 
 		roots = make(map[types.FileContractID][]types.Hash256)
-		for rows.Next() {
-			var contractID types.FileContractID
-			var root types.Hash256
-
-			if err := rows.Scan(decode(&root), decode(&contractID)); err != nil {
-				return fmt.Errorf("failed to scan sector root: %w", err)
+		for _, ref := range contracts {
+			rows, err := rootsStmt.Query(ref.mapID, ref.mapRevNum, ref.sectors)
+			if err != nil {
+				return fmt.Errorf("failed to query roots for contract %v: %w", ref.id, err)
 			}
-			roots[contractID] = append(roots[contractID], root)
+
+			for rows.Next() {
+				var root types.Hash256
+				if err := rows.Scan(decode(&root)); err != nil {
+					rows.Close()
+					return fmt.Errorf("failed to scan sector root: %w", err)
+				}
+				roots[ref.id] = append(roots[ref.id], root)
+			}
+			if err := rows.Err(); err != nil {
+				rows.Close()
+				return err
+			}
+			rows.Close()
 		}
-		return rows.Err()
+		return nil
 	})
 	return
 }
@@ -486,18 +496,7 @@ func (s *Store) ContractActions(index types.ChainIndex, revisionBroadcastHeight 
 // ExpireContractSectors expires all sectors that are no longer covered by an
 // active contract.
 func (s *Store) ExpireContractSectors(height uint64) error {
-	log := s.log.Named("ExpireContractSectors").With(zap.Uint64("height", height))
-	// delete in batches to avoid holding a lock on the database for too long
-	for i := 0; ; i++ {
-		expired, err := s.batchExpireContractSectors(height)
-		if err != nil {
-			return fmt.Errorf("failed to prune sectors: %w", err)
-		} else if expired == 0 {
-			return nil
-		}
-		log.Debug("removed sectors", zap.Int("expired", expired), zap.Int("batch", i))
-		jitterSleep(50 * time.Millisecond) // allow other transactions to run
-	}
+	return nil // TODO: remove
 }
 
 // ExpireV2ContractSectors expires all sectors that are no longer covered by an
@@ -533,36 +532,26 @@ func getContract(tx *txn, contractID int64) (contracts.Contract, error) {
 	return contract, err
 }
 
-func deleteExpiredContractSectors(tx *txn, height uint64) (sectorIDs []int64, err error) {
-	const query = `DELETE FROM contract_sector_roots
-WHERE id IN (SELECT csr.id FROM contract_sector_roots csr
-INNER JOIN contracts c ON (csr.contract_id=c.id)
--- past proof window or not confirmed and past the rebroadcast height
-WHERE c.window_end < $1 OR c.contract_status=$2 LIMIT $3)
-RETURNING sector_id;`
-	rows, err := tx.Query(query, height, contracts.ContractStatusRejected, sqlSectorBatchSize)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		sectorIDs = append(sectorIDs, id)
-	}
-	return sectorIDs, nil
-}
-
 func deleteExpiredV2ContractSectors(tx *txn, height uint64) (sectorIDs []int64, err error) {
-	const query = `DELETE FROM contract_v2_sector_roots
+	// delete roots where the contract at that (map_id, revision_number) is
+	// expired and no active higher-revision contract depends on them
+	const expiredQuery = `DELETE FROM contract_v2_sector_roots
 WHERE id IN (SELECT csr.id FROM contract_v2_sector_roots csr
-INNER JOIN contracts_v2 c ON (csr.contract_id=c.id)
--- past expiration or not confirmed and past the rebroadcast height
-WHERE c.resolution_height < $1 OR c.contract_status=$2 LIMIT $3)
+INNER JOIN contracts_v2 c ON (
+	c.contract_v2_roots_map_id = csr.contract_v2_roots_map_id
+	AND c.contract_v2_roots_map_revision_number = csr.contract_v2_roots_map_revision_number
+)
+WHERE (c.resolution_height IS NOT NULL AND c.resolution_height < $1 OR c.contract_status = $2)
+AND NOT EXISTS (
+	SELECT 1 FROM contracts_v2 c2
+	WHERE c2.contract_v2_roots_map_id = csr.contract_v2_roots_map_id
+	AND c2.contract_v2_roots_map_revision_number > csr.contract_v2_roots_map_revision_number
+	AND (c2.resolution_height IS NULL OR c2.resolution_height >= $1)
+	AND c2.contract_status != $2
+)
+LIMIT $3)
 RETURNING sector_id;`
-	rows, err := tx.Query(query, height, contracts.V2ContractStatusRejected, sqlSectorBatchSize)
+	rows, err := tx.Query(expiredQuery, height, contracts.V2ContractStatusRejected, sqlSectorBatchSize)
 	if err != nil {
 		return nil, err
 	}
@@ -573,6 +562,87 @@ RETURNING sector_id;`
 			return nil, err
 		}
 		sectorIDs = append(sectorIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(sectorIDs) >= sqlSectorBatchSize {
+		return sectorIDs, nil
+	}
+
+	// find expired (map_id, revision_number) pairs that have an active
+	// higher-revision contract. These roots may have been superseded by
+	// a replacement at a higher revision and can be garbage collected.
+	const expiredPairsQuery = `SELECT c.contract_v2_roots_map_id, c.contract_v2_roots_map_revision_number
+FROM contracts_v2 c
+WHERE (c.resolution_height IS NOT NULL AND c.resolution_height < $1 OR c.contract_status = $2)
+AND EXISTS (
+	SELECT 1 FROM contracts_v2 c2
+	WHERE c2.contract_v2_roots_map_id = c.contract_v2_roots_map_id
+	AND c2.contract_v2_roots_map_revision_number > c.contract_v2_roots_map_revision_number
+	AND (c2.resolution_height IS NULL OR c2.resolution_height >= $1)
+	AND c2.contract_status != $2
+)`
+	pairRows, err := tx.Query(expiredPairsQuery, height, contracts.V2ContractStatusRejected)
+	if err != nil {
+		return nil, err
+	}
+	defer pairRows.Close()
+
+	type mapPair struct {
+		mapID    int64
+		revision int64
+	}
+	var pairs []mapPair
+	for pairRows.Next() {
+		var p mapPair
+		if err := pairRows.Scan(&p.mapID, &p.revision); err != nil {
+			return nil, err
+		}
+		pairs = append(pairs, p)
+	}
+	if err := pairRows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(pairs) == 0 {
+		return sectorIDs, nil
+	}
+
+	// for each expired pair, delete roots that have been superseded by a
+	// replacement at a higher revision for the same root_index. This is
+	// scoped to a single map_id so the query is efficient.
+	//
+	// Superseded rows are not included in the returned sectorIDs because
+	// they should not affect the contract sectors metric. When a sector
+	// is replaced at a higher revision, the delta is 0, so deleting the
+	// old row should not decrement the metric.
+	const supersededQuery = `DELETE FROM contract_v2_sector_roots
+WHERE id IN (SELECT csr.id FROM contract_v2_sector_roots csr
+WHERE csr.contract_v2_roots_map_id = $1
+AND csr.contract_v2_roots_map_revision_number = $2
+AND EXISTS (
+	SELECT 1 FROM contract_v2_sector_roots csr2
+	WHERE csr2.contract_v2_roots_map_id = csr.contract_v2_roots_map_id
+	AND csr2.contract_v2_roots_map_revision_number > csr.contract_v2_roots_map_revision_number
+	AND csr2.root_index = csr.root_index
+)
+LIMIT $3)`
+	supersededStmt, err := tx.Prepare(supersededQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer supersededStmt.Close()
+
+	remaining := sqlSectorBatchSize - len(sectorIDs)
+	for _, p := range pairs {
+		if remaining <= 0 {
+			break
+		}
+		if _, err := supersededStmt.Exec(p.mapID, p.revision, remaining); err != nil {
+			return nil, err
+		}
 	}
 	return sectorIDs, nil
 }
@@ -893,7 +963,8 @@ raw_revision, host_sig, renter_sig, confirmed_revision_number, contract_status, 
 func resetRejectedV2Contract(tx *txn, contractID types.FileContractID) error {
 	var dbID int64
 	var status contracts.V2ContractStatus
-	err := tx.QueryRow(`SELECT id, contract_status FROM contracts_v2 WHERE contract_id=$1;`, encode(contractID)).Scan(&dbID, &status)
+	var contractMapID, contractMapRevisionNumber int64
+	err := tx.QueryRow(`SELECT id, contract_status, contract_v2_roots_map_id, contract_v2_roots_map_revision_number FROM contracts_v2 WHERE contract_id=$1;`, encode(contractID)).Scan(&dbID, &status, &contractMapID, &contractMapRevisionNumber)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil // contract does not exist
 	} else if err != nil {
@@ -914,7 +985,7 @@ func resetRejectedV2Contract(tx *txn, contractID types.FileContractID) error {
 	// note: this should already be handled, but there is a small race where
 	// not all of the sectors may be cleaned up before the renter tries to
 	// renew. Instead of failing, it is preferred to clean up the remaining roots.
-	res, err := tx.Exec(`DELETE FROM contract_v2_sector_roots WHERE contract_id=$1;`, dbID)
+	res, err := tx.Exec(`DELETE FROM contract_v2_sector_roots WHERE contract_v2_roots_map_id=$1 AND contract_v2_roots_map_revision_number=$2;`, contractMapID, contractMapRevisionNumber)
 	if err != nil {
 		return fmt.Errorf("failed to delete rejected contract sectors: %w", err)
 	}
@@ -925,6 +996,8 @@ func resetRejectedV2Contract(tx *txn, contractID types.FileContractID) error {
 
 	if _, err = tx.Exec(`DELETE FROM contracts_v2 WHERE id=$1;`, dbID); err != nil {
 		return fmt.Errorf("failed to delete rejected contract: %w", err)
+	} else if _, err = tx.Exec(`DELETE FROM contract_v2_roots_map WHERE id=$1 AND revision_number=$2;`, contractMapID, contractMapRevisionNumber); err != nil {
+		return fmt.Errorf("failed to delete rejected contract roots map: %w", err)
 	}
 
 	if err := incrementNumericStat(metricContractSectors, -n, time.Now()); err != nil {
@@ -935,15 +1008,11 @@ func resetRejectedV2Contract(tx *txn, contractID types.FileContractID) error {
 	return nil
 }
 
-func insertV2Contract(tx *txn, contract contracts.V2Contract, formationSet rhp4.TransactionSet) (dbID int64, err error) {
+func insertV2Contract(tx *txn, contract contracts.V2Contract, mapID, mapRevisionNumber int64, formationSet rhp4.TransactionSet) (dbID int64, err error) {
 	const query = `INSERT INTO contracts_v2 (contract_id, renter_id, locked_collateral, rpc_revenue, storage_revenue, ingress_revenue,
 egress_revenue, account_funding, risked_collateral, revision_number, negotiation_height, proof_height, expiration_height, formation_txn_set,
-formation_txn_set_basis, raw_revision, contract_status) VALUES
- ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) RETURNING id;`
-
-	if err := resetRejectedV2Contract(tx, contract.ID); err != nil {
-		return 0, err
-	}
+formation_txn_set_basis, raw_revision, contract_status, contract_v2_roots_map_id, contract_v2_roots_map_revision_number) VALUES
+ ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) RETURNING id;`
 
 	renterID, err := renterDBID(tx, contract.RenterPublicKey)
 	if err != nil {
@@ -968,11 +1037,10 @@ formation_txn_set_basis, raw_revision, contract_status) VALUES
 		encode(formationSet.Basis),
 		encode(contract.V2FileContract),
 		contracts.V2ContractStatusPending,
+		mapID,
+		mapRevisionNumber,
 	).Scan(&dbID)
-	if err != nil {
-		return 0, fmt.Errorf("failed to insert contract: %w", err)
-	}
-	return
+	return dbID, err
 }
 
 func updateContractSectors(tx *txn, contractDBID int64, oldRoots, newRoots []types.Hash256) error {
@@ -1083,11 +1151,17 @@ func updateV2ContractSectors(tx *txn, contractDBID int64, oldRoots, newRoots []t
 	}
 	defer selectRootIDStmt.Close()
 
-	updateRootStmt, err := tx.Prepare(`INSERT INTO contract_v2_sector_roots (contract_id, sector_id, root_index) VALUES (?, ?, ?) ON CONFLICT (contract_id, root_index) DO UPDATE SET sector_id=excluded.sector_id`)
+	updateRootStmt, err := tx.Prepare(`INSERT INTO contract_v2_sector_roots (contract_v2_roots_map_id, contract_v2_roots_map_revision_number, sector_id, root_index) VALUES (?, ?, ?, ?) ON CONFLICT (contract_v2_roots_map_id, contract_v2_roots_map_revision_number, root_index) DO UPDATE SET sector_id=excluded.sector_id`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare update root statement: %w", err)
 	}
 	defer updateRootStmt.Close()
+
+	var contractMapID, contractMapRevisionID int64
+	err = tx.QueryRow(`SELECT contract_v2_roots_map_id, contract_v2_roots_map_revision_number FROM contracts_v2 WHERE id=$1`, contractDBID).Scan(&contractMapID, &contractMapRevisionID)
+	if err != nil {
+		return fmt.Errorf("failed to get contract map ID: %w", err)
+	}
 
 	for i, root := range newRoots {
 		if i < len(oldRoots) && oldRoots[i] == root {
@@ -1097,15 +1171,8 @@ func updateV2ContractSectors(tx *txn, contractDBID int64, oldRoots, newRoots []t
 		var newSectorID int64
 		if err := selectRootIDStmt.QueryRow(encode(root)).Scan(&newSectorID); err != nil {
 			return fmt.Errorf("failed to get sector ID: %w", err)
-		} else if _, err := updateRootStmt.Exec(contractDBID, newSectorID, i); err != nil {
+		} else if _, err := updateRootStmt.Exec(contractMapID, contractMapRevisionID, newSectorID, i); err != nil {
 			return fmt.Errorf("failed to update sector root: %w", err)
-		}
-	}
-
-	if len(newRoots) < len(oldRoots) {
-		_, err := tx.Exec(`DELETE FROM contract_v2_sector_roots WHERE contract_id=$1 AND root_index >= $2`, contractDBID, len(newRoots))
-		if err != nil {
-			return fmt.Errorf("failed to remove old roots: %w", err)
 		}
 	}
 

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -998,7 +998,6 @@ func v2ContractRoots(tx *txn, contractMapID, contractMapRevision int64, maxSecto
 	for rows.Next() {
 		var root types.Hash256
 		if err := rows.Scan(decode(&root)); err != nil {
-
 			return nil, fmt.Errorf("failed to scan sector root: %w", err)
 		}
 		roots = append(roots, root)

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -235,9 +235,9 @@ func (s *Store) AddV2Contract(contract contracts.V2Contract, formationSet rhp4.T
 }
 
 // RenewV2Contract adds a new v2 contract to the database and sets the old
-// contract's renewed_from field. The old contract's sector roots are
-// copied to the new contract. The status of the old contract should continue
-// to be active until the renewal is confirmed
+// contract's renewed_from field. The new contract inherits the old contract's
+// sector roots. The status of the old contract should continue to be active
+// until the renewal is confirmed
 func (s *Store) RenewV2Contract(renewal contracts.V2Contract, renewalSet rhp4.TransactionSet, renewedID types.FileContractID) error {
 	return s.transaction(func(tx *txn) error {
 		if err := resetRejectedV2Contract(tx, renewal.ID); err != nil {
@@ -902,16 +902,18 @@ func resetRejectedV2Contract(tx *txn, contractID types.FileContractID) error {
 }
 
 func v2ContractRoots(tx *txn, contractMapID, contractMapRevision int64, maxSectors uint64) (roots []types.Hash256, err error) {
+	// sector_root is a bare column not in GROUP BY, but SQLite guarantees it
+	// comes from the row with the maximum revision_number per root_index.
+	// See https://www.sqlite.org/lang_select.html#bare_columns_in_an_aggregate_query
 	const rootsQuery = `SELECT sector_root FROM (
-    SELECT s.sector_root, MAX(cr.contract_v2_roots_map_revision_number)
+    SELECT s.sector_root, cr.root_index, MAX(cr.contract_v2_roots_map_revision_number)
     FROM contract_v2_sector_roots cr
     INNER JOIN stored_sectors s ON (cr.sector_id = s.id)
     WHERE cr.contract_v2_roots_map_id = $1
     AND cr.contract_v2_roots_map_revision_number <= $2
     AND cr.root_index < $3
-    GROUP BY cr.root_index
-    ORDER BY cr.root_index ASC
-);`
+    GROUP BY cr.root_index)
+	ORDER BY root_index ASC;`
 
 	rows, err := tx.Query(rootsQuery, contractMapID, contractMapRevision, maxSectors)
 	if err != nil {

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -953,6 +953,119 @@ WHERE c.contract_id = $1`, encode(contractID)).Scan(&count)
 			t.Fatalf("expected 0 remaining sector roots, got %d", n)
 		}
 	})
+
+	t.Run("renewal rejected then renewed again", func(t *testing.T) {
+		checkSectorRoots := func(t *testing.T, contractID types.FileContractID, expected []types.Hash256) {
+			t.Helper()
+			roots, err := db.V2SectorRoots()
+			if err != nil {
+				t.Fatal(err)
+			}
+			actual := roots[contractID]
+			if !slices.Equal(actual, expected) {
+				t.Fatalf("expected %d roots, got %d", len(expected), len(actual))
+			}
+		}
+
+		rejectContract := func(t *testing.T, contractID types.FileContractID, parentID types.FileContractID) {
+			t.Helper()
+			err := db.transaction(func(tx *txn) error {
+				// set the contract status to rejected
+				if _, err := tx.Exec(`UPDATE contracts_v2 SET contract_status=$1 WHERE contract_id=$2`,
+					contracts.V2ContractStatusRejected, encode(contractID)); err != nil {
+					return err
+				}
+				// clear the renewed_to field on the parent so it can be renewed again
+				if _, err := tx.Exec(`UPDATE contracts_v2 SET renewed_to=NULL WHERE contract_id=$1`, encode(parentID)); err != nil {
+					return err
+				}
+				// increment rejected contracts metric (matches rejectV2Contracts behavior)
+				return incrementNumericStat(tx, metricRejectedContracts, 1, time.Now())
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// create c1
+		c1 := contracts.V2Contract{
+			ID: frand.Entropy256(),
+			V2FileContract: types.V2FileContract{
+				RenterPublicKey:  renterKey.PublicKey(),
+				HostPublicKey:    hostKey.PublicKey(),
+				ProofHeight:      100,
+				ExpirationHeight: 200,
+			},
+		}
+		if err := db.AddV2Contract(c1, rhp4.TransactionSet{}); err != nil {
+			t.Fatal(err)
+		}
+
+		// add sectors to c1
+		c1Roots := storeSectors(t, 8)
+		c1.V2FileContract.RevisionNumber++
+		c1.V2FileContract.Filesize = proto4.SectorSize * uint64(len(c1Roots))
+		if err := db.ReviseV2Contract(c1.ID, c1.V2FileContract, nil, c1Roots, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+
+		// renew c1 → c2
+		c2 := contracts.V2Contract{
+			ID: c1.ID.V2RenewalID(),
+			V2FileContract: types.V2FileContract{
+				RenterPublicKey:  renterKey.PublicKey(),
+				HostPublicKey:    hostKey.PublicKey(),
+				Filesize:         c1.V2FileContract.Filesize,
+				ProofHeight:      200,
+				ExpirationHeight: 300,
+			},
+		}
+		if err := db.RenewV2Contract(c2, rhp4.TransactionSet{}, c1.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		// upload additional sectors to c2
+		c2Extra := storeSectors(t, 4)
+		c2Roots := append(slices.Clone(c1Roots), c2Extra...)
+		c2.V2FileContract.RevisionNumber++
+		c2.V2FileContract.Filesize = proto4.SectorSize * uint64(len(c2Roots))
+		if err := db.ReviseV2Contract(c2.ID, c2.V2FileContract, c1Roots, c2Roots, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+
+		// reject c2 due to a reorg
+		rejectContract(t, c2.ID, c1.ID)
+
+		// renew c1 → c3
+		c3 := contracts.V2Contract{
+			ID: c1.ID.V2RenewalID(),
+			V2FileContract: types.V2FileContract{
+				RenterPublicKey:  renterKey.PublicKey(),
+				HostPublicKey:    hostKey.PublicKey(),
+				Filesize:         c1.V2FileContract.Filesize,
+				ProofHeight:      300,
+				ExpirationHeight: 400,
+			},
+		}
+		if err := db.RenewV2Contract(c3, rhp4.TransactionSet{}, c1.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		// c3 should have c1's original sectors
+		checkSectorRoots(t, c3.ID, c1Roots)
+
+		// upload more sectors to c3
+		c3Extra := storeSectors(t, 5)
+		c3Roots := append(slices.Clone(c1Roots), c3Extra...)
+		c3.V2FileContract.RevisionNumber++
+		c3.V2FileContract.Filesize = proto4.SectorSize * uint64(len(c3Roots))
+		if err := db.ReviseV2Contract(c3.ID, c3.V2FileContract, c1Roots, c3Roots, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+
+		// verify all sectors are present
+		checkSectorRoots(t, c3.ID, c3Roots)
+	})
 }
 
 func BenchmarkV2AppendSectors(b *testing.B) {

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -602,17 +602,6 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 		}
 	}
 
-	checkMetricConsistency := func(t *testing.T, expected uint64) {
-		t.Helper()
-
-		m, err := db.Metrics(time.Now())
-		if err != nil {
-			t.Fatal("failed to get metrics:", err)
-		} else if m.Storage.ContractSectors != expected {
-			t.Fatalf("expected %d contract sectors, got %d", expected, m.Storage.ContractSectors)
-		}
-	}
-
 	var roots []types.Hash256
 	appendSectors := func(t *testing.T, n int) {
 		t.Helper()
@@ -634,7 +623,6 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 		}
 
 		checkRootConsistency(t, newRoots)
-		checkMetricConsistency(t, uint64(len(newRoots)))
 		roots = newRoots
 	}
 
@@ -651,7 +639,6 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 			t.Fatal("failed to revise contract:", err)
 		}
 		checkRootConsistency(t, newRoots)
-		checkMetricConsistency(t, uint64(len(newRoots)))
 		roots = newRoots
 	}
 
@@ -671,7 +658,6 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 		}
 
 		checkRootConsistency(t, newRoots)
-		checkMetricConsistency(t, uint64(len(newRoots)))
 		roots = newRoots
 	}
 
@@ -688,7 +674,6 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 		}
 
 		checkRootConsistency(t, newRoots)
-		checkMetricConsistency(t, uint64(len(newRoots)))
 		roots = newRoots
 	}
 

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -583,11 +584,21 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 	checkRootConsistency := func(t *testing.T, expected []types.Hash256) {
 		t.Helper()
 
-		contractRoots, err := db.V2SectorRoots()
+		var actual []types.Hash256
+		err := db.transaction(func(tx *txn) error {
+			var mapID, mapRevNum int64
+			err := tx.QueryRow(`SELECT contract_v2_roots_map_id, contract_v2_roots_map_revision_number FROM contracts_v2 WHERE contract_id=$1`, encode(contract.ID)).Scan(&mapID, &mapRevNum)
+			if err != nil {
+				return err
+			}
+			// maxint64 is used here to catch orphaned deleted roots
+			actual, err = v2ContractRoots(tx, mapID, mapRevNum, math.MaxInt64)
+			return err
+		})
 		if err != nil {
 			t.Fatal("failed to get sector roots:", err)
-		} else if !slices.Equal(contractRoots[contract.ID], expected) {
-			t.Fatalf("expected roots %v, got %v", expected, contractRoots[contract.ID])
+		} else if !slices.Equal(actual, expected) {
+			t.Fatalf("expected roots %v, got %v", expected, actual)
 		}
 	}
 

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -1226,10 +1226,15 @@ func BenchmarkRefreshContract(b *testing.B) {
 				}
 			}
 
-			if err := db.ReviseV2Contract(contract.ID, contract.V2FileContract, nil, roots, proto4.Usage{}); err != nil {
+			revision := contract.V2FileContract
+			revision.RevisionNumber++
+			revision.Filesize = proto4.SectorSize * uint64(len(roots))
+			revision.FileMerkleRoot = proto4.MetaRoot(roots)
+
+			if err := db.ReviseV2Contract(contract.ID, revision, nil, roots, proto4.Usage{}); err != nil {
 				b.Fatal(err)
 			}
-
+			contract.V2FileContract = revision
 			currentID := contract.ID
 			b.ResetTimer()
 			b.ReportAllocs()
@@ -1257,5 +1262,189 @@ func BenchmarkRefreshContract(b *testing.B) {
 		(10 << 40) / proto4.SectorSize, // 10 TiB
 	} {
 		runBenchmark(b, n)
+	}
+}
+
+func BenchmarkExpireV2ContractSectors(b *testing.B) {
+	const (
+		proofHeight      = 100
+		expirationHeight = 200
+	)
+	contractSectors := b.N * sqlSectorBatchSize * 2
+
+	log := zap.NewNop()
+	db, err := OpenDatabase(filepath.Join(b.TempDir(), "test.db"), log.Named("sqlite3"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	volumeID, err := db.AddVolume("test.dat", false)
+	if err != nil {
+		b.Fatal(err)
+	} else if err := db.SetAvailable(volumeID, true); err != nil {
+		b.Fatal(err)
+	} else if err = db.GrowVolume(volumeID, uint64(contractSectors)); err != nil {
+		b.Fatal(err)
+	}
+
+	contract := contracts.V2Contract{
+		ID: frand.Entropy256(),
+		V2FileContract: types.V2FileContract{
+			RenterPublicKey:  frand.Entropy256(),
+			HostPublicKey:    frand.Entropy256(),
+			RevisionNumber:   1,
+			ProofHeight:      proofHeight,
+			ExpirationHeight: expirationHeight,
+		},
+	}
+	if err := db.AddV2Contract(contract, rhp4.TransactionSet{}); err != nil {
+		b.Fatal(err)
+	}
+
+	roots := make([]types.Hash256, contractSectors)
+	for i := range roots {
+		roots[i] = frand.Entropy256()
+		if err := db.StoreSector(roots[i], func(loc storage.SectorLocation) error { return nil }); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	contract.V2FileContract.RevisionNumber++
+	contract.V2FileContract.Filesize = proto4.SectorSize * uint64(len(roots))
+	contract.V2FileContract.FileMerkleRoot = proto4.MetaRoot(roots)
+	if err := db.ReviseV2Contract(contract.ID, contract.V2FileContract, nil, roots, proto4.Usage{}); err != nil {
+		b.Fatal(err)
+	}
+
+	err = db.transaction(func(tx *txn) error {
+		_, err := tx.Exec(`UPDATE contracts_v2 SET resolution_height=$1, resolution_block_id=$2, contract_status=$3`,
+			100, encode(types.BlockID{}), contracts.V2ContractStatusSuccessful)
+		return err
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.ReportMetric(float64(contractSectors), "sectors")
+
+	for range b.N {
+		n, err := db.batchExpireV2ContractSectors(contract.ExpirationHeight + 1)
+		if err != nil {
+			b.Fatal(err)
+		} else if n != int64(sqlSectorBatchSize) {
+			b.Fatalf("expected to expire %d sectors, expired %d", sqlSectorBatchSize, n)
+		}
+	}
+}
+
+func BenchmarkExpireV2ContractSectorsSuperseded(b *testing.B) {
+	const (
+		proofHeight      = 100
+		expirationHeight = 200
+	)
+	contractSectors := b.N * sqlSectorBatchSize * 2
+
+	log := zap.NewNop()
+	db, err := OpenDatabase(filepath.Join(b.TempDir(), "test.db"), log.Named("sqlite3"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	volumeID, err := db.AddVolume("test.dat", false)
+	if err != nil {
+		b.Fatal(err)
+	} else if err := db.SetAvailable(volumeID, true); err != nil {
+		b.Fatal(err)
+	} else if err = db.GrowVolume(volumeID, uint64(2*contractSectors)); err != nil {
+		b.Fatal(err)
+	}
+
+	// create c1 with sectors
+	c1 := contracts.V2Contract{
+		ID: frand.Entropy256(),
+		V2FileContract: types.V2FileContract{
+			RenterPublicKey:  frand.Entropy256(),
+			HostPublicKey:    frand.Entropy256(),
+			RevisionNumber:   1,
+			ProofHeight:      proofHeight,
+			ExpirationHeight: expirationHeight,
+		},
+	}
+	if err := db.AddV2Contract(c1, rhp4.TransactionSet{}); err != nil {
+		b.Fatal(err)
+	}
+
+	roots := make([]types.Hash256, contractSectors)
+	for i := range roots {
+		roots[i] = frand.Entropy256()
+		if err := db.StoreSector(roots[i], func(loc storage.SectorLocation) error { return nil }); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	c1.V2FileContract.RevisionNumber++
+	c1.V2FileContract.Filesize = proto4.SectorSize * uint64(len(roots))
+	c1.V2FileContract.FileMerkleRoot = proto4.MetaRoot(roots)
+	if err := db.ReviseV2Contract(c1.ID, c1.V2FileContract, nil, roots, proto4.Usage{}); err != nil {
+		b.Fatal(err)
+	}
+
+	// renew c1 -> c2, inheriting all sectors
+	c2 := contracts.V2Contract{
+		ID: frand.Entropy256(),
+		V2FileContract: types.V2FileContract{
+			RenterPublicKey:  c1.RenterPublicKey,
+			HostPublicKey:    c1.HostPublicKey,
+			RevisionNumber:   1,
+			Filesize:         c1.V2FileContract.Filesize,
+			ProofHeight:      200,
+			ExpirationHeight: 300,
+		},
+	}
+	if err := db.RenewV2Contract(c2, rhp4.TransactionSet{}, c1.ID); err != nil {
+		b.Fatal(err)
+	}
+
+	// replace every sector in c2 so all of c1's rows become superseded
+	newRoots := make([]types.Hash256, contractSectors)
+	for i := range newRoots {
+		newRoots[i] = frand.Entropy256()
+		if err := db.StoreSector(newRoots[i], func(loc storage.SectorLocation) error { return nil }); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	c2.V2FileContract.RevisionNumber++
+	c2.V2FileContract.Filesize = proto4.SectorSize * uint64(len(newRoots))
+	c2.V2FileContract.FileMerkleRoot = proto4.MetaRoot(newRoots)
+	if err := db.ReviseV2Contract(c2.ID, c2.V2FileContract, roots, newRoots, proto4.Usage{}); err != nil {
+		b.Fatal(err)
+	}
+
+	// resolve c1 so its rows become eligible for expiry
+	err = db.transaction(func(tx *txn) error {
+		_, err := tx.Exec(`UPDATE contracts_v2 SET resolution_height=$1, resolution_block_id=$2, contract_status=$3 WHERE contract_id=$4`,
+			proofHeight, encode(types.BlockID{}), contracts.V2ContractStatusRenewed, encode(c1.ID))
+		return err
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.ReportMetric(float64(contractSectors), "sectors")
+
+	for range b.N {
+		n, err := db.batchExpireV2ContractSectors(c1.ExpirationHeight + 1)
+		if err != nil {
+			b.Fatal(err)
+		} else if n != int64(sqlSectorBatchSize) {
+			b.Fatalf("expected to expire %d sectors, expired %d", sqlSectorBatchSize, n)
+		}
 	}
 }

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -582,28 +583,11 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 	checkRootConsistency := func(t *testing.T, expected []types.Hash256) {
 		t.Helper()
 
-		err := db.transaction(func(tx *txn) error {
-			stmt, err := tx.Prepare(`SELECT ss.sector_root FROM stored_sectors ss
-INNER JOIN contract_v2_sector_roots csr ON (ss.id = csr.sector_id)
-INNER JOIN contracts_v2 c ON (csr.contract_id = c.id)
-WHERE c.contract_id=$1 AND csr.root_index= $2`)
-			if err != nil {
-				t.Fatal("failed to prepare statement:", err)
-			}
-			defer stmt.Close()
-
-			for i, root := range expected {
-				var dbRoot types.Hash256
-				if err := stmt.QueryRow(encode(contract.ID), i).Scan(decode(&dbRoot)); err != nil {
-					t.Fatalf("failed to scan root %d: %s", i, err)
-				} else if dbRoot != root {
-					t.Fatalf("expected root %q at index %d, got %q", root, i, dbRoot)
-				}
-			}
-			return nil
-		})
+		contractRoots, err := db.V2SectorRoots()
 		if err != nil {
-			t.Fatal("failed to get db roots:", err)
+			t.Fatal("failed to get sector roots:", err)
+		} else if !slices.Equal(contractRoots[contract.ID], expected) {
+			t.Fatalf("expected roots %v, got %v", expected, contractRoots[contract.ID])
 		}
 	}
 
@@ -633,6 +617,7 @@ WHERE c.contract_id=$1 AND csr.root_index= $2`)
 		}
 		newRoots := append(append([]types.Hash256(nil), roots...), appended...)
 		contract.V2FileContract.RevisionNumber++
+		contract.V2FileContract.Filesize = proto4.SectorSize * uint64(len(newRoots))
 		if err := db.ReviseV2Contract(contract.ID, contract.V2FileContract, roots, newRoots, proto4.Usage{}); err != nil {
 			t.Fatal("failed to revise contract:", err)
 		}
@@ -669,6 +654,7 @@ WHERE c.contract_id=$1 AND csr.root_index= $2`)
 		}
 
 		contract.V2FileContract.RevisionNumber++
+		contract.V2FileContract.Filesize = proto4.SectorSize * uint64(len(newRoots))
 		if err := db.ReviseV2Contract(contract.ID, contract.V2FileContract, roots, newRoots, proto4.Usage{}); err != nil {
 			t.Fatal("failed to revise contract:", err)
 		}
@@ -685,6 +671,7 @@ WHERE c.contract_id=$1 AND csr.root_index= $2`)
 		newRoots = newRoots[:len(newRoots)-n]
 
 		contract.V2FileContract.RevisionNumber++
+		contract.V2FileContract.Filesize = proto4.SectorSize * uint64(len(newRoots))
 		if err := db.ReviseV2Contract(contract.ID, contract.V2FileContract, roots, newRoots, proto4.Usage{}); err != nil {
 			t.Fatal("failed to revise contract:", err)
 		}
@@ -883,7 +870,7 @@ func BenchmarkRefreshContract(b *testing.B) {
 						RevisionNumber: 1,
 					},
 				}
-				if err := db.RenewV2Contract(contract, rhp4.TransactionSet{}, currentID, roots); err != nil {
+				if err := db.RenewV2Contract(contract, rhp4.TransactionSet{}, currentID); err != nil {
 					b.Fatal(err)
 				}
 				currentID = contract.ID

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -693,6 +693,268 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 	trimSectors(t, frand.Intn(len(roots)/4)+1)
 }
 
+func TestExpireV2ContractSectorsBatching(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	renterKey := types.NewPrivateKeyFromSeed(frand.Bytes(32))
+	hostKey := types.NewPrivateKeyFromSeed(frand.Bytes(32))
+
+	volumeID, err := db.AddVolume("test.dat", false)
+	if err != nil {
+		t.Fatal(err)
+	} else if err := db.SetAvailable(volumeID, true); err != nil {
+		t.Fatal(err)
+	} else if err = db.GrowVolume(volumeID, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	resolveContract := func(t *testing.T, contractID types.FileContractID, height uint64) {
+		t.Helper()
+		err := db.transaction(func(tx *txn) error {
+			_, err := tx.Exec(`UPDATE contracts_v2 SET resolution_height=$1, resolution_block_id=$2, contract_status=$3 WHERE contract_id=$4`,
+				height, encode(types.BlockID{}), contracts.V2ContractStatusSuccessful, encode(contractID))
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	countSectorRows := func(t *testing.T, contractID types.FileContractID) int {
+		t.Helper()
+		var count int
+		err := db.transaction(func(tx *txn) error {
+			return tx.QueryRow(`SELECT COUNT(*) FROM contract_v2_sector_roots csr
+INNER JOIN contracts_v2 c ON (c.contract_v2_roots_map_id = csr.contract_v2_roots_map_id
+AND c.contract_v2_roots_map_revision_number = csr.contract_v2_roots_map_revision_number)
+WHERE c.contract_id = $1`, encode(contractID)).Scan(&count)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return count
+	}
+
+	countAllSectorRows := func(t *testing.T) int {
+		t.Helper()
+		var count int
+		err := db.transaction(func(tx *txn) error {
+			return tx.QueryRow(`SELECT COUNT(*) FROM contract_v2_sector_roots`).Scan(&count)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return count
+	}
+
+	storeSectors := func(t *testing.T, n int) []types.Hash256 {
+		t.Helper()
+		var roots []types.Hash256
+		for range n {
+			root := frand.Entropy256()
+			if err := db.StoreSector(root, func(loc storage.SectorLocation) error { return nil }); err != nil {
+				t.Fatal(err)
+			}
+			roots = append(roots, root)
+		}
+		return roots
+	}
+
+	t.Run("single contract", func(t *testing.T) {
+		contract := contracts.V2Contract{
+			ID: frand.Entropy256(),
+			V2FileContract: types.V2FileContract{
+				RenterPublicKey:  renterKey.PublicKey(),
+				HostPublicKey:    hostKey.PublicKey(),
+				ProofHeight:      100,
+				ExpirationHeight: 200,
+			},
+		}
+		if err := db.AddV2Contract(contract, rhp4.TransactionSet{}); err != nil {
+			t.Fatal(err)
+		}
+
+		roots := storeSectors(t, 13)
+		contract.V2FileContract.RevisionNumber++
+		contract.V2FileContract.Filesize = proto4.SectorSize * uint64(len(roots))
+		if err := db.ReviseV2Contract(contract.ID, contract.V2FileContract, nil, roots, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+
+		resolveContract(t, contract.ID, 100)
+		if err := db.ExpireV2ContractSectors(101); err != nil {
+			t.Fatal(err)
+		} else if n := countSectorRows(t, contract.ID); n != 0 {
+			t.Fatalf("expected 0 remaining sector roots, got %d", n)
+		}
+	})
+
+	t.Run("renewal chain with orphans", func(t *testing.T) {
+		c1 := contracts.V2Contract{
+			ID: frand.Entropy256(),
+			V2FileContract: types.V2FileContract{
+				RenterPublicKey:  renterKey.PublicKey(),
+				HostPublicKey:    hostKey.PublicKey(),
+				ProofHeight:      100,
+				ExpirationHeight: 200,
+			},
+		}
+		if err := db.AddV2Contract(c1, rhp4.TransactionSet{}); err != nil {
+			t.Fatal(err)
+		}
+
+		roots := storeSectors(t, 8)
+		c1.V2FileContract.RevisionNumber++
+		c1.V2FileContract.Filesize = proto4.SectorSize * uint64(len(roots))
+		if err := db.ReviseV2Contract(c1.ID, c1.V2FileContract, nil, roots, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+
+		// renew the contract — c2 inherits roots from c1
+		c2 := contracts.V2Contract{
+			ID: frand.Entropy256(),
+			V2FileContract: types.V2FileContract{
+				RenterPublicKey:  renterKey.PublicKey(),
+				HostPublicKey:    hostKey.PublicKey(),
+				Filesize:         c1.V2FileContract.Filesize,
+				ProofHeight:      200,
+				ExpirationHeight: 300,
+			},
+		}
+		if err := db.RenewV2Contract(c2, rhp4.TransactionSet{}, c1.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		// delete 3 sectors from the renewal via swap-and-trim, creating
+		// orphaned inherited rows at the old revision
+		newRoots := slices.Clone(roots)
+		newRoots[1] = newRoots[len(newRoots)-1]
+		newRoots[3] = newRoots[len(newRoots)-2]
+		newRoots[5] = newRoots[len(newRoots)-3]
+		newRoots = newRoots[:len(newRoots)-3]
+
+		c2.V2FileContract.RevisionNumber++
+		c2.V2FileContract.Filesize = proto4.SectorSize * uint64(len(newRoots))
+		if err := db.ReviseV2Contract(c2.ID, c2.V2FileContract, roots, newRoots, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+
+		// add more sectors to push total rows past the batch size
+		extra := storeSectors(t, 6)
+		finalRoots := append(slices.Clone(newRoots), extra...)
+		c2.V2FileContract.RevisionNumber++
+		c2.V2FileContract.Filesize = proto4.SectorSize * uint64(len(finalRoots))
+		if err := db.ReviseV2Contract(c2.ID, c2.V2FileContract, newRoots, finalRoots, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+
+		totalBefore := countAllSectorRows(t)
+
+		// resolve the original contract so its rows become eligible for expiry
+		resolveContract(t, c1.ID, 100)
+		if err := db.ExpireV2ContractSectors(101); err != nil {
+			t.Fatal(err)
+		}
+
+		totalAfter := countAllSectorRows(t)
+		// 5 of c1's 8 rows are superseded (indices 1,3,5,6,7 have
+		// replacement rows at rev 1). The other 3 (indices 0,2,4) are
+		// still inherited by c2 and must not be deleted.
+		if totalBefore-totalAfter != 5 {
+			t.Fatalf("expected 5 rows removed, got %d (before=%d, after=%d)", totalBefore-totalAfter, totalBefore, totalAfter)
+		}
+
+		// resolve c2 and expire its sectors
+		resolveContract(t, c2.ID, 200)
+		if err := db.ExpireV2ContractSectors(201); err != nil {
+			t.Fatal(err)
+		} else if n := countAllSectorRows(t); n != 0 {
+			t.Fatalf("expected 0 remaining sector roots, got %d", n)
+		}
+	})
+
+	// Verify that inherited rows at indices beyond the active contract's
+	// sector_count are cleaned up immediately, rather than waiting for
+	// the entire chain to expire.
+	t.Run("out of range inherited rows", func(t *testing.T) {
+		c1 := contracts.V2Contract{
+			ID: frand.Entropy256(),
+			V2FileContract: types.V2FileContract{
+				RenterPublicKey:  renterKey.PublicKey(),
+				HostPublicKey:    hostKey.PublicKey(),
+				ProofHeight:      100,
+				ExpirationHeight: 200,
+			},
+		}
+		if err := db.AddV2Contract(c1, rhp4.TransactionSet{}); err != nil {
+			t.Fatal(err)
+		}
+
+		// add 8 sectors to the original contract
+		roots := storeSectors(t, 8)
+		c1.V2FileContract.RevisionNumber++
+		c1.V2FileContract.Filesize = proto4.SectorSize * uint64(len(roots))
+		if err := db.ReviseV2Contract(c1.ID, c1.V2FileContract, nil, roots, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+
+		// renew — c2 inherits 8 sectors from c1
+		c2 := contracts.V2Contract{
+			ID: frand.Entropy256(),
+			V2FileContract: types.V2FileContract{
+				RenterPublicKey:  renterKey.PublicKey(),
+				HostPublicKey:    hostKey.PublicKey(),
+				Filesize:         c1.V2FileContract.Filesize,
+				ProofHeight:      200,
+				ExpirationHeight: 300,
+			},
+		}
+		if err := db.RenewV2Contract(c2, rhp4.TransactionSet{}, c1.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		// trim c2 down to 3 sectors (indices 0-2 kept, 3-7 out of range)
+		trimmedRoots := roots[:3]
+		c2.V2FileContract.RevisionNumber++
+		c2.V2FileContract.Filesize = proto4.SectorSize * uint64(len(trimmedRoots))
+		if err := db.ReviseV2Contract(c2.ID, c2.V2FileContract, roots, trimmedRoots, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+
+		// 8 rows at rev 0 (c1), 0 new rows at rev 1 (trim only)
+		totalBefore := countAllSectorRows(t)
+		if totalBefore != 8 {
+			t.Fatalf("expected 8 total rows, got %d", totalBefore)
+		}
+
+		// resolve c1 and expire — indices 3-7 are out of range for c2
+		// (sector_count=3), so they should be cleaned up immediately
+		resolveContract(t, c1.ID, 100)
+		if err := db.ExpireV2ContractSectors(101); err != nil {
+			t.Fatal(err)
+		}
+
+		totalAfter := countAllSectorRows(t)
+		// indices 0,1,2 are still inherited by c2, indices 3-7 should be gone
+		if totalAfter != 3 {
+			t.Fatalf("expected 3 remaining rows, got %d", totalAfter)
+		}
+
+		// resolve c2 and clean up the rest
+		resolveContract(t, c2.ID, 200)
+		if err := db.ExpireV2ContractSectors(201); err != nil {
+			t.Fatal(err)
+		} else if n := countAllSectorRows(t); n != 0 {
+			t.Fatalf("expected 0 remaining sector roots, got %d", n)
+		}
+	})
+}
+
 func BenchmarkV2AppendSectors(b *testing.B) {
 	log := zaptest.NewLogger(b)
 	db, err := OpenDatabase(filepath.Join(b.TempDir(), "test.db"), log)

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -160,6 +160,7 @@ CREATE TABLE contracts_v2 (
 	resolution_block_id BLOB, -- null if the resolution has not been confirmed on the blockchain
 	resolution_height INTEGER CHECK((resolution_height IS NULL) = (resolution_block_id IS NULL)), -- null if the resolution has not been confirmed on the blockchain
 	contract_status TEXT NOT NULL,
+	sector_count INTEGER NOT NULL, -- used for cleanup
 
 	contract_v2_roots_map_id INTEGER NOT NULL,
 	contract_v2_roots_map_revision_number INTEGER NOT NULL,

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -196,7 +196,7 @@ CREATE TABLE contract_v2_sector_roots (
 	FOREIGN KEY (contract_v2_roots_map_id, contract_v2_roots_map_revision_number) REFERENCES contract_v2_roots_map(id, revision_number),
 	UNIQUE(contract_v2_roots_map_id, contract_v2_roots_map_revision_number, root_index)
 );
-CREATE INDEX contract_v2_sector_roots_contract_v2_roots_map_id_revision_number ON contract_v2_sector_roots(contract_v2_roots_map_id, contract_v2_roots_map_revision_number);
+CREATE INDEX contract_v2_sector_roots_map_id_root_index_revision_number ON contract_v2_sector_roots(contract_v2_roots_map_id, root_index, contract_v2_roots_map_revision_number);
 CREATE INDEX contract_v2_sector_roots_sector_id ON contract_v2_sector_roots(sector_id);
 
 CREATE TABLE temp_storage_sector_roots (

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -159,7 +159,11 @@ CREATE TABLE contracts_v2 (
 	expiration_height INTEGER NOT NULL,
 	resolution_block_id BLOB, -- null if the resolution has not been confirmed on the blockchain
 	resolution_height INTEGER CHECK((resolution_height IS NULL) = (resolution_block_id IS NULL)), -- null if the resolution has not been confirmed on the blockchain
-	contract_status TEXT NOT NULL
+	contract_status TEXT NOT NULL,
+
+	contract_v2_roots_map_id INTEGER NOT NULL,
+	contract_v2_roots_map_revision_number INTEGER NOT NULL,
+	FOREIGN KEY (contract_v2_roots_map_id, contract_v2_roots_map_revision_number) REFERENCES contract_v2_roots_map(id, revision_number)
 );
 CREATE INDEX contracts_v2_contract_id ON contracts_v2(contract_id);
 CREATE INDEX contracts_v2_renter_id ON contracts_v2(renter_id);
@@ -174,16 +178,25 @@ CREATE INDEX contracts_v2_confirmation_index_resolution_block_id_expiration_heig
 CREATE INDEX contracts_v2_resolution_height ON contracts_v2(resolution_height);
 CREATE INDEX contracts_v2_confirmation_index_proof_height ON contracts_v2(confirmation_index, proof_height);
 CREATE INDEX contracts_v2_confirmation_index_negotiation_height ON contracts_v2(confirmation_index, negotiation_height);
+CREATE INDEX contracts_v2_roots_map_id_contract_v2_roots_map_revision_number ON contracts_v2(contract_v2_roots_map_id, contract_v2_roots_map_revision_number);
+
+CREATE TABLE contract_v2_roots_map (
+	id INTEGER NOT NULL,
+	revision_number INTEGER NOT NULL,
+	PRIMARY KEY (id, revision_number)
+);
 
 CREATE TABLE contract_v2_sector_roots (
 	id INTEGER PRIMARY KEY,
-	contract_id INTEGER NOT NULl REFERENCES contracts_v2(id),
 	sector_id INTEGER NOT NULL REFERENCES stored_sectors(id),
 	root_index INTEGER NOT NULL,
-	UNIQUE(contract_id, root_index)
+	contract_v2_roots_map_id INTEGER NOT NULL,
+	contract_v2_roots_map_revision_number INTEGER NOT NULL,
+	FOREIGN KEY (contract_v2_roots_map_id, contract_v2_roots_map_revision_number) REFERENCES contract_v2_roots_map(id, revision_number),
+	UNIQUE(contract_v2_roots_map_id, contract_v2_roots_map_revision_number, root_index)
 );
+CREATE INDEX contract_v2_sector_roots_contract_v2_roots_map_id_revision_number ON contract_v2_sector_roots(contract_v2_roots_map_id, contract_v2_roots_map_revision_number);
 CREATE INDEX contract_v2_sector_roots_sector_id ON contract_v2_sector_roots(sector_id);
-CREATE INDEX contract_v2_sector_roots_contract_id_root_index ON contract_v2_sector_roots(contract_id, root_index);
 
 CREATE TABLE temp_storage_sector_roots (
 	id INTEGER PRIMARY KEY,

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -153,7 +153,7 @@ DROP TABLE contracts_v2_old;`)
 	if err != nil {
 		return fmt.Errorf("failed to drop old tables and create indexes: %w", err)
 	}
-	return nil
+	return recalcContractSectorsMetrics(tx)
 }
 
 // migrateVersion48 deletes stored_sectors that are no longer referenced by any
@@ -1326,6 +1326,10 @@ egress_limit, dyn_dns_provider, dns_update_v4, dns_update_v6, dyn_dns_opts, regi
 	return nil
 }
 
+func migrateVersion50(tx *txn, _ *zap.Logger) error {
+	return recalcContractSectorsMetrics(tx)
+}
+
 // migrations is a list of functions that are run to migrate the database from
 // one version to the next. Migrations are used to update existing databases to
 // match the schema in init.sql.
@@ -1378,4 +1382,5 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion47,
 	migrateVersion48,
 	migrateVersion49,
+	migrateVersion50,
 }

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -12,6 +12,150 @@ import (
 	"go.uber.org/zap"
 )
 
+func migrateVersion49(tx *txn, log *zap.Logger) error {
+	_, err := tx.Exec(`
+-- drop old indices
+DROP INDEX contracts_v2_contract_id;
+DROP INDEX contracts_v2_renter_id;
+DROP INDEX contracts_v2_renewed_to;
+DROP INDEX contracts_v2_renewed_from;
+DROP INDEX contracts_v2_negotiation_height;
+DROP INDEX contracts_v2_contract_status;
+DROP INDEX contracts_v2_proof_height;
+DROP INDEX contracts_v2_expiration_height;
+DROP INDEX contracts_v2_confirmation_index_resolution_block_id_proof_height;
+DROP INDEX contracts_v2_confirmation_index_resolution_block_id_expiration_height;
+DROP INDEX contracts_v2_resolution_height;
+DROP INDEX contracts_v2_confirmation_index_proof_height;
+DROP INDEX contracts_v2_confirmation_index_negotiation_height;
+DROP INDEX contract_v2_sector_roots_sector_id;
+DROP INDEX contract_v2_sector_roots_contract_id_root_index;
+-- tables are renamed instead of updated since they will contain new NOT NULL columns
+ALTER TABLE contract_v2_sector_roots RENAME TO contract_v2_sector_roots_old;
+-- rename tables that reference contracts_v2 to avoid broken foreign keys
+ALTER TABLE contract_v2_state_elements RENAME TO contract_v2_state_elements_old;
+ALTER TABLE contract_v2_account_funding RENAME TO contract_v2_account_funding_old;
+ALTER TABLE contracts_v2 RENAME TO contracts_v2_old;
+CREATE TABLE contract_v2_roots_map (
+	id INTEGER NOT NULL,
+	revision_number INTEGER NOT NULL,
+	PRIMARY KEY (id, revision_number)
+);
+CREATE TABLE contract_v2_sector_roots (
+	id INTEGER PRIMARY KEY,
+	sector_id INTEGER NOT NULL REFERENCES stored_sectors(id),
+	root_index INTEGER NOT NULL,
+	contract_v2_roots_map_id INTEGER NOT NULL,
+	contract_v2_roots_map_revision_number INTEGER NOT NULL,
+	FOREIGN KEY (contract_v2_roots_map_id, contract_v2_roots_map_revision_number) REFERENCES contract_v2_roots_map(id, revision_number),
+	UNIQUE(contract_v2_roots_map_id, contract_v2_roots_map_revision_number, root_index)
+);
+CREATE INDEX contract_v2_sector_roots_contract_v2_roots_map_id_revision_number ON contract_v2_sector_roots(contract_v2_roots_map_id, contract_v2_roots_map_revision_number);
+CREATE INDEX contract_v2_sector_roots_sector_id ON contract_v2_sector_roots(sector_id);
+
+CREATE TABLE contracts_v2 (
+	id INTEGER PRIMARY KEY,
+	renter_id INTEGER NOT NULL REFERENCES contract_renters(id),
+	renewed_to INTEGER REFERENCES contracts_v2(id) ON DELETE SET NULL,
+	renewed_from INTEGER REFERENCES contracts_v2(id) ON DELETE SET NULL,
+	contract_id BLOB UNIQUE NOT NULL,
+	revision_number BLOB NOT NULL, -- stored as BLOB to support uint64_max on clearing revisions
+	formation_txn_set BLOB NOT NULL, -- binary serialized transaction set
+	formation_txn_set_basis BLOB NOT NULL,
+	locked_collateral BLOB NOT NULL,
+	rpc_revenue BLOB NOT NULL,
+	storage_revenue BLOB NOT NULL,
+	ingress_revenue BLOB NOT NULL,
+	egress_revenue BLOB NOT NULL,
+	account_funding BLOB NOT NULL,
+	risked_collateral BLOB NOT NULL,
+	raw_revision BLOB NOT NULL, -- binary serialized contract revision
+	confirmation_index BLOB, -- null if the contract has not been confirmed on the blockchain, otherwise the chain index of the block containing the confirmation transaction
+	negotiation_height INTEGER NOT NULL, -- determines if the formation txn should be rebroadcast or if the contract should be deleted
+	proof_height INTEGER NOT NULL,
+	expiration_height INTEGER NOT NULL,
+	resolution_block_id BLOB, -- null if the resolution has not been confirmed on the blockchain
+	resolution_height INTEGER CHECK((resolution_height IS NULL) = (resolution_block_id IS NULL)), -- null if the resolution has not been confirmed on the blockchain
+	contract_status TEXT NOT NULL,
+
+	contract_v2_roots_map_id INTEGER NOT NULL,
+	contract_v2_roots_map_revision_number INTEGER NOT NULL,
+	FOREIGN KEY (contract_v2_roots_map_id, contract_v2_roots_map_revision_number) REFERENCES contract_v2_roots_map(id, revision_number)
+);
+CREATE INDEX contracts_v2_contract_id ON contracts_v2(contract_id);
+CREATE INDEX contracts_v2_renter_id ON contracts_v2(renter_id);
+CREATE INDEX contracts_v2_renewed_to ON contracts_v2(renewed_to);
+CREATE INDEX contracts_v2_renewed_from ON contracts_v2(renewed_from);
+CREATE INDEX contracts_v2_negotiation_height ON contracts_v2(negotiation_height);
+CREATE INDEX contracts_v2_proof_height ON contracts_v2(proof_height);
+CREATE INDEX contracts_v2_expiration_height ON contracts_v2(expiration_height);
+CREATE INDEX contracts_v2_contract_status ON contracts_v2(contract_status);
+CREATE INDEX contracts_v2_confirmation_index_resolution_block_id_proof_height ON contracts_v2(confirmation_index, resolution_block_id, proof_height);
+CREATE INDEX contracts_v2_confirmation_index_resolution_block_id_expiration_height ON contracts_v2(confirmation_index, resolution_block_id, expiration_height);
+CREATE INDEX contracts_v2_resolution_height ON contracts_v2(resolution_height);
+CREATE INDEX contracts_v2_confirmation_index_proof_height ON contracts_v2(confirmation_index, proof_height);
+CREATE INDEX contracts_v2_confirmation_index_negotiation_height ON contracts_v2(confirmation_index, negotiation_height);
+CREATE INDEX contracts_v2_roots_map_id_contract_v2_roots_map_revision_number ON contracts_v2(contract_v2_roots_map_id, contract_v2_roots_map_revision_number);`)
+	if err != nil {
+		return fmt.Errorf("failed to create contract_v2_roots_map table: %w", err)
+	}
+
+	// create a roots map entry for each existing contract using the contract's id
+	_, err = tx.Exec(`INSERT INTO contract_v2_roots_map (id, revision_number) SELECT id, 0 FROM contracts_v2_old;`)
+	if err != nil {
+		return fmt.Errorf("failed to insert contract roots maps: %w", err)
+	}
+
+	log.Info("migrating contracts to new schema")
+	// uses the contract db ID as a unique root map ID to simplify migration.
+	// All existing contracts have their own map. The copy-on-write logic will be correct going forward.
+	_, err = tx.Exec(`INSERT INTO contracts_v2 (id, renter_id, renewed_to, renewed_from, contract_id, revision_number, formation_txn_set, formation_txn_set_basis, locked_collateral, rpc_revenue, storage_revenue, ingress_revenue, egress_revenue, account_funding, risked_collateral, raw_revision, confirmation_index, negotiation_height, proof_height, expiration_height, resolution_block_id, resolution_height, contract_status, contract_v2_roots_map_id, contract_v2_roots_map_revision_number)
+SELECT id, renter_id, renewed_to, renewed_from, contract_id, revision_number, formation_txn_set, formation_txn_set_basis, locked_collateral, rpc_revenue, storage_revenue, ingress_revenue, egress_revenue, account_funding, risked_collateral, raw_revision, confirmation_index, negotiation_height, proof_height, expiration_height, resolution_block_id, resolution_height, contract_status, id, 0 FROM contracts_v2_old;`)
+	if err != nil {
+		return fmt.Errorf("failed to migrate contracts: %w", err)
+	}
+
+	log.Info("migrating sector roots to new schema")
+	_, err = tx.Exec(`INSERT INTO contract_v2_sector_roots (sector_id, root_index, contract_v2_roots_map_id, contract_v2_roots_map_revision_number)
+SELECT sector_id, root_index, contract_id, 0 FROM contract_v2_sector_roots_old;`)
+	if err != nil {
+		return fmt.Errorf("failed to migrate contract sector roots: %w", err)
+	}
+
+	log.Info("cleaning up old tables and creating indexes")
+	_, err = tx.Exec(`
+-- recreate tables that reference contracts_v2
+CREATE TABLE contract_v2_state_elements (
+	contract_id INTEGER PRIMARY KEY REFERENCES contracts_v2(id),
+	leaf_index BLOB NOT NULL,
+	merkle_proof BLOB NOT NULL,
+	raw_contract BLOB NOT NULL, -- binary serialized contract
+	revision_number BLOB NOT NULL -- for comparison
+);
+INSERT INTO contract_v2_state_elements (contract_id, leaf_index, merkle_proof, raw_contract, revision_number)
+SELECT contract_id, leaf_index, merkle_proof, raw_contract, revision_number FROM contract_v2_state_elements_old;
+
+CREATE TABLE contract_v2_account_funding (
+	id INTEGER PRIMARY KEY,
+	contract_id INTEGER NOT NULL REFERENCES contracts_v2(id),
+	account_id INTEGER NOT NULL REFERENCES accounts(id),
+	amount BLOB NOT NULL,
+	UNIQUE (contract_id, account_id)
+);
+INSERT INTO contract_v2_account_funding (id, contract_id, account_id, amount)
+SELECT id, contract_id, account_id, amount FROM contract_v2_account_funding_old;
+
+-- drop old tables
+DROP TABLE contract_v2_state_elements_old;
+DROP TABLE contract_v2_account_funding_old;
+DROP TABLE contract_v2_sector_roots_old;
+DROP TABLE contracts_v2_old;`)
+	if err != nil {
+		return fmt.Errorf("failed to drop old tables and create indexes: %w", err)
+	}
+	return nil
+}
+
 // migrateVersion48 deletes stored_sectors that are no longer referenced by any
 // volume_sectors, contracts, or temp storage.
 func migrateVersion48(tx *txn, _ *zap.Logger) error {
@@ -1233,4 +1377,5 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion46,
 	migrateVersion47,
 	migrateVersion48,
+	migrateVersion49,
 }

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"time"
 
+	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/v2/host/contracts"
 	"go.uber.org/zap"
@@ -77,6 +78,7 @@ CREATE TABLE contracts_v2 (
 	resolution_block_id BLOB, -- null if the resolution has not been confirmed on the blockchain
 	resolution_height INTEGER CHECK((resolution_height IS NULL) = (resolution_block_id IS NULL)), -- null if the resolution has not been confirmed on the blockchain
 	contract_status TEXT NOT NULL,
+	sector_count INTEGER NOT NULL,
 
 	contract_v2_roots_map_id INTEGER NOT NULL,
 	contract_v2_roots_map_revision_number INTEGER NOT NULL,
@@ -109,10 +111,48 @@ CREATE INDEX contracts_v2_roots_map_id_contract_v2_roots_map_revision_number ON 
 	log.Info("migrating contracts to new schema")
 	// uses the contract db ID as a unique root map ID to simplify migration.
 	// All existing contracts have their own map. The copy-on-write logic will be correct going forward.
-	_, err = tx.Exec(`INSERT INTO contracts_v2 (id, renter_id, renewed_to, renewed_from, contract_id, revision_number, formation_txn_set, formation_txn_set_basis, locked_collateral, rpc_revenue, storage_revenue, ingress_revenue, egress_revenue, account_funding, risked_collateral, raw_revision, confirmation_index, negotiation_height, proof_height, expiration_height, resolution_block_id, resolution_height, contract_status, contract_v2_roots_map_id, contract_v2_roots_map_revision_number)
-SELECT id, renter_id, renewed_to, renewed_from, contract_id, revision_number, formation_txn_set, formation_txn_set_basis, locked_collateral, rpc_revenue, storage_revenue, ingress_revenue, egress_revenue, account_funding, risked_collateral, raw_revision, confirmation_index, negotiation_height, proof_height, expiration_height, resolution_block_id, resolution_height, contract_status, id, 0 FROM contracts_v2_old;`)
+	_, err = tx.Exec(`INSERT INTO contracts_v2 (id, renter_id, renewed_to, renewed_from, contract_id, revision_number, formation_txn_set, formation_txn_set_basis, locked_collateral, rpc_revenue, storage_revenue, ingress_revenue, egress_revenue, account_funding, risked_collateral, raw_revision, confirmation_index, negotiation_height, proof_height, expiration_height, resolution_block_id, resolution_height, contract_status, sector_count, contract_v2_roots_map_id, contract_v2_roots_map_revision_number)
+SELECT id, renter_id, renewed_to, renewed_from, contract_id, revision_number, formation_txn_set, formation_txn_set_basis, locked_collateral, rpc_revenue, storage_revenue, ingress_revenue, egress_revenue, account_funding, risked_collateral, raw_revision, confirmation_index, negotiation_height, proof_height, expiration_height, resolution_block_id, resolution_height, contract_status, 0, id, 0 FROM contracts_v2_old;`)
 	if err != nil {
 		return fmt.Errorf("failed to migrate contracts: %w", err)
+	}
+
+	// populate sector_count from the decoded raw_revision filesize
+	rows, err := tx.Query(`SELECT id, raw_revision FROM contracts_v2`)
+	if err != nil {
+		return fmt.Errorf("failed to query contracts for sector_count: %w", err)
+	}
+	defer rows.Close()
+
+	type contractEntry struct {
+		dbID        int64
+		sectorCount uint64
+	}
+	var entries []contractEntry
+	for rows.Next() {
+		var dbID int64
+		var fc types.V2FileContract
+		if err := rows.Scan(&dbID, decode(&fc)); err != nil {
+			return fmt.Errorf("failed to scan contract: %w", err)
+		}
+		entries = append(entries, contractEntry{dbID, fc.Filesize / proto4.SectorSize})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate contracts: %w", err)
+	} else if err := rows.Close(); err != nil {
+		return fmt.Errorf("failed to close rows: %w", err)
+	}
+
+	updateStmt, err := tx.Prepare(`UPDATE contracts_v2 SET sector_count=? WHERE id=?`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare sector_count update: %w", err)
+	}
+	defer updateStmt.Close()
+
+	for _, e := range entries {
+		if _, err := updateStmt.Exec(e.sectorCount, e.dbID); err != nil {
+			return fmt.Errorf("failed to update sector_count: %w", err)
+		}
 	}
 
 	log.Info("migrating sector roots to new schema")
@@ -153,6 +193,7 @@ DROP TABLE contracts_v2_old;`)
 	if err != nil {
 		return fmt.Errorf("failed to drop old tables and create indexes: %w", err)
 	}
+
 	return recalcContractSectorsMetrics(tx)
 }
 
@@ -1326,10 +1367,6 @@ egress_limit, dyn_dns_provider, dns_update_v4, dns_update_v6, dyn_dns_opts, regi
 	return nil
 }
 
-func migrateVersion50(tx *txn, _ *zap.Logger) error {
-	return recalcContractSectorsMetrics(tx)
-}
-
 // migrations is a list of functions that are run to migrate the database from
 // one version to the next. Migrations are used to update existing databases to
 // match the schema in init.sql.
@@ -1382,5 +1419,4 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion47,
 	migrateVersion48,
 	migrateVersion49,
-	migrateVersion50,
 }

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -51,7 +51,7 @@ CREATE TABLE contract_v2_sector_roots (
 	FOREIGN KEY (contract_v2_roots_map_id, contract_v2_roots_map_revision_number) REFERENCES contract_v2_roots_map(id, revision_number),
 	UNIQUE(contract_v2_roots_map_id, contract_v2_roots_map_revision_number, root_index)
 );
-CREATE INDEX contract_v2_sector_roots_contract_v2_roots_map_id_revision_number ON contract_v2_sector_roots(contract_v2_roots_map_id, contract_v2_roots_map_revision_number);
+CREATE INDEX contract_v2_sector_roots_map_id_root_index_revision_number ON contract_v2_sector_roots(contract_v2_roots_map_id, root_index, contract_v2_roots_map_revision_number);
 CREATE INDEX contract_v2_sector_roots_sector_id ON contract_v2_sector_roots(sector_id);
 
 CREATE TABLE contracts_v2 (

--- a/persist/sqlite/recalc.go
+++ b/persist/sqlite/recalc.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/v2/host/contracts"
 	"go.uber.org/zap"
@@ -142,9 +143,20 @@ func recalcContractSectorsMetrics(tx *txn) error {
 	}
 
 	var v2Count uint64
-	err = tx.QueryRow(`SELECT COUNT(*) FROM contract_v2_sector_roots`).Scan(&v2Count)
+	rows, err := tx.Query(`SELECT raw_revision FROM contracts_v2 WHERE contract_status = ?`, contracts.V2ContractStatusActive)
 	if err != nil {
-		return fmt.Errorf("failed to query v2 contract sector count: %w", err)
+		return fmt.Errorf("failed to query active v2 contracts: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var fc types.V2FileContract
+		if err := rows.Scan(decode(&fc)); err != nil {
+			return fmt.Errorf("failed to scan v2 contract: %w", err)
+		}
+		v2Count += fc.Filesize / proto4.SectorSize
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate active v2 contracts: %w", err)
 	}
 
 	setNumericStat(tx, metricContractSectors, v1Count+v2Count, time.Now())

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -12,6 +12,7 @@ import (
 
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	rhp4 "go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/hostd/v2/host/contracts"
 	"go.sia.tech/hostd/v2/host/storage"
 	"go.uber.org/zap"
@@ -736,36 +737,45 @@ func TestPrune(t *testing.T) {
 	renterKey := types.NewPrivateKeyFromSeed(frand.Bytes(32))
 	hostKey := types.NewPrivateKeyFromSeed(frand.Bytes(32))
 
-	addContract := func(t *testing.T, expiration uint64) contracts.SignedRevision {
-		// add a contract to store the sectors
-		contractUnlockConditions := types.UnlockConditions{
-			PublicKeys: []types.UnlockKey{
-				renterKey.PublicKey().UnlockKey(),
-				hostKey.PublicKey().UnlockKey(),
-			},
-			SignaturesRequired: 2,
-		}
-		c := contracts.SignedRevision{
-			Revision: types.FileContractRevision{
-				ParentID:         types.FileContractID(frand.Entropy256()),
-				UnlockConditions: contractUnlockConditions,
-				FileContract: types.FileContract{
-					UnlockHash:  contractUnlockConditions.UnlockHash(),
-					WindowStart: expiration,
-					WindowEnd:   expiration,
-				},
+	revisionNumber := uint64(0)
+	addContract := func(t *testing.T, proofHeight, expirationHeight uint64) contracts.V2Contract {
+		t.Helper()
+		c := contracts.V2Contract{
+			ID: frand.Entropy256(),
+			V2FileContract: types.V2FileContract{
+				RenterPublicKey:  renterKey.PublicKey(),
+				HostPublicKey:    hostKey.PublicKey(),
+				RevisionNumber:   revisionNumber,
+				ProofHeight:      proofHeight,
+				ExpirationHeight: expirationHeight,
 			},
 		}
-		if err := db.AddContract(c, []types.Transaction{}, types.MaxCurrency, contracts.Usage{}, 100); err != nil {
+		revisionNumber++
+		if err := db.AddV2Contract(c, rhp4.TransactionSet{}); err != nil {
 			t.Fatal(err)
 		}
 		return c
 	}
 
-	addSectorsToContract := func(t *testing.T, c *contracts.SignedRevision, sectors []types.Hash256) {
+	addSectorsToContract := func(t *testing.T, c *contracts.V2Contract, sectors []types.Hash256) {
 		t.Helper()
 
-		err = db.ReviseContract(*c, []types.Hash256{}, sectors, contracts.Usage{})
+		c.V2FileContract.RevisionNumber = revisionNumber
+		c.V2FileContract.Filesize = uint64(len(sectors)) * proto4.SectorSize
+		revisionNumber++
+		if err := db.ReviseV2Contract(c.ID, c.V2FileContract, nil, sectors, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	resolveContract := func(t *testing.T, c contracts.V2Contract, height uint64) {
+		t.Helper()
+
+		err := db.transaction(func(tx *txn) error {
+			_, err := tx.Exec(`UPDATE contracts_v2 SET resolution_height=$1, resolution_block_id=$2, contract_status=$3 WHERE contract_id=$4`,
+				height, encode(types.BlockID{}), contracts.V2ContractStatusSuccessful, encode(c.ID))
+			return err
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -773,8 +783,8 @@ func TestPrune(t *testing.T) {
 
 	contract1Sectors, contract2Sectors, tempSectors, unreferencedSectors := roots[:10], roots[10:25], roots[25:50], roots[50:]
 
-	c1 := addContract(t, 100)
-	c2 := addContract(t, 110)
+	c1 := addContract(t, 100, 200)
+	c2 := addContract(t, 110, 210)
 
 	// add the sectors to the contract
 	addSectorsToContract(t, &c1, contract1Sectors)
@@ -841,8 +851,9 @@ func TestPrune(t *testing.T) {
 	}
 	assertSectors(t, 25, 25, available, deleted)
 
-	// expire one of the contract's sectors
-	if err := db.ExpireContractSectors(101); err != nil {
+	// resolve c1 and expire its sectors
+	resolveContract(t, c1, 100)
+	if err := db.ExpireV2ContractSectors(101); err != nil {
 		t.Fatal(err)
 	} else if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
@@ -859,12 +870,14 @@ func TestPrune(t *testing.T) {
 	available, deleted = contract2Sectors, append(deleted, tempSectors...)
 	assertSectors(t, 15, 0, available, deleted)
 
-	if err := db.ExpireContractSectors(111); err != nil {
+	// resolve c2 and expire its sectors
+	resolveContract(t, c2, 110)
+	if err := db.ExpireV2ContractSectors(111); err != nil {
 		t.Fatal(err)
 	} else if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
-	available, deleted = nil, append(deleted, contract1Sectors...)
+	available, deleted = nil, append(deleted, contract2Sectors...)
 	assertSectors(t, 0, 0, available, deleted)
 }
 

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -802,7 +802,7 @@ func TestPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertSectors := func(t *testing.T, contract, temp uint64, available, deleted []types.Hash256) {
+	assertSectors := func(t *testing.T, temp uint64, available, deleted []types.Hash256) {
 		t.Helper()
 
 		for _, root := range available {
@@ -828,8 +828,6 @@ func TestPrune(t *testing.T) {
 			t.Fatalf("failed to get metrics: %v", err)
 		} else if m.Storage.PhysicalSectors != uint64(len(available)) {
 			t.Fatalf("expected %v physical sectors, got %v", len(available), m.Storage.PhysicalSectors)
-		} else if m.Storage.ContractSectors != contract {
-			t.Fatalf("expected %v contract sectors, got %v", contract, m.Storage.ContractSectors)
 		} else if m.Storage.TempSectors != temp {
 			t.Fatalf("expected %v temporary sectors, got %v", temp, m.Storage.TempSectors)
 		}
@@ -842,14 +840,14 @@ func TestPrune(t *testing.T) {
 			t.Fatalf("expected %d stored_sectors entries, got %d", len(available), stored)
 		}
 	}
-	assertSectors(t, 25, 25, roots, nil)
+	assertSectors(t, 25, roots, nil)
 
 	// prune unreferenced sectors
 	available, deleted := roots[:len(roots)-len(unreferencedSectors)], unreferencedSectors
 	if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
-	assertSectors(t, 25, 25, available, deleted)
+	assertSectors(t, 25, available, deleted)
 
 	// resolve c1 and expire its sectors
 	resolveContract(t, c1, 100)
@@ -859,7 +857,7 @@ func TestPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 	available, deleted = append(contract2Sectors, tempSectors...), append(deleted, contract1Sectors...)
-	assertSectors(t, 15, 25, available, deleted)
+	assertSectors(t, 25, available, deleted)
 
 	// expire the temp sectors
 	if err := db.ExpireTempSectors(101); err != nil {
@@ -868,7 +866,7 @@ func TestPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 	available, deleted = contract2Sectors, append(deleted, tempSectors...)
-	assertSectors(t, 15, 0, available, deleted)
+	assertSectors(t, 0, available, deleted)
 
 	// resolve c2 and expire its sectors
 	resolveContract(t, c2, 110)
@@ -878,7 +876,7 @@ func TestPrune(t *testing.T) {
 		t.Fatal(err)
 	}
 	available, deleted = nil, append(deleted, contract2Sectors...)
-	assertSectors(t, 0, 0, available, deleted)
+	assertSectors(t, 0, available, deleted)
 }
 
 func BenchmarkVolumeGrow(b *testing.B) {


### PR DESCRIPTION
Contract renewals and refreshes previously copied every sector root row when creating a new contract. For hosts with large contracts, this locked the database for a long time and caused performance issues. The original design traded off simplicity for performance while ensuring hosts could fall back to the previous contract if a renewal was rejected on-chain.

Added a `contract_v2_roots_map` table that acts as an indirection layer between contracts and their sector roots. When a contract is renewed or refreshed, the new contract shares the same roots map as the old one at a higher "revision number" instead of duplicating all the rows. Sector roots are then copy-on-write — only modified sectors get new rows at the new window. If a renewed contract is rejected, the original can still see its "view" of the sectors.

This does remove a nice guarantee of the old design where one sector root in a contract is guaranteed one row.

Please review extensively. This is a critical component with lots of side effects. There be lots of dragons here.
