### PR TITLE
Repair v2 contract statuses in database

### DIFF
--- a/.changeset/repair_v2_contracts_stuck_active_after_renewal.md
+++ b/.changeset/repair_v2_contracts_stuck_active_after_renewal.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Repair v2 contracts stuck "active" after renewal.
+
+Adds a database migration that corrects v2 contracts whose renewal landed in the same block as a revision and was therefore never recorded against the parent. Affected contracts are flipped from active to renewed, their resolution index is populated from the renewed contract's confirmation index, and contract count, sector, revenue and collateral metrics are recalculated. Existing deployments no longer need a chain rescan to clear the stuck rows reported in #912.

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -13,6 +13,64 @@ import (
 	"go.uber.org/zap"
 )
 
+// migrateVersion51 corrects v2 contracts left in active status when their
+// renewal landed in the same block as a revision.
+func migrateVersion51(tx *txn, log *zap.Logger) error {
+	// fetch active contracts with a renewal that has been confirmed
+	// on chain but the old contract was not marked as renewed
+	rows, err := tx.Query(`SELECT c.id, cc.confirmation_index
+FROM contracts_v2 c
+INNER JOIN contracts_v2 cc ON c.renewed_to = cc.id
+WHERE c.contract_status = ?
+AND cc.confirmation_index IS NOT NULL`, contracts.V2ContractStatusActive)
+	if err != nil {
+		return fmt.Errorf("failed to query stuck contracts: %w", err)
+	}
+	defer rows.Close()
+
+	affected := make(map[int64]types.ChainIndex, 0)
+	for rows.Next() {
+		var dbID int64
+		var ci types.ChainIndex
+		if err := rows.Scan(&dbID, decode(&ci)); err != nil {
+			return fmt.Errorf("failed to scan stuck contract: %w", err)
+		}
+		affected[dbID] = ci
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate stuck contracts: %w", err)
+	} else if err := rows.Close(); err != nil {
+		return fmt.Errorf("failed to close stuck contracts rows: %w", err)
+	} else if len(affected) == 0 {
+		return nil
+	}
+
+	// update contract status to renewed for the affected contracts and
+	// set the resolution index to the confirmation index of the renewal
+	log.Info("repairing v2 contracts left active after renewal", zap.Int("count", len(affected)))
+	updateStmt, err := tx.Prepare(`UPDATE contracts_v2 SET contract_status=?, resolution_block_id=?, resolution_height=? WHERE id=?`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare update statement: %w", err)
+	}
+	defer updateStmt.Close()
+
+	for dbID, ci := range affected {
+		if _, err := updateStmt.Exec(contracts.V2ContractStatusRenewed, encode(ci.ID), ci.Height, dbID); err != nil {
+			return fmt.Errorf("failed to repair contract %d: %w", dbID, err)
+		}
+	}
+
+	// historical time series points are not backfilled
+	if err := recalcContractCountMetrics(tx); err != nil {
+		return fmt.Errorf("failed to recalc contract count metrics: %w", err)
+	} else if err := recalcContractSectorsMetrics(tx); err != nil {
+		return fmt.Errorf("failed to recalc contract sectors metric: %w", err)
+	} else if err := recalcContractRevenueCollateralMetrics(tx, log); err != nil {
+		return fmt.Errorf("failed to recalc contract revenue and collateral metrics: %w", err)
+	}
+	return nil
+}
+
 func migrateVersion50(tx *txn, _ *zap.Logger) error {
 	_, err := tx.Exec(`
 CREATE TABLE rhp4_pools (
@@ -1449,4 +1507,5 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion48,
 	migrateVersion49,
 	migrateVersion50,
+	migrateVersion51,
 }

--- a/persist/sqlite/migrations_test.go
+++ b/persist/sqlite/migrations_test.go
@@ -6,7 +6,9 @@ import (
 	"math"
 	"path/filepath"
 	"testing"
+	"time"
 
+	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/v2/host/contracts"
 	"go.uber.org/zap"
@@ -568,7 +570,7 @@ func TestMigrateV51(t *testing.T) {
 			return err
 		}
 
-		insertContract := func(id types.FileContractID, status contracts.V2ContractStatus, confirmation *types.ChainIndex) (int64, error) {
+		insertContract := func(id types.FileContractID, status contracts.V2ContractStatus, confirmation *types.ChainIndex, lockedCollateral, storageRevenue types.Currency, filesize uint64) (int64, error) {
 			var confEncoded any
 			if confirmation != nil {
 				confEncoded = encode(*confirmation)
@@ -583,14 +585,14 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
 				encode(uint64(1)),
 				encodeSlice([]types.V2Transaction{}),
 				encode(types.ChainIndex{}),
+				encode(lockedCollateral),
+				encode(types.ZeroCurrency),
+				encode(storageRevenue),
 				encode(types.ZeroCurrency),
 				encode(types.ZeroCurrency),
 				encode(types.ZeroCurrency),
 				encode(types.ZeroCurrency),
-				encode(types.ZeroCurrency),
-				encode(types.ZeroCurrency),
-				encode(types.ZeroCurrency),
-				encode(types.V2FileContract{}),
+				encode(types.V2FileContract{Filesize: filesize}),
 				confEncoded,
 				uint64(0),
 				uint64(100),
@@ -604,11 +606,11 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
 		}
 
 		// stuck case
-		parentID, err := insertContract(stuckParent, contracts.V2ContractStatusActive, nil)
+		parentID, err := insertContract(stuckParent, contracts.V2ContractStatusActive, nil, types.Siacoins(100), types.Siacoins(10), 2*proto4.SectorSize)
 		if err != nil {
 			return err
 		}
-		childID, err := insertContract(stuckChild, contracts.V2ContractStatusActive, &renewalIndex)
+		childID, err := insertContract(stuckChild, contracts.V2ContractStatusActive, &renewalIndex, types.Siacoins(50), types.Siacoins(5), proto4.SectorSize)
 		if err != nil {
 			return err
 		} else if _, err := tx.Exec(`UPDATE contracts_v2 SET renewed_to=$1 WHERE id=$2`, childID, parentID); err != nil {
@@ -618,11 +620,11 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
 		}
 
 		// pending case
-		pParentID, err := insertContract(pendingParent, contracts.V2ContractStatusActive, nil)
+		pParentID, err := insertContract(pendingParent, contracts.V2ContractStatusActive, nil, types.ZeroCurrency, types.ZeroCurrency, 0)
 		if err != nil {
 			return err
 		}
-		pChildID, err := insertContract(pendingChild, contracts.V2ContractStatusPending, nil)
+		pChildID, err := insertContract(pendingChild, contracts.V2ContractStatusPending, nil, types.ZeroCurrency, types.ZeroCurrency, 0)
 		if err != nil {
 			return err
 		} else if _, err := tx.Exec(`UPDATE contracts_v2 SET renewed_to=$1 WHERE id=$2`, pChildID, pParentID); err != nil {
@@ -632,7 +634,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
 		}
 
 		// lone case
-		if _, err := insertContract(loneActive, contracts.V2ContractStatusActive, nil); err != nil {
+		if _, err := insertContract(loneActive, contracts.V2ContractStatusActive, nil, types.ZeroCurrency, types.ZeroCurrency, 0); err != nil {
 			return err
 		}
 		return nil
@@ -684,5 +686,25 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
 		t.Fatal(err)
 	} else if c.Status != contracts.V2ContractStatusActive {
 		t.Fatal("unexpected", c.Status)
+	}
+
+	// assert metrics were recalculated against the corrected statuses: the
+	// repaired parent drops out of the active counts, its locked collateral
+	// and sectors are no longer counted, and its revenue moves to earned
+	m, err := store.Metrics(time.Now())
+	if err != nil {
+		t.Fatal(err)
+	} else if m.Contracts.Active != 3 {
+		t.Fatal("unexpected", m.Contracts.Active)
+	} else if m.Contracts.Renewed != 1 {
+		t.Fatal("unexpected", m.Contracts.Renewed)
+	} else if !m.Contracts.LockedCollateral.Equals(types.Siacoins(50)) {
+		t.Fatal("unexpected", m.Contracts.LockedCollateral)
+	} else if !m.Revenue.Potential.Storage.Equals(types.Siacoins(5)) {
+		t.Fatal("unexpected", m.Revenue.Potential.Storage)
+	} else if !m.Revenue.Earned.Storage.Equals(types.Siacoins(10)) {
+		t.Fatal("unexpected", m.Revenue.Earned.Storage)
+	} else if m.Storage.ContractSectors != 1 {
+		t.Fatal("unexpected", m.Storage.ContractSectors)
 	}
 }

--- a/persist/sqlite/migrations_test.go
+++ b/persist/sqlite/migrations_test.go
@@ -536,3 +536,153 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
 		t.Fatalf("unexpected resolution index: got %v, want %v", contract.ResolutionIndex, resolutionIndex)
 	}
 }
+
+// TestMigrateV51 ensures that v2 contracts left active when their renewal
+// landed in the same block as a revision are corrected to renewed and have
+// their resolution index populated from the renewed_to contract.
+func TestMigrateV51(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	fp := filepath.Join(t.TempDir(), "hostd.sqlite3")
+	store := initDBVersion(t, fp, 50, log)
+
+	// stuck case: parent active with a confirmed renewal child
+	stuckParent := types.FileContractID(frand.Entropy256())
+	stuckChild := types.FileContractID(frand.Entropy256())
+	renewalIndex := types.ChainIndex{
+		ID:     frand.Entropy256(),
+		Height: frand.Uint64n(math.MaxUint32),
+	}
+
+	// pending case: parent active with a child still pending confirmation
+	pendingParent := types.FileContractID(frand.Entropy256())
+	pendingChild := types.FileContractID(frand.Entropy256())
+
+	// lone case: active contract that is not part of any renewal chain
+	loneActive := types.FileContractID(frand.Entropy256())
+
+	err := store.transaction(func(tx *txn) error {
+		var renterID int64
+		if err := tx.QueryRow(`INSERT INTO contract_renters (public_key) VALUES ($1) RETURNING id`, encode(types.PublicKey(frand.Entropy256()))).Scan(&renterID); err != nil {
+			return err
+		} else if _, err := tx.Exec(`INSERT INTO contract_v2_roots_map (id, revision_number) VALUES (1, 0)`); err != nil {
+			return err
+		}
+
+		insertContract := func(id types.FileContractID, status contracts.V2ContractStatus, confirmation *types.ChainIndex) (int64, error) {
+			var confEncoded any
+			if confirmation != nil {
+				confEncoded = encode(*confirmation)
+			}
+			var dbID int64
+			err := tx.QueryRow(`INSERT INTO contracts_v2 (renter_id, contract_id, revision_number, formation_txn_set, formation_txn_set_basis,
+locked_collateral, rpc_revenue, storage_revenue, ingress_revenue, egress_revenue, account_funding, risked_collateral, raw_revision,
+confirmation_index, negotiation_height, proof_height, expiration_height, contract_status, sector_count, contract_v2_roots_map_id, contract_v2_roots_map_revision_number)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) RETURNING id`,
+				renterID,
+				encode(id),
+				encode(uint64(1)),
+				encodeSlice([]types.V2Transaction{}),
+				encode(types.ChainIndex{}),
+				encode(types.ZeroCurrency),
+				encode(types.ZeroCurrency),
+				encode(types.ZeroCurrency),
+				encode(types.ZeroCurrency),
+				encode(types.ZeroCurrency),
+				encode(types.ZeroCurrency),
+				encode(types.ZeroCurrency),
+				encode(types.V2FileContract{}),
+				confEncoded,
+				uint64(0),
+				uint64(100),
+				uint64(110),
+				status,
+				uint64(0),
+				int64(1),
+				int64(0),
+			).Scan(&dbID)
+			return dbID, err
+		}
+
+		// stuck case
+		parentID, err := insertContract(stuckParent, contracts.V2ContractStatusActive, nil)
+		if err != nil {
+			return err
+		}
+		childID, err := insertContract(stuckChild, contracts.V2ContractStatusActive, &renewalIndex)
+		if err != nil {
+			return err
+		} else if _, err := tx.Exec(`UPDATE contracts_v2 SET renewed_to=$1 WHERE id=$2`, childID, parentID); err != nil {
+			return err
+		} else if _, err := tx.Exec(`UPDATE contracts_v2 SET renewed_from=$1 WHERE id=$2`, parentID, childID); err != nil {
+			return err
+		}
+
+		// pending case
+		pParentID, err := insertContract(pendingParent, contracts.V2ContractStatusActive, nil)
+		if err != nil {
+			return err
+		}
+		pChildID, err := insertContract(pendingChild, contracts.V2ContractStatusPending, nil)
+		if err != nil {
+			return err
+		} else if _, err := tx.Exec(`UPDATE contracts_v2 SET renewed_to=$1 WHERE id=$2`, pChildID, pParentID); err != nil {
+			return err
+		} else if _, err := tx.Exec(`UPDATE contracts_v2 SET renewed_from=$1 WHERE id=$2`, pParentID, pChildID); err != nil {
+			return err
+		}
+
+		// lone case
+		if _, err := insertContract(loneActive, contracts.V2ContractStatusActive, nil); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// reopen to trigger the migration
+	store, err = OpenDatabase(fp, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// assert stuck parent is now renewed with the renewal index copied over
+	c, err := store.V2Contract(stuckParent)
+	if err != nil {
+		t.Fatal(err)
+	} else if c.Status != contracts.V2ContractStatusRenewed {
+		t.Fatal("unexpected", c.Status)
+	} else if c.ResolutionIndex != renewalIndex {
+		t.Fatal("unexpected", c.ResolutionIndex)
+	}
+
+	// assert stuck child unchanged
+	c, err = store.V2Contract(stuckChild)
+	if err != nil {
+		t.Fatal(err)
+	} else if c.Status != contracts.V2ContractStatusActive {
+		t.Fatal("unexpected", c.Status)
+	}
+
+	// assert pending parent unchanged
+	c, err = store.V2Contract(pendingParent)
+	if err != nil {
+		t.Fatal(err)
+	} else if c.Status != contracts.V2ContractStatusActive {
+		t.Fatal("unexpected", c.Status)
+	} else if c.ResolutionIndex != (types.ChainIndex{}) {
+		t.Fatal("unexpected", c.ResolutionIndex)
+	}
+
+	// assert lone active contract unchanged
+	c, err = store.V2Contract(loneActive)
+	if err != nil {
+		t.Fatal(err)
+	} else if c.Status != contracts.V2ContractStatusActive {
+		t.Fatal("unexpected", c.Status)
+	}
+}


### PR DESCRIPTION
This PR repairs v2 contracts left in active after renewal. There was a bug where a single block could contain both a revision and the renewal resolution for the same contract: the renewal was dropped and the parent's contract_status, resolution_block_id, and resolution_height were never written. The forward fix landed in #930, this PR adds a migration so existing deployments get corrected without a chain rescan. The historical time series in host_stats is not backfilled. That would require a chain rescan.

Side benefit: ExpireV2ContractSectors is gated on resolution_height IS NOT NULL, so the stuck rows previously kept their sector roots around forever. They get cleaned up on the next call.

Closes #912