### PR TITLE
fix: apply syncer rate limits to inbound peer connections

### DIFF
--- a/.changeset/apply_syncer_rate_limits_to_inbound_peer_connections.md
+++ b/.changeset/apply_syncer_rate_limits_to_inbound_peer_connections.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Apply syncer rate limits to inbound peer connections.
+
+The `syncerIngressLimit` and `syncerEgressLimit` settings now correctly throttle inbound peer connections in addition to outbound ones.

--- a/cmd/hostd/run.go
+++ b/cmd/hostd/run.go
@@ -348,7 +348,12 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 
 	syncerRecorder := monitoring.NewDataRecorder(store.IncrementSyncerDataUsage, log.Named("syncer-data"))
 	defer syncerRecorder.Close()
-	syncerListener, err := monitoring.Listen("tcp", cfg.Syncer.Address, monitoring.WithDataMonitor(syncerRecorder))
+	srl := rate.NewLimiter(rate.Inf, 0)
+	swl := rate.NewLimiter(rate.Inf, 0)
+	syncerListener, err := monitoring.Listen("tcp", cfg.Syncer.Address,
+		monitoring.WithDataMonitor(syncerRecorder),
+		monitoring.WithReadLimit(srl),
+		monitoring.WithWriteLimit(swl))
 	if err != nil {
 		return fmt.Errorf("failed to listen on syncer address: %w", err)
 	}
@@ -386,8 +391,6 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 
 	log.Debug("starting syncer", zap.String("syncer address", syncerAddr))
-	srl := rate.NewLimiter(rate.Inf, 0)
-	swl := rate.NewLimiter(rate.Inf, 0)
 	syncerDialer := monitoring.NewDialer(monitoring.WithDataMonitor(syncerRecorder),
 		monitoring.WithReadLimit(srl), monitoring.WithWriteLimit(swl))
 	s := syncer.New(syncerListener, cm, ps, gateway.Header{

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"net"
 	"path/filepath"
 	"testing"
 	"time"
@@ -141,12 +140,6 @@ func NewConsensusNode(t testing.TB, network *consensus.Network, genesis types.Bl
 	}
 	cm := chain.NewManager(cs, tipState)
 
-	syncerListener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatal("failed to listen:", err)
-	}
-	t.Cleanup(func() { syncerListener.Close() })
-
 	ps, err := sqlite.NewPeerStore(db)
 	if err != nil {
 		t.Fatal("failed to create peer store:", err)
@@ -157,6 +150,15 @@ func NewConsensusNode(t testing.TB, network *consensus.Network, genesis types.Bl
 
 	srl := rate.NewLimiter(rate.Inf, 0)
 	swl := rate.NewLimiter(rate.Inf, 0)
+	syncerListener, err := monitoring.Listen("tcp", "localhost:0",
+		monitoring.WithDataMonitor(syncerRecorder),
+		monitoring.WithReadLimit(srl),
+		monitoring.WithWriteLimit(swl))
+	if err != nil {
+		t.Fatal("failed to listen:", err)
+	}
+	t.Cleanup(func() { syncerListener.Close() })
+
 	syncerDialer := monitoring.NewDialer(monitoring.WithDataMonitor(syncerRecorder),
 		monitoring.WithReadLimit(srl), monitoring.WithWriteLimit(swl))
 	syncer := syncer.New(syncerListener, cm, ps, gateway.Header{


### PR DESCRIPTION
The syncer's read/write rate limiters were only wired to the dialer. Pass the same rate limiters to `monitoring.Listen` so the listener shares them with the dialer and the settings manager, ensuring both inbound and outbound syncer traffic are capped by the configured limits.

Fixes #957