### PR TITLE
ci: bump SiaFoundation/workflows pin to 2dc0b0f

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ env:
 
 jobs:
   test:
-    uses: SiaFoundation/workflows/.github/workflows/go-test.yml@dddded471aae1c7b6f0fbc388d603b8b16336f6f # master
+    uses: SiaFoundation/workflows/.github/workflows/go-test.yml@2dc0b0ff59df8c1a5345719e34e62a398f7a165c # master

--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   sync:
-    uses: SiaFoundation/workflows/.github/workflows/sync-openapi-version.yml@dddded471aae1c7b6f0fbc388d603b8b16336f6f # master
+    uses: SiaFoundation/workflows/.github/workflows/sync-openapi-version.yml@2dc0b0ff59df8c1a5345719e34e62a398f7a165c # master
     with:
       spec_path: openapi.yml

--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   add-to-project:
-    uses: SiaFoundation/workflows/.github/workflows/project-add.yml@dddded471aae1c7b6f0fbc388d603b8b16336f6f # master
+    uses: SiaFoundation/workflows/.github/workflows/project-add.yml@2dc0b0ff59df8c1a5345719e34e62a398f7a165c # master
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   publish:
-    uses: SiaFoundation/workflows/.github/workflows/go-publish.yml@dddded471aae1c7b6f0fbc388d603b8b16336f6f # master
+    uses: SiaFoundation/workflows/.github/workflows/go-publish.yml@2dc0b0ff59df8c1a5345719e34e62a398f7a165c # master
     secrets: inherit
     with:
       linux-build-args: -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update UI and open PR
-        uses: SiaFoundation/workflows/.github/actions/ui-update@dddded471aae1c7b6f0fbc388d603b8b16336f6f # master
+        uses: SiaFoundation/workflows/.github/actions/ui-update@2dc0b0ff59df8c1a5345719e34e62a398f7a165c # master
         with:
           moduleName: 'hostd'
           goVersion: '1.21'


### PR DESCRIPTION
Updates `SiaFoundation/workflows` pins from `dddded47` to `2dc0b0f`:

- `go-test.yml`
- `sync-openapi-version.yml`
- `project-add.yml`
- `go-publish.yml`
- `.github/actions/ui-update`