### PR TITLE
Update action to use newer Node

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,7 +12,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'chore: prepare release')" # Skip merges from releases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Configure Git


### PR DESCRIPTION
Note: [actions/checkout@v5](https://github.com/actions/checkout/tree/v5) and [actions/upload-artifact@v6](https://github.com/actions/upload-artifact/tree/v6) are stable.
