### PR TITLE
Move sector cache to dedicated table

### DIFF
--- a/.changeset/fix_stored_sectors_table_bloat.md
+++ b/.changeset/fix_stored_sectors_table_bloat.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Fix the merkle cache bloating the stored sectors table
+
+The cache kept 32 KiB of subtree roots inline on every sector row, which slowed
+sector reads, pruning and contract root lookups. Cached roots are discarded on
+upgrade and rebuilt on the next read.

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -33,11 +33,14 @@ CREATE INDEX wallet_events_maturity_height ON wallet_events(maturity_height DESC
 CREATE TABLE stored_sectors (
 	id INTEGER PRIMARY KEY,
 	sector_root BLOB UNIQUE NOT NULL,
-	cached_subtree_roots BLOB,
 	last_access_timestamp INTEGER NOT NULL
 );
 CREATE INDEX stored_sectors_sector_root ON stored_sectors(sector_root);
-CREATE INDEX stored_sectors_id_last_access ON stored_sectors(id, last_access_timestamp);
+
+CREATE TABLE sector_subtree_cache (
+	sector_id INTEGER PRIMARY KEY REFERENCES stored_sectors(id) ON DELETE CASCADE,
+	subtree_roots BLOB NOT NULL
+);
 
 CREATE TABLE storage_volumes (
 	id INTEGER PRIMARY KEY,

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -13,14 +13,31 @@ import (
 	"go.uber.org/zap"
 )
 
-// migrateVersion53 adds a covering index for the sector pruning query. Without
-// it the query's ORDER BY id falls back to a rowid scan of stored_sectors,
-// which has to walk the cached_subtree_roots overflow pages of every row to
-// reach the last_access_timestamp declared after them. The old index is
-// dropped since the pruning query was its only reader.
+// migrateVersion54 moves the merkle cache into its own table. The cached roots
+// are not carried over, they are rebuilt on the next read.
+//
+// It also drops stored_sectors_id_last_access, which unreleased builds created
+// to keep the pruning scan off rows made expensive by the inline cache. The
+// rows are cheap to read without it, so the index only cost writes.
+func migrateVersion54(tx *txn, _ *zap.Logger) error {
+	_, err := tx.Exec(`
+CREATE TABLE sector_subtree_cache (
+	sector_id INTEGER PRIMARY KEY REFERENCES stored_sectors(id) ON DELETE CASCADE,
+	subtree_roots BLOB NOT NULL
+);
+ALTER TABLE stored_sectors DROP COLUMN cached_subtree_roots;
+DROP INDEX IF EXISTS stored_sectors_id_last_access;`)
+	if err != nil {
+		return fmt.Errorf("failed to move merkle cache: %w", err)
+	}
+	return nil
+}
+
+// migrateVersion53 drops the index on last_access_timestamp. Nothing reads that
+// column except the sector pruning query, which cannot use the index since it
+// orders by id.
 func migrateVersion53(tx *txn, _ *zap.Logger) error {
 	_, err := tx.Exec(`
-CREATE INDEX IF NOT EXISTS stored_sectors_id_last_access ON stored_sectors(id, last_access_timestamp);
 DROP INDEX IF EXISTS stored_sectors_last_access;`)
 	if err != nil {
 		return fmt.Errorf("failed to update stored sector indices: %w", err)
@@ -1534,4 +1551,5 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion51,
 	migrateVersion52,
 	migrateVersion53,
+	migrateVersion54,
 }

--- a/persist/sqlite/sectors.go
+++ b/persist/sqlite/sectors.go
@@ -82,7 +82,10 @@ func (s *Store) RemoveSector(root types.Hash256) (err error) {
 // CacheSubtrees stores the cached subtree roots for a sector
 func (s *Store) CacheSubtrees(root types.Hash256, subtrees []types.Hash256) error {
 	return s.transaction(func(tx *txn) error {
-		_, err := tx.Exec(`UPDATE stored_sectors SET cached_subtree_roots=$1 WHERE sector_root=$2;`, encode(subtrees), encode(root))
+		const query = `INSERT INTO sector_subtree_cache (sector_id, subtree_roots)
+SELECT id, $1 FROM stored_sectors WHERE sector_root=$2
+ON CONFLICT (sector_id) DO UPDATE SET subtree_roots=EXCLUDED.subtree_roots;`
+		_, err := tx.Exec(query, encode(subtrees), encode(root))
 		return err
 	})
 }
@@ -102,8 +105,8 @@ func (s *Store) SectorMetadata(root types.Hash256) (meta storage.SectorMetadata,
 			return fmt.Errorf("failed to get sector location: %w", err)
 		}
 
-		err = tx.QueryRow(`SELECT cached_subtree_roots FROM stored_sectors WHERE id=$1;`, sectorID).Scan(decodeNullable(&meta.CachedSubtrees))
-		if err != nil {
+		err = tx.QueryRow(`SELECT subtree_roots FROM sector_subtree_cache WHERE sector_id=$1;`, sectorID).Scan(decode(&meta.CachedSubtrees))
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("failed to get cached subtrees: %w", err)
 		}
 		return nil

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -1462,8 +1462,8 @@ func BenchmarkPruneSectorsFullScan(b *testing.B) {
 	}
 }
 
-// cacheTestSubtrees populates cached_subtree_roots for the given sector roots,
-// as the merkle cache does in production.
+// cacheTestSubtrees populates the merkle cache for the given sector roots, as
+// production does for every stored sector.
 func cacheTestSubtrees(db *Store, roots []types.Hash256) error {
 	// 1024 roots, 32 KiB, per sector
 	subtrees := proto4.CachedSectorSubtrees(new([proto4.SectorSize]byte))
@@ -1474,7 +1474,9 @@ func cacheTestSubtrees(db *Store, roots []types.Hash256) error {
 		batch := roots[i:min(i+batchSize, len(roots))]
 
 		err := db.transaction(func(tx *txn) error {
-			stmt, err := tx.Prepare(`UPDATE stored_sectors SET cached_subtree_roots=$1 WHERE sector_root=$2`)
+			stmt, err := tx.Prepare(`INSERT INTO sector_subtree_cache (sector_id, subtree_roots)
+SELECT id, $1 FROM stored_sectors WHERE sector_root=$2
+ON CONFLICT (sector_id) DO UPDATE SET subtree_roots=EXCLUDED.subtree_roots`)
 			if err != nil {
 				return fmt.Errorf("failed to prepare statement: %w", err)
 			}


### PR DESCRIPTION
I have been digging a bit more since I didn't get why not everyone was affected by the recent CPU spike. So here is what I think happened.

SQLite is Index-Organized while Postgres is Heap based. So in SQLite the whole table data is stored in a B-Tree clustered by rowid and a primary key just maps to a rowid. In Postgres the primary key is stored separately in its own B-Tree.

So for the stored_sectors table that means joining on the id and filtering by it scans a B-Tree that holds very few rows per page due to the cache. Not the full 32kib but probably around half a kib. The reason being some [math](https://www.sqlite.org/fileformat.html#b_tree_pages) that happens on the page size which determines the minimum amount of data actually kept inline before spilling over into the overflow pages.

The fix we implemented, which I still think was the right hotfix, was bypassing the B-Tree by giving the query a covering index. 

Here comes the interesting part. When you installed hostd before we added the cache, the migration appended the column at the end. Rather than before the last_access_timestamp. This directly affects the scan time because a row is decoded in column order, and anything past the inlined portion means walking the row's overflow pages one at a time. So if it needs column 1 and 2 it reads only 1 and 2. If it needs 1 and 3 it will read 1, 2 and 3. Meaning that a migrated database performs significantly faster due to much smaller reads.

During some local testing I realized that the same issue also causes other queries to be slower than necessary. But saw some significant improvements after moving the cache to a separate table to avoid reading it on any hot path that doesn't need to read it.

The migration itself should also not be as bad as you might think. Dropping a column should not cause the database to grow on disk and frees the overflow pages immediately. Which are then reused when rebuilding the cache. The only waste is about 1-2% of the cache which remains as sparse space within the `stored_sectors` B-Tree which requires a vacuum. But there is going to be a lot of disk i/o for hosts as they rebuild their caches. 
