### PR TITLE
Use reference counter for pruning instead of lookups

### DIFF
--- a/.changeset/index_unreferenced_sectors.md
+++ b/.changeset/index_unreferenced_sectors.md
@@ -1,0 +1,13 @@
+---
+default: minor
+---
+
+# Index unreferenced sectors for pruning
+
+Sectors now track how many contract and temp storage references they have, and
+a location holds a lock while a sector is being written to it. The prune sweep
+reads unreferenced sectors from an index instead of scanning every stored
+sector, which on a 100 TiB host held the database for about six seconds every
+five minutes. The last access timestamp is removed. The upgrade computes the
+counts for existing sectors and rewrites the sector table, which takes about a
+minute at that size.

--- a/cmd/hostd/main.go
+++ b/cmd/hostd/main.go
@@ -271,6 +271,8 @@ func runRecalcCommand(srcPath string, log *zap.Logger) error {
 		log.Fatal("failed to recalculate contract metrics", zap.Error(err))
 	} else if err := db.RecalcVolumeMetrics(); err != nil {
 		log.Fatal("failed to recalculate volume metrics", zap.Error(err))
+	} else if err := db.RecalcSectorReferences(); err != nil {
+		log.Fatal("failed to recalculate sector references", zap.Error(err))
 	} else if err := db.Vacuum(); err != nil {
 		log.Fatal("failed to vacuum database", zap.Error(err))
 	}

--- a/host/contracts/manager_test.go
+++ b/host/contracts/manager_test.go
@@ -258,7 +258,7 @@ func TestV2ContractLifecycle(t *testing.T) {
 		t.Helper()
 
 		// ensure any dereferenced sectors have been pruned
-		if err := node.Store.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
+		if err := node.Store.PruneSectors(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1473,7 +1473,7 @@ func TestV2SectorRoots(t *testing.T) {
 	rev := txn.FileContracts[0]
 	for range sectors {
 		root := frand.Entropy256()
-		err := node.Store.StoreSector(root, func(loc storage.SectorLocation) error { return nil })
+		err := node.Store.AddTempSector(root, 100, func(loc storage.SectorLocation) error { return nil })
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/host/storage/persist.go
+++ b/host/storage/persist.go
@@ -3,15 +3,15 @@ package storage
 import (
 	"context"
 	"errors"
-	"time"
 
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 )
 
 type (
-	// StoreFunc is called for every sector that needs written
-	// to disk.
+	// StoreFunc is called with an empty location the sector should be written
+	// and synced to. The location is locked until the write is published or
+	// fails.
 	StoreFunc func(loc SectorLocation) error
 	// MigrateFunc is called for every sector that needs migration.
 	// The sector should be migrated from 'from' to 'to' during
@@ -39,7 +39,8 @@ type (
 		// nil is returned.
 		GrowVolume(volumeID int64, maxSectors uint64) error
 		// ShrinkVolume shrinks a storage volume's metadata to maxSectors. If
-		// there are used sectors in the shrink range, an error is returned.
+		// there are used sectors or locked locations in the shrink range, an
+		// error is returned.
 		ShrinkVolume(volumeID int64, maxSectors uint64) error
 
 		// SetReadOnly sets the read-only flag on a volume.
@@ -47,23 +48,23 @@ type (
 		// SetAvailable sets the available flag on a volume.
 		SetAvailable(volumeID int64, available bool) error
 
-		// PruneSectors removes all sectors that have not been accessed since
-		// lastAccess and are no longer referenced by a contract or temp storage.
-		// If the context is canceled, pruning is stopped and the function returns
-		// with the error.
-		PruneSectors(ctx context.Context, lastAccess time.Time) error
+		// PruneSectors removes all sectors that are no longer referenced by a
+		// contract or temp storage. If the context is canceled, pruning is
+		// stopped and the function returns with the error.
+		PruneSectors(ctx context.Context) error
 
 		// MigrateSectors returns a new location for each occupied sector of a
 		// volume starting at min. The sector data should be copied to the new
 		// location and synced to disk during migrateFn. If migrateFn returns an
 		// error, migration will continue, but that sector is not migrated.
 		MigrateSectors(ctx context.Context, volumeID int64, min uint64, fn MigrateFunc) (migrated, failed int, err error)
-		// StoreSector calls fn with an empty location in a writable volume. If
-		// the sector root already exists, nil is returned. The sector should be
-		// written to disk within fn. If fn returns an error, the metadata is
-		// rolled back and the error is returned. If no space is available,
+		// AddTempSector adds a temporary reference to a sector. If the sector
+		// is not stored, fn is called with an empty location and the sector is
+		// published with its reference after fn succeeds. If a concurrent
+		// upload completes the same root first, its copy is used and the
+		// reservation is released. If no space is available,
 		// ErrNotEnoughStorage is returned.
-		StoreSector(root types.Hash256, fn StoreFunc) error
+		AddTempSector(root types.Hash256, expiration uint64, fn StoreFunc) error
 		// RemoveSector removes the metadata of a sector and returns its
 		// location in the volume.
 		RemoveSector(root types.Hash256) error
@@ -78,9 +79,6 @@ type (
 		// SectorMetadata returns the metadata of a sector or an error if the
 		// sector is not found.
 		SectorMetadata(types.Hash256) (SectorMetadata, error)
-		// AddTempSector adds a sector to temporary storage. The sectors will be deleted
-		// after the expiration height
-		AddTempSector(root types.Hash256, expiration uint64) error
 		// AddTemporarySectors adds a list of sectors to the temporary store.
 		// The sectors are not referenced by a contract and will be removed
 		// at the expiration height.

--- a/host/storage/storage.go
+++ b/host/storage/storage.go
@@ -334,47 +334,37 @@ func (vm *VolumeManager) shrinkVolume(ctx context.Context, id int64, volume *vol
 }
 
 // writeSector atomically adds a sector to the database and writes it to disk
-func (vm *VolumeManager) writeSector(root types.Hash256, data *[proto4.SectorSize]byte) error {
-	err := vm.vs.StoreSector(root, func(loc SectorLocation) error {
-		start := time.Now()
+func (vm *VolumeManager) writeSector(loc SectorLocation, root types.Hash256, data *[proto4.SectorSize]byte) error {
+	start := time.Now()
 
-		vm.mu.Lock()
-		vol, ok := vm.volumes[loc.Volume]
-		vm.mu.Unlock()
-		if !ok {
-			return fmt.Errorf("volume %v not found", loc.Volume)
-		}
-
-		// write the sector to the volume
-		if err := vol.WriteSector(data, loc.Index); err != nil {
-			stats := vol.Stats()
-			vm.alerts.Register(alerts.Alert{
-				ID:       vol.alertID("write"),
-				Severity: alerts.SeverityError,
-				Message:  "Failed to write sector",
-				Data: map[string]any{
-					"volume":       vol.Location(),
-					"failedReads":  stats.FailedReads,
-					"failedWrites": stats.FailedWrites,
-					"sector":       root,
-					"error":        err.Error(),
-				},
-				Timestamp: time.Now(),
-			})
-			return err
-		}
-		vm.log.Debug("wrote sector", zap.String("root", root.String()), zap.Int64("volume", loc.Volume), zap.Uint64("index", loc.Index), zap.Duration("elapsed", time.Since(start)))
-
-		return vol.Sync()
-	})
-	if errors.Is(err, ErrNotEnoughStorage) {
-		vm.updateNoWritableStorageAlert(err)
-	} else if err == nil && vm.alerts.IsActive(NoWritableStorageAlertID) {
-		// a nil error does not prove writable space remains: the sector may
-		// already have been stored, so re-evaluate instead of dismissing
-		vm.updateNoWritableStorageAlert(nil)
+	vm.mu.Lock()
+	vol, ok := vm.volumes[loc.Volume]
+	vm.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("volume %v not found", loc.Volume)
 	}
-	return err
+
+	// write the sector to the volume
+	if err := vol.WriteSector(data, loc.Index); err != nil {
+		stats := vol.Stats()
+		vm.alerts.Register(alerts.Alert{
+			ID:       vol.alertID("write"),
+			Severity: alerts.SeverityError,
+			Message:  "Failed to write sector",
+			Data: map[string]any{
+				"volume":       vol.Location(),
+				"failedReads":  stats.FailedReads,
+				"failedWrites": stats.FailedWrites,
+				"sector":       root,
+				"error":        err.Error(),
+			},
+			Timestamp: time.Now(),
+		})
+		return err
+	}
+	vm.log.Debug("wrote sector", zap.Stringer("root", root), zap.Int64("volume", loc.Volume), zap.Uint64("index", loc.Index), zap.Duration("elapsed", time.Since(start)))
+
+	return vol.Sync()
 }
 
 func (vm *VolumeManager) updateNoWritableStorageAlert(cause error) {
@@ -1068,22 +1058,25 @@ func (vm *VolumeManager) StoreSector(root types.Hash256, data *[proto4.SectorSiz
 	}
 	defer done()
 
-	if err := vm.writeSector(root, data); errors.Is(err, ErrNotEnoughStorage) {
-		return proto4.ErrNotEnoughStorage
-	} else if err != nil {
-		return fmt.Errorf("failed to store sector: %w", err)
-	} else if err := vm.vs.AddTempSector(root, expiration); errors.Is(err, ErrNotEnoughStorage) {
+	err = vm.vs.AddTempSector(root, expiration, func(loc SectorLocation) error {
+		return vm.writeSector(loc, root, data)
+	})
+	if errors.Is(err, ErrNotEnoughStorage) {
 		vm.updateNoWritableStorageAlert(err)
 		return proto4.ErrNotEnoughStorage
 	} else if err != nil {
-		return fmt.Errorf("failed to reference temporary sector: %w", err)
+		return fmt.Errorf("failed to store sector: %w", err)
+	} else if vm.alerts.IsActive(NoWritableStorageAlertID) {
+		// a nil error does not prove writable space remains: the sector may
+		// already have been stored, so re-evaluate instead of dismissing
+		vm.updateNoWritableStorageAlert(nil)
 	}
 	if vm.merkleCacheEnabled {
 		go func() {
 			// optimistically cache the sector subtrees after storing
 			// the sector to avoid blocking the RPC response
 			if err := vm.vs.CacheSubtrees(root, subtrees); err != nil {
-				vm.log.Error("failed to cache sector subtrees", zap.String("sector", root.String()), zap.Error(err))
+				vm.log.Error("failed to cache sector subtrees", zap.Stringer("sector", root), zap.Error(err))
 			}
 		}()
 	}
@@ -1132,7 +1125,7 @@ func NewVolumeManager(vs VolumeStore, opts ...VolumeManagerOption) (*VolumeManag
 			case <-ctx.Done():
 				return
 			case <-time.After(vm.pruneInterval):
-				if err := vm.vs.PruneSectors(ctx, time.Now().Add(-1*vm.pruneInterval)); err != nil && !errors.Is(err, context.Canceled) {
+				if err := vm.vs.PruneSectors(ctx); err != nil && !errors.Is(err, context.Canceled) {
 					vm.log.Error("failed to prune sectors", zap.Error(err))
 				}
 				// expired temp sectors and pruned sectors free space without

--- a/persist/sqlite/contracts_test.go
+++ b/persist/sqlite/contracts_test.go
@@ -211,7 +211,7 @@ func TestReviseContract(t *testing.T) {
 		t.Helper()
 
 		// prune all possible sectors
-		if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
+		if err := db.PruneSectors(context.Background()); err != nil {
 			return fmt.Errorf("failed to prune sectors: %w", err)
 		}
 
@@ -260,7 +260,7 @@ func TestReviseContract(t *testing.T) {
 		var appended []types.Hash256
 		for range n {
 			root := frand.Entropy256()
-			err := db.StoreSector(root, func(loc storage.SectorLocation) error { return nil })
+			err := db.AddTempSector(root, 100, func(loc storage.SectorLocation) error { return nil })
 			if err != nil {
 				t.Fatal("failed to store sector:", err)
 			}
@@ -269,6 +269,8 @@ func TestReviseContract(t *testing.T) {
 		newRoots := append(append([]types.Hash256(nil), roots...), appended...)
 		if err := db.ReviseContract(contract, roots, newRoots, contracts.Usage{}); err != nil {
 			t.Fatal("failed to revise contract:", err)
+		} else if err := db.ExpireTempSectors(100); err != nil {
+			t.Fatal("failed to expire temp sectors:", err)
 		}
 
 		checkConsistency(t, newRoots)
@@ -609,7 +611,7 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 		var appended []types.Hash256
 		for range n {
 			root := frand.Entropy256()
-			err := db.StoreSector(root, func(loc storage.SectorLocation) error { return nil })
+			err := db.AddTempSector(root, 100, func(loc storage.SectorLocation) error { return nil })
 			if err != nil {
 				t.Fatal("failed to store sector:", err)
 			}
@@ -620,6 +622,8 @@ func TestReviseV2ContractConsistency(t *testing.T) {
 		contract.V2FileContract.Filesize = proto4.SectorSize * uint64(len(newRoots))
 		if err := db.ReviseV2Contract(contract.ID, contract.V2FileContract, roots, newRoots, proto4.Usage{}); err != nil {
 			t.Fatal("failed to revise contract:", err)
+		} else if err := db.ExpireTempSectors(100); err != nil {
+			t.Fatal("failed to expire temp sectors:", err)
 		}
 
 		checkRootConsistency(t, newRoots)
@@ -757,7 +761,7 @@ WHERE c.contract_id = $1`, encode(contractID)).Scan(&count)
 		var roots []types.Hash256
 		for range n {
 			root := frand.Entropy256()
-			if err := db.StoreSector(root, func(loc storage.SectorLocation) error { return nil }); err != nil {
+			if err := db.AddTempSector(root, 100, func(loc storage.SectorLocation) error { return nil }); err != nil {
 				t.Fatal(err)
 			}
 			roots = append(roots, root)
@@ -1103,10 +1107,8 @@ func BenchmarkV2AppendSectors(b *testing.B) {
 		root := types.Hash256(frand.Entropy256())
 		roots = append(roots, root)
 
-		err := db.StoreSector(root, func(loc storage.SectorLocation) error { return nil })
+		err := db.AddTempSector(root, 100, func(loc storage.SectorLocation) error { return nil })
 		if err != nil {
-			b.Fatal(err)
-		} else if err := db.AddTemporarySectors([]storage.TempSector{{Root: root, Expiration: 100}}); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -1156,10 +1158,8 @@ func BenchmarkV2TrimSectors(b *testing.B) {
 		root := types.Hash256(frand.Entropy256())
 		roots = append(roots, root)
 
-		err := db.StoreSector(root, func(loc storage.SectorLocation) error { return nil })
+		err := db.AddTempSector(root, 100, func(loc storage.SectorLocation) error { return nil })
 		if err != nil {
-			b.Fatal(err)
-		} else if err := db.AddTemporarySectors([]storage.TempSector{{Root: root, Expiration: 100}}); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -1218,10 +1218,8 @@ func BenchmarkRefreshContract(b *testing.B) {
 				root := types.Hash256(frand.Entropy256())
 				roots = append(roots, root)
 
-				err := db.StoreSector(root, func(loc storage.SectorLocation) error { return nil })
+				err := db.AddTempSector(root, 100, func(loc storage.SectorLocation) error { return nil })
 				if err != nil {
-					b.Fatal(err)
-				} else if err := db.AddTemporarySectors([]storage.TempSector{{Root: root, Expiration: 100}}); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -1305,7 +1303,7 @@ func BenchmarkExpireV2ContractSectors(b *testing.B) {
 	roots := make([]types.Hash256, contractSectors)
 	for i := range roots {
 		roots[i] = frand.Entropy256()
-		if err := db.StoreSector(roots[i], func(loc storage.SectorLocation) error { return nil }); err != nil {
+		if err := db.AddTempSector(roots[i], 100, func(loc storage.SectorLocation) error { return nil }); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -1381,7 +1379,7 @@ func BenchmarkExpireV2ContractSectorsSuperseded(b *testing.B) {
 	roots := make([]types.Hash256, contractSectors)
 	for i := range roots {
 		roots[i] = frand.Entropy256()
-		if err := db.StoreSector(roots[i], func(loc storage.SectorLocation) error { return nil }); err != nil {
+		if err := db.AddTempSector(roots[i], 100, func(loc storage.SectorLocation) error { return nil }); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -1413,7 +1411,7 @@ func BenchmarkExpireV2ContractSectorsSuperseded(b *testing.B) {
 	newRoots := make([]types.Hash256, contractSectors)
 	for i := range newRoots {
 		newRoots[i] = frand.Entropy256()
-		if err := db.StoreSector(newRoots[i], func(loc storage.SectorLocation) error { return nil }); err != nil {
+		if err := db.AddTempSector(newRoots[i], 100, func(loc storage.SectorLocation) error { return nil }); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -33,9 +33,10 @@ CREATE INDEX wallet_events_maturity_height ON wallet_events(maturity_height DESC
 CREATE TABLE stored_sectors (
 	id INTEGER PRIMARY KEY,
 	sector_root BLOB UNIQUE NOT NULL,
-	last_access_timestamp INTEGER NOT NULL
+	ref_count INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX stored_sectors_sector_root ON stored_sectors(sector_root);
+CREATE INDEX stored_sectors_unreferenced ON stored_sectors(id) WHERE ref_count=0;
 
 CREATE TABLE sector_subtree_cache (
 	sector_id INTEGER PRIMARY KEY REFERENCES stored_sectors(id) ON DELETE CASCADE,
@@ -66,6 +67,10 @@ CREATE INDEX volume_sectors_volume_id_sector_id ON volume_sectors(volume_id, sec
 CREATE INDEX volume_sectors_volume_id ON volume_sectors(volume_id);
 CREATE INDEX volume_sectors_volume_index ON volume_sectors(volume_index ASC);
 CREATE INDEX volume_sectors_sector_id ON volume_sectors(sector_id);
+
+CREATE TABLE volume_sector_locks (
+	volume_sector_id INTEGER PRIMARY KEY REFERENCES volume_sectors(id) ON DELETE CASCADE
+);
 
 CREATE TABLE contract_renters (
 	id INTEGER PRIMARY KEY,
@@ -122,6 +127,20 @@ CREATE TABLE contract_sector_roots (
 );
 CREATE INDEX contract_sector_roots_sector_id ON contract_sector_roots(sector_id);
 CREATE INDEX contract_sector_roots_contract_id_root_index ON contract_sector_roots(contract_id, root_index);
+CREATE TRIGGER contract_sector_roots_ref_count_insert AFTER INSERT ON contract_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
+CREATE TRIGGER contract_sector_roots_ref_count_delete AFTER DELETE ON contract_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+END;
+CREATE TRIGGER contract_sector_roots_ref_count_update AFTER UPDATE OF sector_id ON contract_sector_roots
+WHEN OLD.sector_id != NEW.sector_id
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
 
 CREATE TABLE contract_v2_state_elements (
 	contract_id INTEGER PRIMARY KEY REFERENCES contracts_v2(id),
@@ -201,6 +220,20 @@ CREATE TABLE contract_v2_sector_roots (
 );
 CREATE INDEX contract_v2_sector_roots_map_id_root_index_revision_number ON contract_v2_sector_roots(contract_v2_roots_map_id, root_index, contract_v2_roots_map_revision_number);
 CREATE INDEX contract_v2_sector_roots_sector_id ON contract_v2_sector_roots(sector_id);
+CREATE TRIGGER contract_v2_sector_roots_ref_count_insert AFTER INSERT ON contract_v2_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
+CREATE TRIGGER contract_v2_sector_roots_ref_count_delete AFTER DELETE ON contract_v2_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+END;
+CREATE TRIGGER contract_v2_sector_roots_ref_count_update AFTER UPDATE OF sector_id ON contract_v2_sector_roots
+WHEN OLD.sector_id != NEW.sector_id
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
 
 CREATE TABLE temp_storage_sector_roots (
 	id INTEGER PRIMARY KEY,
@@ -209,6 +242,20 @@ CREATE TABLE temp_storage_sector_roots (
 );
 CREATE INDEX temp_storage_sector_roots_sector_id ON temp_storage_sector_roots(sector_id);
 CREATE INDEX temp_storage_sector_roots_expiration_height ON temp_storage_sector_roots(expiration_height);
+CREATE TRIGGER temp_storage_sector_roots_ref_count_insert AFTER INSERT ON temp_storage_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
+CREATE TRIGGER temp_storage_sector_roots_ref_count_delete AFTER DELETE ON temp_storage_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+END;
+CREATE TRIGGER temp_storage_sector_roots_ref_count_update AFTER UPDATE OF sector_id ON temp_storage_sector_roots
+WHEN OLD.sector_id != NEW.sector_id
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
 
 CREATE TABLE registry_entries (
 	registry_key BLOB PRIMARY KEY,

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -33,7 +33,7 @@ CREATE INDEX wallet_events_maturity_height ON wallet_events(maturity_height DESC
 CREATE TABLE stored_sectors (
 	id INTEGER PRIMARY KEY,
 	sector_root BLOB UNIQUE NOT NULL,
-	ref_count INTEGER NOT NULL DEFAULT 0
+	ref_count INTEGER NOT NULL DEFAULT 0 CHECK (ref_count >= 0)
 );
 CREATE INDEX stored_sectors_sector_root ON stored_sectors(sector_root);
 CREATE INDEX stored_sectors_unreferenced ON stored_sectors(id) WHERE ref_count=0;

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -19,7 +19,7 @@ import (
 func migrateVersion55(tx *txn, _ *zap.Logger) error {
 	_, err := tx.Exec(`
 ALTER TABLE stored_sectors DROP COLUMN last_access_timestamp;
-ALTER TABLE stored_sectors ADD COLUMN ref_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE stored_sectors ADD COLUMN ref_count INTEGER NOT NULL DEFAULT 0 CHECK (ref_count >= 0);
 CREATE TABLE volume_sector_locks (
 	volume_sector_id INTEGER PRIMARY KEY REFERENCES volume_sectors(id) ON DELETE CASCADE
 );

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -13,6 +13,65 @@ import (
 	"go.uber.org/zap"
 )
 
+// migrateVersion55 adds a reference count to stored_sectors maintained by
+// triggers on the contract and temp storage root tables, replaces the last
+// access timestamp with volume_sector_locks and indexes unreferenced sectors.
+func migrateVersion55(tx *txn, _ *zap.Logger) error {
+	_, err := tx.Exec(`
+ALTER TABLE stored_sectors DROP COLUMN last_access_timestamp;
+ALTER TABLE stored_sectors ADD COLUMN ref_count INTEGER NOT NULL DEFAULT 0;
+CREATE TABLE volume_sector_locks (
+	volume_sector_id INTEGER PRIMARY KEY REFERENCES volume_sectors(id) ON DELETE CASCADE
+);
+CREATE INDEX stored_sectors_unreferenced ON stored_sectors(id) WHERE ref_count=0;
+CREATE TRIGGER contract_sector_roots_ref_count_insert AFTER INSERT ON contract_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
+CREATE TRIGGER contract_sector_roots_ref_count_delete AFTER DELETE ON contract_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+END;
+CREATE TRIGGER contract_sector_roots_ref_count_update AFTER UPDATE OF sector_id ON contract_sector_roots
+WHEN OLD.sector_id != NEW.sector_id
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
+CREATE TRIGGER contract_v2_sector_roots_ref_count_insert AFTER INSERT ON contract_v2_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
+CREATE TRIGGER contract_v2_sector_roots_ref_count_delete AFTER DELETE ON contract_v2_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+END;
+CREATE TRIGGER contract_v2_sector_roots_ref_count_update AFTER UPDATE OF sector_id ON contract_v2_sector_roots
+WHEN OLD.sector_id != NEW.sector_id
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
+CREATE TRIGGER temp_storage_sector_roots_ref_count_insert AFTER INSERT ON temp_storage_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;
+CREATE TRIGGER temp_storage_sector_roots_ref_count_delete AFTER DELETE ON temp_storage_sector_roots
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+END;
+CREATE TRIGGER temp_storage_sector_roots_ref_count_update AFTER UPDATE OF sector_id ON temp_storage_sector_roots
+WHEN OLD.sector_id != NEW.sector_id
+BEGIN
+	UPDATE stored_sectors SET ref_count=ref_count-1 WHERE id=OLD.sector_id;
+	UPDATE stored_sectors SET ref_count=ref_count+1 WHERE id=NEW.sector_id;
+END;`)
+	if err != nil {
+		return fmt.Errorf("failed to update sector schema: %w", err)
+	}
+	return recalcSectorReferences(tx)
+}
+
 // migrateVersion54 moves the merkle cache into its own table. The cached roots
 // are not carried over, they are rebuilt on the next read.
 //
@@ -1552,4 +1611,5 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion52,
 	migrateVersion53,
 	migrateVersion54,
+	migrateVersion55,
 }

--- a/persist/sqlite/migrations_test.go
+++ b/persist/sqlite/migrations_test.go
@@ -1,7 +1,9 @@
 package sqlite
 
 import (
+	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -11,6 +13,7 @@ import (
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/hostd/v2/host/contracts"
+	"go.sia.tech/hostd/v2/host/storage"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
@@ -383,6 +386,51 @@ func TestMigrationConsistency(t *testing.T) {
 		}
 	}
 
+	getTriggers := func(db *sql.DB) (map[string]bool, error) {
+		const query = `SELECT name, tbl_name, sql FROM sqlite_schema WHERE type='trigger'`
+		rows, err := db.Query(query)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+
+		triggers := make(map[string]bool)
+		for rows.Next() {
+			var name, table, sqlStr string
+			if err := rows.Scan(&name, &table, &sqlStr); err != nil {
+				return nil, err
+			}
+			triggers[fmt.Sprintf("%s.%s.%s", name, table, sqlStr)] = true
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return triggers, nil
+	}
+
+	// ensure the migrated database has the same triggers as the baseline
+	baselineTriggers, err := getTriggers(baseline.readerDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	migratedTriggers, err := getTriggers(store.readerDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k := range baselineTriggers {
+		if !migratedTriggers[k] {
+			t.Errorf("missing trigger %s", k)
+		}
+	}
+
+	for k := range migratedTriggers {
+		if !baselineTriggers[k] {
+			t.Errorf("unexpected trigger %s", k)
+		}
+	}
+
 	getTables := func(db *sql.DB) (map[string]bool, error) {
 		const query = `SELECT name FROM sqlite_schema WHERE type='table'`
 		rows, err := db.Query(query)
@@ -714,5 +762,81 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
 		t.Fatal("unexpected", m.Revenue.Earned.Storage)
 	} else if m.Storage.ContractSectors != 1 {
 		t.Fatal("unexpected", m.Storage.ContractSectors)
+	}
+}
+
+// TestMigrateV55 ensures the migration from version 54 to 55 computes the
+// reference count of existing sectors and that pruning works afterwards.
+func TestMigrateV55(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	fp := filepath.Join(t.TempDir(), "hostd.sqlite3")
+	store := initDBVersion(t, fp, 54, log)
+
+	roots := make([]types.Hash256, 4)
+	for i := range roots {
+		roots[i] = frand.Entropy256()
+	}
+	contractRoot, tempRoot, sharedRoot, unreferencedRoot := roots[0], roots[1], roots[2], roots[3]
+
+	// populate the pre-migration schema directly
+	err := store.transaction(func(tx *txn) error {
+		if _, err := tx.Exec(`INSERT INTO storage_volumes (id, disk_path, used_sectors, total_sectors, read_only, available) VALUES (1, 'test', 4, 4, false, true)`); err != nil {
+			return err
+		} else if err := incrementNumericStat(tx, metricPhysicalSectors, len(roots), time.Now()); err != nil {
+			return err
+		} else if _, err := tx.Exec(`INSERT INTO contract_v2_roots_map (id, revision_number) VALUES (1, 0)`); err != nil {
+			return err
+		}
+		for i, root := range roots {
+			if _, err := tx.Exec(`INSERT INTO stored_sectors (id, sector_root, last_access_timestamp) VALUES ($1, $2, $3)`, i+1, encode(root), encode(time.Now())); err != nil {
+				return err
+			} else if _, err := tx.Exec(`INSERT INTO volume_sectors (volume_id, volume_index, sector_id) VALUES (1, $1, $2)`, i, i+1); err != nil {
+				return err
+			}
+		}
+		// the contract holds contractRoot and sharedRoot, temp storage holds
+		// tempRoot and sharedRoot
+		if _, err := tx.Exec(`INSERT INTO contract_v2_sector_roots (sector_id, root_index, contract_v2_roots_map_id, contract_v2_roots_map_revision_number) VALUES (1, 0, 1, 0), (3, 1, 1, 0)`); err != nil {
+			return err
+		} else if _, err := tx.Exec(`INSERT INTO temp_storage_sector_roots (sector_id, expiration_height) VALUES (2, 100), (3, 100)`); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = OpenDatabase(fp, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	assertRefCount := func(t *testing.T, root types.Hash256, expected int) {
+		t.Helper()
+		var n int
+		if err := store.readerDB.QueryRow(`SELECT ref_count FROM stored_sectors WHERE sector_root=$1`, encode(root)).Scan(&n); err != nil {
+			t.Fatal(err)
+		} else if n != expected {
+			t.Fatalf("expected ref_count %d for %v, got %d", expected, root, n)
+		}
+	}
+	assertRefCount(t, contractRoot, 1)
+	assertRefCount(t, tempRoot, 1)
+	assertRefCount(t, sharedRoot, 2)
+
+	if err := store.PruneSectors(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, root := range []types.Hash256{contractRoot, tempRoot, sharedRoot} {
+		if _, err := store.SectorLocation(root); err != nil {
+			t.Fatalf("expected sector %v to be retained: %s", root, err)
+		}
+	}
+	if _, err := store.SectorLocation(unreferencedRoot); !errors.Is(err, storage.ErrSectorNotFound) {
+		t.Fatalf("expected ErrSectorNotFound, got %v", err)
 	}
 }

--- a/persist/sqlite/recalc.go
+++ b/persist/sqlite/recalc.go
@@ -136,6 +136,23 @@ GROUP BY sv.id`
 	return nil
 }
 
+func recalcSectorReferences(tx *txn) error {
+	_, err := tx.Exec(`
+CREATE TEMP TABLE sector_ref_counts (sector_id INTEGER PRIMARY KEY, n INTEGER NOT NULL);
+INSERT INTO sector_ref_counts SELECT sector_id, SUM(n) FROM (
+	SELECT sector_id, COUNT(*) AS n FROM contract_sector_roots GROUP BY sector_id
+	UNION ALL SELECT sector_id, COUNT(*) FROM contract_v2_sector_roots GROUP BY sector_id
+	UNION ALL SELECT sector_id, COUNT(*) FROM temp_storage_sector_roots GROUP BY sector_id
+) GROUP BY sector_id;
+UPDATE stored_sectors SET ref_count=COALESCE((SELECT n FROM sector_ref_counts WHERE sector_id=stored_sectors.id), 0)
+WHERE ref_count != COALESCE((SELECT n FROM sector_ref_counts WHERE sector_id=stored_sectors.id), 0);
+DROP TABLE sector_ref_counts;`)
+	if err != nil {
+		return fmt.Errorf("failed to recalculate sector references: %w", err)
+	}
+	return nil
+}
+
 func recalcContractSectorsMetrics(tx *txn) error {
 	var v1Count uint64
 	err := tx.QueryRow(`SELECT COUNT(*) FROM contract_sector_roots`).Scan(&v1Count)
@@ -346,6 +363,12 @@ func (s *Store) RecalcVolumeMetrics() error {
 	return s.writeTransaction(func(tx *txn) error {
 		return recalcVolumeMetrics(tx, s.log)
 	})
+}
+
+// RecalcSectorReferences recomputes the reference count of every stored sector
+// from the contract and temp storage roots.
+func (s *Store) RecalcSectorReferences() error {
+	return s.writeTransaction(recalcSectorReferences)
 }
 
 // Vacuum runs the VACUUM command on the database.

--- a/persist/sqlite/recalc_test.go
+++ b/persist/sqlite/recalc_test.go
@@ -38,7 +38,7 @@ func TestRecalcVolumeMetricsEmptyVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 	for range 4 {
-		if err := db.StoreSector(frand.Entropy256(), func(storage.SectorLocation) error { return nil }); err != nil {
+		if err := db.AddTempSector(frand.Entropy256(), 100, func(storage.SectorLocation) error { return nil }); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/persist/sqlite/sectors.go
+++ b/persist/sqlite/sectors.go
@@ -130,27 +130,6 @@ func (s *Store) SectorLocation(root types.Hash256) (location storage.SectorLocat
 	return
 }
 
-// AddTempSector adds a sector to temporary storage. The sectors will be deleted
-// after the expiration height
-func (s *Store) AddTempSector(root types.Hash256, expiration uint64) error {
-	return s.writeTransaction(func(tx *txn) error {
-		// ensure the sector is written to a volume
-		var sectorID int64
-		err := tx.QueryRow(`SELECT ss.id FROM stored_sectors ss
-INNER JOIN volume_sectors vs ON (vs.sector_id = ss.id)
-WHERE ss.sector_root=$1`, encode(root)).Scan(&sectorID)
-		if errors.Is(err, sql.ErrNoRows) {
-			return storage.ErrSectorNotFound
-		} else if err != nil {
-			return fmt.Errorf("failed to find sector: %w", err)
-		} else if err := incrementNumericStat(tx, metricTempSectors, 1, time.Now()); err != nil {
-			return fmt.Errorf("failed to update metric: %w", err)
-		}
-		_, err = tx.Exec(`INSERT INTO temp_storage_sector_roots (sector_id, expiration_height) VALUES ($1, $2)`, sectorID, expiration)
-		return err
-	})
-}
-
 // AddTemporarySectors adds the roots of sectors that are temporarily stored
 // on the host. The sectors will be deleted after the expiration height.
 //
@@ -239,106 +218,112 @@ WHERE ss.sector_root=$1 AND (EXISTS (SELECT 1 FROM contract_sector_roots csr WHE
 	return
 }
 
-type volumeSectorRef struct {
-	VolumeID       int64
-	VolumeSectorID int64
+type pruneCandidate struct {
 	SectorID       int64
+	VolumeSectorID sql.NullInt64
+	VolumeID       sql.NullInt64
+	Referenced     bool
 }
 
-func updatePruneableVolumeSectors(tx *txn, lastAccess time.Time, afterSectorID int64) (refs []volumeSectorRef, err error) {
-	const selectQuery = `
-SELECT vs.id, vs.volume_id, vs.sector_id
-FROM volume_sectors vs
-INNER JOIN stored_sectors ss ON vs.sector_id=ss.id
-WHERE ss.id > $1
-	AND ss.last_access_timestamp < $2
-	AND NOT EXISTS (SELECT 1 FROM contract_sector_roots csr WHERE csr.sector_id=ss.id)
-	AND NOT EXISTS (SELECT 1 FROM contract_v2_sector_roots csr2 WHERE csr2.sector_id=ss.id)
-	AND NOT EXISTS (SELECT 1 FROM temp_storage_sector_roots tsr WHERE tsr.sector_id=ss.id)
-ORDER BY ss.id
-LIMIT $3;`
-
-	rows, err := tx.Query(selectQuery, afterSectorID, encode(lastAccess), sqlSectorBatchSize)
-	if err != nil {
-		return nil, fmt.Errorf("failed to select volume sectors: %w", err)
+// removePruneCandidates releases the locations of the unreferenced candidates
+// and deletes their metadata. A candidate the reference tables still point at
+// has its count recomputed instead.
+func removePruneCandidates(tx *txn, log *zap.Logger, candidates []pruneCandidate) error {
+	var repairIDs, sectorIDs, volumeSectorIDs []any
+	volumeDeltas := make(map[int64]int)
+	for _, c := range candidates {
+		if c.Referenced {
+			repairIDs = append(repairIDs, c.SectorID)
+			continue
+		}
+		sectorIDs = append(sectorIDs, c.SectorID)
+		if c.VolumeSectorID.Valid {
+			volumeSectorIDs = append(volumeSectorIDs, c.VolumeSectorID.Int64)
+			volumeDeltas[c.VolumeID.Int64]--
+		}
 	}
-	refs, err = collectRows(rows, func(s scanner) (ref volumeSectorRef, err error) {
-		err = s.Scan(&ref.VolumeSectorID, &ref.VolumeID, &ref.SectorID)
-		return ref, err
+
+	if len(repairIDs) > 0 {
+		log.Warn("repairing sector reference counts", zap.Int("sectors", len(repairIDs)))
+		repairQuery := `UPDATE stored_sectors SET ref_count=(SELECT COUNT(*) FROM contract_sector_roots WHERE sector_id=stored_sectors.id)
+	+(SELECT COUNT(*) FROM contract_v2_sector_roots WHERE sector_id=stored_sectors.id)
+	+(SELECT COUNT(*) FROM temp_storage_sector_roots WHERE sector_id=stored_sectors.id)
+WHERE id IN (` + queryPlaceHolders(len(repairIDs)) + `)`
+		if _, err := tx.Exec(repairQuery, repairIDs...); err != nil {
+			return fmt.Errorf("failed to repair sector reference counts: %w", err)
+		}
+	}
+	if len(sectorIDs) == 0 {
+		return nil
+	}
+
+	if len(volumeSectorIDs) > 0 {
+		updateQuery := `UPDATE volume_sectors SET sector_id=NULL WHERE id IN (` + queryPlaceHolders(len(volumeSectorIDs)) + `)`
+		if _, err := tx.Exec(updateQuery, volumeSectorIDs...); err != nil {
+			return fmt.Errorf("failed to release volume sectors: %w", err)
+		}
+		for volumeID, delta := range volumeDeltas {
+			if err := incrementVolumeUsage(tx, volumeID, delta); err != nil {
+				return fmt.Errorf("failed to update volume %d usage: %w", volumeID, err)
+			}
+		}
+	}
+
+	deleteQuery := `DELETE FROM stored_sectors WHERE id IN (` + queryPlaceHolders(len(sectorIDs)) + `)`
+	if _, err := tx.Exec(deleteQuery, sectorIDs...); err != nil {
+		return fmt.Errorf("failed to delete stored sectors: %w", err)
+	}
+	return nil
+}
+
+// pruneSectorBatch removes up to sqlSectorBatchSize unreferenced sectors and
+// returns the number of candidates it considered.
+func pruneSectorBatch(tx *txn, log *zap.Logger) (int, error) {
+	const query = `SELECT ss.id, vs.id, vs.volume_id,
+	EXISTS (SELECT 1 FROM contract_sector_roots csr WHERE csr.sector_id=ss.id)
+	OR EXISTS (SELECT 1 FROM contract_v2_sector_roots csr2 WHERE csr2.sector_id=ss.id)
+	OR EXISTS (SELECT 1 FROM temp_storage_sector_roots tsr WHERE tsr.sector_id=ss.id)
+FROM stored_sectors ss
+LEFT JOIN volume_sectors vs ON vs.sector_id=ss.id
+WHERE ss.ref_count=0
+ORDER BY ss.id
+LIMIT $1`
+	rows, err := tx.Query(query, sqlSectorBatchSize)
+	if err != nil {
+		return 0, fmt.Errorf("failed to select sectors: %w", err)
+	}
+	candidates, err := collectRows(rows, func(s scanner) (c pruneCandidate, err error) {
+		err = s.Scan(&c.SectorID, &c.VolumeSectorID, &c.VolumeID, &c.Referenced)
+		return c, err
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get volume sectors: %w", err)
-	} else if len(refs) == 0 {
-		return nil, nil
+		return 0, fmt.Errorf("failed to scan sectors: %w", err)
+	} else if err := removePruneCandidates(tx, log, candidates); err != nil {
+		return 0, err
 	}
-
-	volumeSectorIDs := make([]any, 0, len(refs))
-	for _, ref := range refs {
-		volumeSectorIDs = append(volumeSectorIDs, ref.VolumeSectorID)
-	}
-
-	// update the volume_sectors table to null out the sector_id
-	updateQuery := `UPDATE volume_sectors SET sector_id=null WHERE id IN (` + queryPlaceHolders(len(refs)) + `)`
-	if _, err := tx.Exec(updateQuery, volumeSectorIDs...); err != nil {
-		return nil, fmt.Errorf("failed to update volume sectors: %w", err)
-	}
-	return refs, nil
+	return len(candidates), nil
 }
 
-// PruneSectors removes volume references for sectors that have not been accessed since the provided
-// timestamp and are no longer referenced by a contract or temp storage.
-func (s *Store) PruneSectors(ctx context.Context, lastAccess time.Time) error {
-	// note: last access can be removed after v2 when sectors are immediately committed to temp storage
-	var afterSectorID int64
-	for i := 0; ; i++ {
+// PruneSectors removes sectors that are no longer referenced by a contract or
+// temp storage.
+func (s *Store) PruneSectors(ctx context.Context) error {
+	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
 
-		var (
-			done bool
-			refs []volumeSectorRef
-		)
-		err := s.writeTransaction(func(tx *txn) error {
-			var err error
-			refs, err = updatePruneableVolumeSectors(tx, lastAccess, afterSectorID)
-			if err != nil {
-				return fmt.Errorf("failed to select volume sectors: %w", err)
-			} else if len(refs) == 0 {
-				done = true
-				return nil
-			}
-
-			volumeDeltas := make(map[int64]int)
-			sectorIDs := make([]any, 0, len(refs))
-			for _, ref := range refs {
-				volumeDeltas[ref.VolumeID]--
-				sectorIDs = append(sectorIDs, ref.SectorID)
-			}
-
-			for volumeID, delta := range volumeDeltas {
-				if err := incrementVolumeUsage(tx, volumeID, delta); err != nil {
-					return fmt.Errorf("failed to update volume %d usage: %w", volumeID, err)
-				}
-			}
-
-			// delete the orphaned stored_sectors entries
-			deleteQuery := `DELETE FROM stored_sectors WHERE id IN (` + queryPlaceHolders(len(sectorIDs)) + `)`
-			if _, err := tx.Exec(deleteQuery, sectorIDs...); err != nil {
-				return fmt.Errorf("failed to delete stored sectors: %w", err)
-			}
-			return nil
+		var n int
+		err := s.writeTransaction(func(tx *txn) (err error) {
+			n, err = pruneSectorBatch(tx, s.log)
+			return err
 		})
 		if err != nil {
 			return fmt.Errorf("failed to prune sectors: %w", err)
-		} else if done {
+		} else if n == 0 {
 			return nil
 		}
-		// continue after the last sector pruned instead of repeatedly scanning
-		// retained sectors at the beginning of the table for every batch.
-		afterSectorID = refs[len(refs)-1].SectorID
 		jitterSleep(50 * time.Millisecond)
 	}
 }

--- a/persist/sqlite/store.go
+++ b/persist/sqlite/store.go
@@ -331,9 +331,15 @@ func OpenDatabase(fp string, log *zap.Logger) (*Store, error) {
 		log:      log,
 	}
 	if err := store.init(int64(len(migrations) + 1)); err != nil {
-		defer readerDB.Close()
-		defer writerDB.Close()
+		if closeErr := store.Close(); closeErr != nil {
+			log.Warn("failed to close store after init failure", zap.Error(closeErr))
+		}
 		return nil, err
+	} else if err := store.writeTransaction(clearVolumeSectorLocks); err != nil {
+		if closeErr := store.Close(); closeErr != nil {
+			log.Warn("failed to close store after volume lock clear failure", zap.Error(closeErr))
+		}
+		return nil, fmt.Errorf("failed to clear sector write locks: %w", err)
 	}
 	sqliteVersion, _, _ := sqlite3.Version()
 	log.Debug("database initialized", zap.String("sqliteVersion", sqliteVersion), zap.Int("schemaVersion", len(migrations)+1), zap.String("path", fp))

--- a/persist/sqlite/temp_sector_test.go
+++ b/persist/sqlite/temp_sector_test.go
@@ -1,0 +1,155 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/hostd/v2/host/storage"
+	"go.uber.org/zap"
+)
+
+func assertTempSectorState(t *testing.T, db *Store, sectors, references, locks int) {
+	t.Helper()
+	var stored, assigned, refs, held, counted int
+	err := db.readerDB.QueryRow(`SELECT
+(SELECT COUNT(*) FROM stored_sectors),
+(SELECT COUNT(*) FROM volume_sectors WHERE sector_id IS NOT NULL),
+(SELECT COUNT(*) FROM temp_storage_sector_roots),
+(SELECT COUNT(*) FROM volume_sector_locks),
+(SELECT COALESCE(SUM(ref_count), 0) FROM stored_sectors)`).Scan(&stored, &assigned, &refs, &held, &counted)
+	if err != nil {
+		t.Fatal(err)
+	} else if stored != sectors || assigned != sectors || refs != references || counted != references || held != locks {
+		t.Fatalf("unexpected state: stored=%d assigned=%d refs=%d ref_count=%d locks=%d", stored, assigned, refs, counted, held)
+	}
+	m, err := db.Metrics(time.Now())
+	if err != nil {
+		t.Fatal(err)
+	} else if m.Storage.PhysicalSectors != uint64(sectors) || m.Storage.TempSectors != uint64(references) {
+		t.Fatalf("unexpected storage metrics: %+v", m.Storage)
+	}
+}
+
+func TestAddTempSectorPublication(t *testing.T) {
+	for _, outcome := range []string{"success", "write failure", "reference failure"} {
+		t.Run(outcome, func(t *testing.T) {
+			db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), zap.NewNop())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			if _, err := addTestVolume(db, "test", 1); err != nil {
+				t.Fatal(err)
+			}
+			root := types.Hash256{1}
+			writeErr := errors.New("write failed")
+			err = db.AddTempSector(root, 100, func(loc storage.SectorLocation) error {
+				assertTempSectorState(t, db, 0, 0, 1)
+				if _, err := db.SectorLocation(root); !errors.Is(err, storage.ErrSectorNotFound) {
+					t.Fatalf("expected unpublished root, got %v", err)
+				} else if err := db.PruneSectors(context.Background()); err != nil {
+					t.Fatal(err)
+				}
+				for _, force := range []bool{false, true} {
+					if err := db.RemoveVolume(loc.Volume, force); err == nil {
+						t.Fatal("removed a pending write reservation")
+					}
+				}
+				if outcome == "write failure" {
+					return writeErr
+				} else if outcome == "reference failure" {
+					return db.writeTransaction(func(tx *txn) error {
+						_, err := tx.Exec(`CREATE TRIGGER fail_temp_reference BEFORE INSERT ON temp_storage_sector_roots
+BEGIN SELECT RAISE(ABORT, 'injected reference failure'); END`)
+						return err
+					})
+				}
+				return nil
+			})
+			if outcome == "success" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertTempSectorState(t, db, 1, 1, 0)
+				// An existing copy can be referenced even when the volume is full.
+				if err := db.AddTempSector(root, 200, func(_ storage.SectorLocation) error {
+					t.Fatal("unexpected write for a stored sector")
+					return nil
+				}); err != nil {
+					t.Fatal(err)
+				}
+				assertTempSectorState(t, db, 1, 2, 0)
+				if err := db.ExpireTempSectors(100); err != nil {
+					t.Fatal(err)
+				}
+				assertTempSectorState(t, db, 1, 1, 0)
+			} else {
+				if err == nil || outcome == "write failure" && !errors.Is(err, writeErr) {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				assertTempSectorState(t, db, 0, 0, 0)
+			}
+		})
+	}
+}
+
+func TestAddTempSectorConcurrentRoot(t *testing.T) {
+	for _, failFirst := range []bool{false, true} {
+		t.Run(fmt.Sprintf("failFirst=%v", failFirst), func(t *testing.T) {
+			db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), zap.NewNop())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			if _, err := addTestVolume(db, "test", 2); err != nil {
+				t.Fatal(err)
+			}
+			root := types.Hash256{1}
+			writeErr := errors.New("first write failed")
+			var winner storage.SectorLocation
+			err = db.AddTempSector(root, 100, func(first storage.SectorLocation) error {
+				// Interleave a second upload that completes before the first.
+				if err := db.AddTempSector(root, 200, func(second storage.SectorLocation) error {
+					if second.ID == first.ID {
+						t.Fatal("second upload reused unfinished data")
+					}
+					winner = second
+					assertTempSectorState(t, db, 0, 0, 2)
+					return nil
+				}); err != nil {
+					t.Fatal(err)
+				}
+				assertTempSectorState(t, db, 1, 1, 1)
+				if failFirst {
+					return writeErr
+				}
+				return nil
+			})
+			refs := 2
+			if failFirst {
+				refs = 1
+				if !errors.Is(err, writeErr) {
+					t.Fatalf("expected write error, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			assertTempSectorState(t, db, 1, refs, 0)
+			if loc, err := db.SectorLocation(root); err != nil {
+				t.Fatal(err)
+			} else if loc.ID != winner.ID {
+				t.Fatal("first upload replaced the completed copy")
+			}
+			// The redundant slot is immediately writable by another root.
+			if err := db.AddTempSector(types.Hash256{2}, 100, func(storage.SectorLocation) error { return nil }); err != nil {
+				t.Fatal(err)
+			}
+			assertTempSectorState(t, db, 2, refs+1, 0)
+		})
+	}
+}

--- a/persist/sqlite/volumes.go
+++ b/persist/sqlite/volumes.go
@@ -54,8 +54,22 @@ func deleteVolumeSectors(tx *txn, volumeID int64) (removed int64, err error) {
 	return
 }
 
+func addTempSector(tx *txn, sectorID int64, expiration uint64) error {
+	if err := incrementNumericStat(tx, metricTempSectors, 1, time.Now()); err != nil {
+		return fmt.Errorf("failed to update metric: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO temp_storage_sector_roots (sector_id, expiration_height) VALUES ($1, $2)`, sectorID, expiration); err != nil {
+		return fmt.Errorf("failed to add temp sector root: %w", err)
+	}
+	return nil
+}
+
 func (s *Store) batchRemoveVolumeSectors(id int64, force bool) (removed, lost int64, err error) {
 	err = s.writeTransaction(func(tx *txn) error {
+		removed, lost = 0, 0
+		if err := checkVolumeSectorLocks(tx, id, 0); err != nil {
+			return err
+		}
 		if force {
 			removed, lost, err = forceDeleteVolumeSectors(tx, id)
 			if err != nil {
@@ -139,51 +153,29 @@ WHERE v.id=$1`
 	return
 }
 
-// StoreSector calls fn with an empty location in a writable volume. If
-// the sector root already exists, nil is returned. The sector should be
-// written to disk within fn. If fn returns an error, the metadata is
-// rolled back and the error is returned. If no space is available,
-// ErrNotEnoughStorage is returned.
-func (s *Store) StoreSector(root types.Hash256, fn storage.StoreFunc) error {
+// AddTempSector adds a temporary reference to a sector, storing it first if
+// necessary.
+func (s *Store) AddTempSector(root types.Hash256, expiration uint64, fn storage.StoreFunc) error {
 	var location storage.SectorLocation
-	var sectorID int64
 	var exists bool
-
 	err := s.writeTransaction(func(tx *txn) error {
-		var err error
-		sectorID, err = insertSectorDBID(tx, root)
-		if err != nil {
-			return fmt.Errorf("failed to get sector id: %w", err)
-		}
-
-		// check if the sector is already stored on disk
-		location, err = sectorLocation(tx, sectorID, root)
-		if err != nil && !errors.Is(err, storage.ErrSectorNotFound) {
-			return fmt.Errorf("failed to check existing sector location: %w", err)
-		} else if err == nil {
+		exists = false
+		var sectorID int64
+		err := tx.QueryRow(`SELECT ss.id FROM stored_sectors ss
+INNER JOIN volume_sectors vs ON vs.sector_id=ss.id
+WHERE ss.sector_root=$1`, encode(root)).Scan(&sectorID)
+		if err == nil {
 			exists = true
-			return nil
+			return addTempSector(tx, sectorID, expiration)
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("failed to check existing sector: %w", err)
 		}
-
 		location, err = emptyLocation(tx)
 		if err != nil {
 			return fmt.Errorf("failed to get empty location: %w", err)
 		}
-
-		res, err := tx.Exec(`UPDATE volume_sectors SET sector_id=$1 WHERE id=$2`, sectorID, location.ID)
-		if err != nil {
-			return fmt.Errorf("failed to commit sector location: %w", err)
-		} else if rows, err := res.RowsAffected(); err != nil {
-			return fmt.Errorf("failed to check rows affected: %w", err)
-		} else if rows == 0 {
-			return storage.ErrSectorNotFound
-		}
-
-		// increment the volume usage
-		if err := incrementVolumeUsage(tx, location.Volume, 1); err != nil {
-			return fmt.Errorf("failed to update volume metadata: %w", err)
-		}
-		return nil
+		location.Root = root
+		return lockVolumeSector(tx, location.ID)
 	})
 	if err != nil {
 		return err
@@ -191,27 +183,46 @@ func (s *Store) StoreSector(root types.Hash256, fn storage.StoreFunc) error {
 		return nil
 	}
 
-	// call fn with the location
+	cleanup := func(cause error) error {
+		if err := s.writeTransaction(func(tx *txn) error {
+			return releaseVolumeSector(tx, location.ID)
+		}); err != nil {
+			return errors.Join(cause, fmt.Errorf("failed to release location: %w", err))
+		}
+		return cause
+	}
 	if err := fn(location); err != nil {
-		rollbackErr := s.writeTransaction(func(tx *txn) error {
-			res, err := tx.Exec(`UPDATE volume_sectors SET sector_id=null WHERE id=$1 AND sector_id=$2`, location.ID, sectorID)
+		return cleanup(err)
+	}
+
+	err = s.writeTransaction(func(tx *txn) error {
+		sectorID, err := insertSectorDBID(tx, root)
+		if err != nil {
+			return fmt.Errorf("failed to insert sector: %w", err)
+		}
+		// a concurrent upload may have published the root during fn
+		_, err = sectorLocation(tx, sectorID, root)
+		if errors.Is(err, storage.ErrSectorNotFound) {
+			res, err := tx.Exec(`UPDATE volume_sectors SET sector_id=$1 WHERE id=$2 AND sector_id IS NULL`, sectorID, location.ID)
 			if err != nil {
-				return fmt.Errorf("failed to rollback sector location: %w", err)
+				return fmt.Errorf("failed to commit sector location: %w", err)
 			} else if n, err := res.RowsAffected(); err != nil {
 				return fmt.Errorf("failed to check rows affected: %w", err)
-			} else if n == 0 {
-				// location was released in the meantime
-				return nil
-			} else if err := incrementVolumeUsage(tx, location.Volume, -1); err != nil {
-				return fmt.Errorf("failed to update volume metadata: %w", err)
+			} else if n != 1 {
+				return errors.New("reserved sector location is gone or occupied")
+			} else if err := incrementVolumeUsage(tx, location.Volume, 1); err != nil {
+				return fmt.Errorf("failed to update volume usage: %w", err)
 			}
-			return nil
-		})
-		if rollbackErr != nil {
-			// rollbacks are best-effort. The dangling reference will be picked up by prune regardless.
-			s.log.Error("failed to rollback volume metadata: %w", zap.NamedError("rollbackErr", rollbackErr), zap.Stringer("root", root), zap.Error(err))
+		} else if err != nil {
+			return fmt.Errorf("failed to check completed sector: %w", err)
 		}
-		return err
+		if err := addTempSector(tx, sectorID, expiration); err != nil {
+			return err
+		}
+		return releaseVolumeSector(tx, location.ID)
+	})
+	if err != nil {
+		return cleanup(err)
 	}
 	return nil
 }
@@ -331,6 +342,7 @@ func (s *Store) AddVolume(localPath string, readOnly bool) (volumeID int64, err 
 // RemoveVolume removes a storage volume from the volume store. If there
 // are used sectors in the volume, ErrVolumeNotEmpty is returned. If force is
 // true, the volume is removed regardless of whether it is empty.
+// Locked locations prevent removal even when force is true.
 func (s *Store) RemoveVolume(id int64, force bool) error {
 	log := s.log.Named("RemoveVolume").With(zap.Int64("volume", id), zap.Bool("force", force))
 	// remove the volume sectors in batches to avoid holding a transaction lock
@@ -384,12 +396,16 @@ func (s *Store) GrowVolume(id int64, maxSectors uint64) error {
 
 // ShrinkVolume shrinks a storage volume's metadata to maxSectors. If there are
 // used sectors outside of the new maximum, ErrVolumeNotEmpty is returned.
+// Locked locations outside of the new maximum also prevent shrinking.
 func (s *Store) ShrinkVolume(id int64, maxSectors uint64) error {
 	if maxSectors == 0 {
 		panic("maxSectors must be greater than 0") // dev error
 	}
 
 	return s.writeTransaction(func(tx *txn) error {
+		if err := checkVolumeSectorLocks(tx, id, maxSectors); err != nil {
+			return err
+		}
 		// check if there are any used sectors in the shrink range
 		var usedSectors uint64
 		err := tx.QueryRow(`SELECT COUNT(sector_id) FROM volume_sectors WHERE volume_id=$1 AND volume_index >= $2 AND sector_id IS NOT NULL;`, id, maxSectors).Scan(&usedSectors)
@@ -443,7 +459,7 @@ func (s *Store) SetAvailable(volumeID int64, available bool) error {
 
 // sectorDBID returns the ID of a sector root in the stored_sectors table.
 func sectorDBID(tx *txn, root types.Hash256) (id int64, err error) {
-	err = tx.QueryRow(`UPDATE stored_sectors SET last_access_timestamp=$1 WHERE sector_root=$2 RETURNING id`, encode(time.Now()), encode(root)).Scan(&id)
+	err = tx.QueryRow(`SELECT id FROM stored_sectors WHERE sector_root=$1`, encode(root)).Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
 		err = storage.ErrSectorNotFound
 	}
@@ -454,8 +470,36 @@ func sectorDBID(tx *txn, root types.Hash256) (id int64, err error) {
 // does not already exist. If the sector root already exists, the ID is
 // returned.
 func insertSectorDBID(tx *txn, root types.Hash256) (id int64, err error) {
-	err = tx.QueryRow(`INSERT INTO stored_sectors (sector_root, last_access_timestamp) VALUES ($1, $2) ON CONFLICT (sector_root) DO UPDATE SET last_access_timestamp=EXCLUDED.last_access_timestamp RETURNING id`, encode(root), encode(time.Now())).Scan(&id)
+	err = tx.QueryRow(`INSERT INTO stored_sectors (sector_root) VALUES ($1) ON CONFLICT (sector_root) DO UPDATE SET sector_root=EXCLUDED.sector_root RETURNING id`, encode(root)).Scan(&id)
 	return
+}
+
+func checkVolumeSectorLocks(tx *txn, volumeID int64, minIndex uint64) error {
+	var index uint64
+	err := tx.QueryRow(`SELECT vs.volume_index FROM volume_sectors vs
+INNER JOIN volume_sector_locks l ON l.volume_sector_id=vs.id
+WHERE vs.volume_id=$1 AND vs.volume_index >= $2 LIMIT 1`, volumeID, minIndex).Scan(&index)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to check volume sector locks: %w", err)
+	}
+	return fmt.Errorf("sector at volume %d index %d is locked", volumeID, index)
+}
+
+func lockVolumeSector(tx *txn, volumeSectorID int64) error {
+	_, err := tx.Exec(`INSERT INTO volume_sector_locks (volume_sector_id) VALUES ($1)`, volumeSectorID)
+	return err
+}
+
+func releaseVolumeSector(tx *txn, volumeSectorID int64) error {
+	_, err := tx.Exec(`DELETE FROM volume_sector_locks WHERE volume_sector_id=$1`, volumeSectorID)
+	return err
+}
+
+func clearVolumeSectorLocks(tx *txn) error {
+	_, err := tx.Exec(`DELETE FROM volume_sector_locks`)
+	return err
 }
 
 func addVolume(tx *txn, localPath string, readOnly bool) (volumeID int64, err error) {
@@ -517,6 +561,7 @@ func emptyLocation(tx *txn) (loc storage.SectorLocation, err error) {
 	FROM volume_sectors vs INDEXED BY volume_sectors_sector_writes_volume_id_sector_id_volume_index_compound
 	INNER JOIN storage_volumes sv ON (sv.id=vs.volume_id)
 	WHERE vs.sector_id IS NULL AND sv.available=true AND sv.read_only=false
+		AND NOT EXISTS (SELECT 1 FROM volume_sector_locks l WHERE l.volume_sector_id=vs.id)
 	ORDER BY vs.sector_writes ASC
 	LIMIT 1;`
 	err = tx.QueryRow(query).Scan(&loc.ID, &loc.Volume, &loc.Index)
@@ -545,6 +590,7 @@ func emptyLocationForMigration(tx *txn, volumeID int64, maxIndex uint64) (loc st
 	const query = `SELECT vs.id, vs.volume_id, vs.volume_index
 FROM volume_sectors vs
 WHERE vs.sector_id IS NULL AND vs.volume_id=$1 AND vs.volume_index < $2
+	AND NOT EXISTS (SELECT 1 FROM volume_sector_locks l WHERE l.volume_sector_id=vs.id)
 LIMIT 1;`
 	err = tx.QueryRow(query, volumeID, maxIndex).Scan(&loc.ID, &loc.Volume, &loc.Index)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/persist/sqlite/volumes.go
+++ b/persist/sqlite/volumes.go
@@ -476,8 +476,8 @@ func insertSectorDBID(tx *txn, root types.Hash256) (id int64, err error) {
 
 func checkVolumeSectorLocks(tx *txn, volumeID int64, minIndex uint64) error {
 	var index uint64
-	err := tx.QueryRow(`SELECT vs.volume_index FROM volume_sectors vs
-INNER JOIN volume_sector_locks l ON l.volume_sector_id=vs.id
+	err := tx.QueryRow(`SELECT vs.volume_index FROM volume_sector_locks l
+CROSS JOIN volume_sectors vs ON vs.id=l.volume_sector_id
 WHERE vs.volume_id=$1 AND vs.volume_index >= $2 LIMIT 1`, volumeID, minIndex).Scan(&index)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil
@@ -487,6 +487,9 @@ WHERE vs.volume_id=$1 AND vs.volume_index >= $2 LIMIT 1`, volumeID, minIndex).Sc
 	return fmt.Errorf("sector at volume %d index %d is locked", volumeID, index)
 }
 
+// lockVolumeSector locks a volume location so concurrent
+// operations can't re-use it while disk IO is inflight. Requires
+// an exclusive write transaction.
 func lockVolumeSector(tx *txn, volumeSectorID int64) error {
 	_, err := tx.Exec(`INSERT INTO volume_sector_locks (volume_sector_id) VALUES ($1)`, volumeSectorID)
 	return err

--- a/persist/sqlite/volumes_test.go
+++ b/persist/sqlite/volumes_test.go
@@ -48,7 +48,7 @@ func TestVolumeSetReadOnly(t *testing.T) {
 	}
 
 	// try to add a sector to the volume
-	err = db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation) error { return nil })
+	err = db.AddTempSector(frand.Entropy256(), 100, func(loc storage.SectorLocation) error { return nil })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestVolumeSetReadOnly(t *testing.T) {
 
 	// try to add another sector to the volume, should fail with
 	// ErrNotEnoughStorage
-	err = db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation) error { return nil })
+	err = db.AddTempSector(frand.Entropy256(), 100, func(loc storage.SectorLocation) error { return nil })
 	if !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
@@ -84,7 +84,7 @@ func TestAddSector(t *testing.T) {
 	root := frand.Entropy256()
 	// try to store a sector in the empty volume, should return
 	// ErrNotEnoughStorage
-	err = db.StoreSector(root, func(storage.SectorLocation) error { return nil })
+	err = db.AddTempSector(root, 100, func(storage.SectorLocation) error { return nil })
 	if !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
@@ -94,7 +94,7 @@ func TestAddSector(t *testing.T) {
 		t.Fatal(err)
 	}
 	// store the sector
-	err = db.StoreSector(root, func(loc storage.SectorLocation) error {
+	err = db.AddTempSector(root, 100, func(loc storage.SectorLocation) error {
 		// check that the sector was stored in the expected location
 		if loc.Volume != volumeID {
 			t.Fatalf("expected volume ID %v, got %v", volumeID, loc.Volume)
@@ -129,9 +129,9 @@ func TestAddSector(t *testing.T) {
 		t.Fatalf("expected 1 used sector, got %v", volumes[0].UsedSectors)
 	}
 
-	// store the sector again, should be a no-op
-	err = db.StoreSector(root, func(loc storage.SectorLocation) error {
-		t.Fatal("store function called twice")
+	// storing the sector again does not write
+	err = db.AddTempSector(root, 100, func(storage.SectorLocation) error {
+		t.Fatal("unexpected write for a stored sector")
 		return nil
 	})
 	if err != nil {
@@ -150,7 +150,7 @@ func TestAddSector(t *testing.T) {
 
 	// try to store another sector in the volume, should return
 	// ErrNotEnoughStorage
-	err = db.StoreSector(frand.Entropy256(), func(storage.SectorLocation) error { return nil })
+	err = db.AddTempSector(frand.Entropy256(), 100, func(storage.SectorLocation) error { return nil })
 	if !errors.Is(err, storage.ErrNotEnoughStorage) {
 		t.Fatalf("expected ErrNotEnoughStorage, got %v", err)
 	}
@@ -175,11 +175,10 @@ func TestStoreSectorRollbackReleasedLocation(t *testing.T) {
 
 	root := frand.Entropy256()
 	writeErr := errors.New("write failed")
-	err = db.StoreSector(root, func(loc storage.SectorLocation) error {
-		// release the location out from under the write, as a migration or a
-		// removal would. This already decrements the volume usage.
-		if err := db.RemoveSector(root); err != nil {
-			t.Fatal(err)
+	err = db.AddTempSector(root, 100, func(loc storage.SectorLocation) error {
+		// the sector is not published until fn returns
+		if err := db.RemoveSector(root); !errors.Is(err, storage.ErrSectorNotFound) {
+			t.Fatalf("expected unpublished sector, got %v", err)
 		}
 		return writeErr // cause rollback
 	})
@@ -187,7 +186,7 @@ func TestStoreSectorRollbackReleasedLocation(t *testing.T) {
 		t.Fatalf("expected write error, got %v", err)
 	}
 
-	// the rollback must not decrement the usage a second time
+	// usage is unchanged after the failed write
 	v, err := db.Volume(volume.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -197,7 +196,7 @@ func TestStoreSectorRollbackReleasedLocation(t *testing.T) {
 
 	// the volume must still be fully writable
 	for range 2 {
-		if err := db.StoreSector(frand.Entropy256(), func(storage.SectorLocation) error { return nil }); err != nil {
+		if err := db.AddTempSector(frand.Entropy256(), 100, func(storage.SectorLocation) error { return nil }); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -227,7 +226,7 @@ func TestForceRemoveVolumeSectorsUsage(t *testing.T) {
 	}
 
 	for range sectors {
-		if err := db.StoreSector(frand.Entropy256(), func(storage.SectorLocation) error { return nil }); err != nil {
+		if err := db.AddTempSector(frand.Entropy256(), 100, func(storage.SectorLocation) error { return nil }); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -279,7 +278,7 @@ func TestHasSector(t *testing.T) {
 
 	root := frand.Entropy256()
 	// store the sector
-	err = db.StoreSector(root, func(loc storage.SectorLocation) error {
+	err = db.AddTempSector(root, 100, func(loc storage.SectorLocation) error {
 		// check that the sector was stored in the expected location
 		if loc.Volume != volumeID {
 			t.Fatalf("expected volume ID %v, got %v", volumeID, loc.Volume)
@@ -304,25 +303,24 @@ func TestHasSector(t *testing.T) {
 		t.Fatalf("expected sector index 0, got %v", loc.Index)
 	}
 
-	// the sector should not exist since it is not referenced
+	// the sector exists while it is referenced by temp storage
 	exists, err := db.HasSector(root)
-	if err != nil {
-		t.Fatal(err)
-	} else if exists {
-		t.Fatal("expected sector to not exist")
-	}
-
-	// add a temporary sector
-	if err = db.AddTempSector(root, 1); err != nil {
-		t.Fatal(err)
-	}
-
-	// the sector should now exist since it is referenced by a temp sector
-	exists, err = db.HasSector(root)
 	if err != nil {
 		t.Fatal(err)
 	} else if !exists {
 		t.Fatal("expected sector to exist")
+	}
+
+	if err := db.ExpireTempSectors(100); err != nil {
+		t.Fatal(err)
+	}
+
+	// the sector no longer exists once it is unreferenced
+	exists, err = db.HasSector(root)
+	if err != nil {
+		t.Fatal(err)
+	} else if exists {
+		t.Fatal("expected sector to not exist")
 	}
 }
 
@@ -494,7 +492,7 @@ func TestShrinkVolume(t *testing.T) {
 
 	// add a few sectors
 	for i := range 5 {
-		err := db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation) error {
+		err := db.AddTempSector(frand.Entropy256(), 100, func(loc storage.SectorLocation) error {
 			if loc.Volume != volume.ID {
 				t.Fatalf("expected volume ID %v, got %v", volume.ID, loc.Volume)
 			} else if loc.Index != uint64(i) {
@@ -538,10 +536,7 @@ func TestMigrateConcurrency(t *testing.T) {
 
 	// fill the volume
 	for range initialSectors {
-		root := frand.Entropy256()
-		if err := db.StoreSector(root, func(_ storage.SectorLocation) error { return nil }); err != nil {
-			t.Fatal(err)
-		} else if err := db.AddTempSector(root, 100); err != nil {
+		if err := db.AddTempSector(frand.Entropy256(), 100, func(storage.SectorLocation) error { return nil }); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -582,14 +577,12 @@ func TestMigrateConcurrency(t *testing.T) {
 	// fill the second volume
 	for range initialSectors {
 		root := types.Hash256(frand.Entropy256())
-		err := db.StoreSector(root, func(_ storage.SectorLocation) error {
+		err := db.AddTempSector(root, 100, func(storage.SectorLocation) error {
 			// simulate disk i/o
 			time.Sleep(10 * time.Millisecond)
 			return nil
 		})
 		if err != nil {
-			t.Fatal(err)
-		} else if err := db.AddTempSector(root, 100); err != nil {
 			t.Fatal(err)
 		}
 		log.Debug("stored sector", zap.Stringer("root", root))
@@ -634,7 +627,7 @@ func TestRemoveVolume(t *testing.T) {
 	// add a few sectors
 	for i := range 5 {
 		sectorRoot := frand.Entropy256()
-		err := db.StoreSector(sectorRoot, func(loc storage.SectorLocation) error {
+		err := db.AddTempSector(sectorRoot, uint64(i), func(loc storage.SectorLocation) error {
 			if loc.Volume != volume.ID {
 				t.Fatalf("expected volume ID %v, got %v", volume.ID, loc.Volume)
 			} else if loc.Index != uint64(i) {
@@ -642,11 +635,6 @@ func TestRemoveVolume(t *testing.T) {
 			}
 			return nil
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = db.AddTemporarySectors([]storage.TempSector{{Root: sectorRoot, Expiration: uint64(i)}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -669,7 +657,7 @@ func TestRemoveVolume(t *testing.T) {
 	// expire all of the temporary sectors
 	if err := db.ExpireTempSectors(5); err != nil {
 		t.Fatal(err)
-	} else if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
+	} else if err := db.PruneSectors(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -707,7 +695,7 @@ func TestMigrateSectors(t *testing.T) {
 	for i := range roots {
 		root := frand.Entropy256()
 		roots[i] = root
-		err := db.StoreSector(root, func(loc storage.SectorLocation) error {
+		err := db.AddTempSector(root, 100, func(loc storage.SectorLocation) error {
 			if loc.Volume != volume.ID {
 				t.Fatalf("expected volume ID %v, got %v", volume.ID, loc.Volume)
 			} else if loc.Index != uint64(i) {
@@ -824,7 +812,7 @@ func TestPrune(t *testing.T) {
 	roots := make([]types.Hash256, 0, sectors)
 	for i := range sectors {
 		root := frand.Entropy256()
-		err := db.StoreSector(root, func(loc storage.SectorLocation) error {
+		err := db.AddTempSector(root, 50, func(loc storage.SectorLocation) error {
 			if loc.Volume != volume.ID {
 				t.Fatalf("expected volume ID %v, got %v", volume.ID, loc.Volume)
 			} else if loc.Index != uint64(i) {
@@ -836,6 +824,10 @@ func TestPrune(t *testing.T) {
 			t.Fatal(err)
 		}
 		roots = append(roots, root)
+	}
+	// expire the upload references so only the references added below remain
+	if err := db.ExpireTempSectors(50); err != nil {
+		t.Fatal(err)
 	}
 
 	renterKey := types.NewPrivateKeyFromSeed(frand.Bytes(32))
@@ -946,9 +938,9 @@ func TestPrune(t *testing.T) {
 	}
 	assertSectors(t, 25, roots, nil)
 
-	// prune unreferenced sectors
+	// prune the unreferenced sectors
 	available, deleted := roots[:len(roots)-len(unreferencedSectors)], unreferencedSectors
-	if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
+	if err := db.PruneSectors(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	assertSectors(t, 25, available, deleted)
@@ -957,7 +949,7 @@ func TestPrune(t *testing.T) {
 	resolveContract(t, c1, 100)
 	if err := db.ExpireV2ContractSectors(101); err != nil {
 		t.Fatal(err)
-	} else if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
+	} else if err := db.PruneSectors(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	available, deleted = append(contract2Sectors, tempSectors...), append(deleted, contract1Sectors...)
@@ -966,7 +958,7 @@ func TestPrune(t *testing.T) {
 	// expire the temp sectors
 	if err := db.ExpireTempSectors(101); err != nil {
 		t.Fatal(err)
-	} else if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
+	} else if err := db.PruneSectors(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	available, deleted = contract2Sectors, append(deleted, tempSectors...)
@@ -976,11 +968,181 @@ func TestPrune(t *testing.T) {
 	resolveContract(t, c2, 110)
 	if err := db.ExpireV2ContractSectors(111); err != nil {
 		t.Fatal(err)
-	} else if err := db.PruneSectors(context.Background(), time.Now().Add(time.Hour)); err != nil {
+	} else if err := db.PruneSectors(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	available, deleted = nil, append(deleted, contract2Sectors...)
 	assertSectors(t, 0, available, deleted)
+}
+
+func TestSectorRefCount(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := addTestVolume(db, "test", 3); err != nil {
+		t.Fatal(err)
+	}
+
+	roots := make([]types.Hash256, 3)
+	for i := range roots {
+		roots[i] = frand.Entropy256()
+		if err := db.AddTempSector(roots[i], 50, func(storage.SectorLocation) error { return nil }); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.ExpireTempSectors(50); err != nil {
+		t.Fatal(err)
+	}
+
+	assertRefCounts := func(t *testing.T, expected ...int) {
+		t.Helper()
+		for i, root := range roots {
+			var n int
+			err := db.readerDB.QueryRow(`SELECT ref_count FROM stored_sectors WHERE sector_root=$1`, encode(root)).Scan(&n)
+			if err != nil {
+				t.Fatal(err)
+			} else if n != expected[i] {
+				t.Fatalf("expected ref_count %d for sector %d, got %d", expected[i], i, n)
+			}
+		}
+	}
+	assertRefCounts(t, 0, 0, 0)
+
+	if err := db.AddTempSector(roots[0], 100, func(storage.SectorLocation) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	assertRefCounts(t, 1, 0, 0)
+
+	contract := contracts.V2Contract{
+		ID: frand.Entropy256(),
+		V2FileContract: types.V2FileContract{
+			RevisionNumber: 1,
+		},
+	}
+	if err := db.AddV2Contract(contract, rhp4.TransactionSet{}); err != nil {
+		t.Fatal(err)
+	}
+	revise := func(t *testing.T, oldRoots, newRoots []types.Hash256) {
+		t.Helper()
+		contract.V2FileContract.RevisionNumber++
+		contract.V2FileContract.Filesize = uint64(len(newRoots)) * proto4.SectorSize
+		if err := db.ReviseV2Contract(contract.ID, contract.V2FileContract, oldRoots, newRoots, proto4.Usage{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// append two roots to the contract
+	revise(t, nil, roots[:2])
+	assertRefCounts(t, 2, 1, 0)
+
+	// replace the second root, which updates the existing row in place
+	revise(t, roots[:2], []types.Hash256{roots[0], roots[2]})
+	assertRefCounts(t, 2, 0, 1)
+
+	// trim the contract back to one root
+	revise(t, []types.Hash256{roots[0], roots[2]}, roots[:1])
+	assertRefCounts(t, 2, 0, 0)
+
+	if err := db.ExpireTempSectors(101); err != nil {
+		t.Fatal(err)
+	}
+	assertRefCounts(t, 1, 0, 0)
+
+	// resolve the contract and expire its sectors
+	err = db.transaction(func(tx *txn) error {
+		_, err := tx.Exec(`UPDATE contracts_v2 SET resolution_height=$1, resolution_block_id=$2, contract_status=$3 WHERE contract_id=$4`,
+			100, encode(types.BlockID{}), contracts.V2ContractStatusSuccessful, encode(contract.ID))
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if err := db.ExpireV2ContractSectors(101); err != nil {
+		t.Fatal(err)
+	}
+	// expiry only drops the reference, the sweep removes the sector
+	assertRefCounts(t, 0, 0, 0)
+
+	if err := db.PruneSectors(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	var stored int
+	if err := db.readerDB.QueryRow(`SELECT COUNT(*) FROM stored_sectors`).Scan(&stored); err != nil {
+		t.Fatal(err)
+	} else if stored != 0 {
+		t.Fatalf("expected all sectors pruned, %d remain", stored)
+	}
+}
+
+func TestPruneRepairsRefCount(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := addTestVolume(db, "test", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	root := types.Hash256(frand.Entropy256())
+	if err := db.AddTempSector(root, 100, func(storage.SectorLocation) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	err = db.writeTransaction(func(tx *txn) error {
+		_, err := tx.Exec(`UPDATE stored_sectors SET ref_count=0 WHERE sector_root=$1`, encode(root))
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if err := db.PruneSectors(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if _, err := db.SectorLocation(root); err != nil {
+		t.Fatal(err)
+	}
+	var n int
+	if err := db.readerDB.QueryRow(`SELECT ref_count FROM stored_sectors WHERE sector_root=$1`, encode(root)).Scan(&n); err != nil {
+		t.Fatal(err)
+	} else if n != 1 {
+		t.Fatalf("expected repaired ref_count 1, got %d", n)
+	}
+}
+
+func TestVolumeSectorLocksCleared(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	fp := filepath.Join(t.TempDir(), "test.db")
+	db, err := OpenDatabase(fp, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { db.Close() }()
+
+	if _, err := addTestVolume(db, "test", 1); err != nil {
+		t.Fatal(err)
+	}
+	var locationID int64
+	if err := db.readerDB.QueryRow(`SELECT id FROM volume_sectors LIMIT 1`).Scan(&locationID); err != nil {
+		t.Fatal(err)
+	} else if err := db.writeTransaction(func(tx *txn) error { return lockVolumeSector(tx, locationID) }); err != nil {
+		t.Fatal(err)
+	} else if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err = OpenDatabase(fp, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var locks int
+	if err := db.readerDB.QueryRow(`SELECT COUNT(*) FROM volume_sector_locks`).Scan(&locks); err != nil {
+		t.Fatal(err)
+	} else if locks != 0 {
+		t.Fatalf("expected locks to be cleared, got %d", locks)
+	}
 }
 
 func BenchmarkVolumeGrow(b *testing.B) {
@@ -1050,7 +1212,7 @@ func BenchmarkVolumeMigrate(b *testing.B) {
 	roots := make([]types.Hash256, b.N)
 	for i := range roots {
 		roots[i] = frand.Entropy256()
-		err := db.StoreSector(roots[i], func(loc storage.SectorLocation) error { return nil })
+		err := db.AddTempSector(roots[i], 100, func(loc storage.SectorLocation) error { return nil })
 		if err != nil {
 			b.Fatalf("failed to store sector %v: %v", i, err)
 		}
@@ -1103,7 +1265,7 @@ func BenchmarkStoreSector(b *testing.B) {
 	b.ReportMetric(float64(b.N), "sectors")
 
 	for i := 0; i < b.N; i++ {
-		err := db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation) error { return nil })
+		err := db.AddTempSector(frand.Entropy256(), 100, func(loc storage.SectorLocation) error { return nil })
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -1141,7 +1303,7 @@ func BenchmarkStoreSectorParallel(b *testing.B) {
 			for range nThreads {
 				wg.Go(func() {
 					for range jobs {
-						err := db.StoreSector(frand.Entropy256(), func(loc storage.SectorLocation) error { return nil })
+						err := db.AddTempSector(frand.Entropy256(), 100, func(loc storage.SectorLocation) error { return nil })
 						if err != nil {
 							b.Error(err)
 							return
@@ -1179,7 +1341,7 @@ func BenchmarkReadSector(b *testing.B) {
 	}
 
 	root := frand.Entropy256()
-	err = db.StoreSector(root, func(loc storage.SectorLocation) error { return nil })
+	err = db.AddTempSector(root, 100, func(loc storage.SectorLocation) error { return nil })
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1217,7 +1379,7 @@ func BenchmarkReadSectorParallel(b *testing.B) {
 
 	roots := make([]types.Hash256, 50)
 	for i := range roots {
-		err = db.StoreSector(roots[i], func(loc storage.SectorLocation) error { return nil })
+		err = db.AddTempSector(roots[i], 100, func(loc storage.SectorLocation) error { return nil })
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -1288,7 +1450,7 @@ func BenchmarkPruneSectors(b *testing.B) {
 				root := types.Hash256(frand.Entropy256())
 				roots = append(roots, root)
 
-				if err := db.StoreSector(root, func(loc storage.SectorLocation) error { return nil }); err != nil {
+				if err := db.AddTempSector(root, 100, func(loc storage.SectorLocation) error { return nil }); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -1307,49 +1469,39 @@ func BenchmarkPruneSectors(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			// start after the last retained sector, the position the prune loop
-			// reaches once it has skipped the contract's sectors
-			var afterSectorID int64
-			if err := db.transaction(func(tx *txn) error {
-				return tx.QueryRow(`SELECT COALESCE(MAX(id), 0) FROM stored_sectors`).Scan(&afterSectorID)
-			}); err != nil {
-				b.Fatal(err)
-			}
-
-			// store the prunable sectors after the retained ones
+			// store the prunable sectors
 			prunableRoots := make([]types.Hash256, 0, prunable)
 			for range prunable {
 				root := types.Hash256(frand.Entropy256())
 				prunableRoots = append(prunableRoots, root)
 
-				if err := db.StoreSector(root, func(loc storage.SectorLocation) error { return nil }); err != nil {
+				if err := db.AddTempSector(root, 0, func(loc storage.SectorLocation) error { return nil }); err != nil {
 					b.Fatal(err)
 				}
+			}
+			if err := db.ExpireTempSectors(0); err != nil {
+				b.Fatal(err)
 			}
 
 			if err := cacheTestSubtrees(db, prunableRoots); err != nil {
 				b.Fatal(err)
 			}
 
-			lastAccess := time.Now().Add(time.Hour)
-
 			b.ResetTimer()
 			b.ReportAllocs()
 			b.ReportMetric(float64(retained), "retained")
 
 			for range b.N {
-				var refs []volumeSectorRef
-				err := db.transaction(func(tx *txn) (err error) {
-					refs, err = updatePruneableVolumeSectors(tx, lastAccess, afterSectorID)
+				var n int
+				err := db.writeTransaction(func(tx *txn) (err error) {
+					n, err = pruneSectorBatch(tx, log)
 					return
 				})
 				if err != nil {
 					b.Fatal(err)
-				} else if len(refs) != sqlSectorBatchSize {
-					b.Fatalf("expected to prune %d sectors, pruned %d", sqlSectorBatchSize, len(refs))
+				} else if n == 0 {
+					b.Fatal("expected a batch of sectors to prune")
 				}
-
-				afterSectorID = refs[len(refs)-1].SectorID
 			}
 		})
 	}
@@ -1399,9 +1551,12 @@ func BenchmarkPruneSectorsFullScan(b *testing.B) {
 			root := types.Hash256(frand.Entropy256())
 			roots = append(roots, root)
 
-			if err := db.StoreSector(root, func(loc storage.SectorLocation) error { return nil }); err != nil {
+			if err := db.AddTempSector(root, 50, func(loc storage.SectorLocation) error { return nil }); err != nil {
 				b.Fatal(err)
 			}
+		}
+		if err := db.ExpireTempSectors(50); err != nil {
+			b.Fatal(err)
 		}
 
 		// hold half the sectors in a contract and half in temp storage so
@@ -1418,7 +1573,7 @@ func BenchmarkPruneSectorsFullScan(b *testing.B) {
 		}
 
 		for _, root := range tempRoots {
-			if err := db.AddTempSector(root, 100); err != nil {
+			if err := db.AddTempSector(root, 100, func(storage.SectorLocation) error { return nil }); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -1430,23 +1585,20 @@ func BenchmarkPruneSectorsFullScan(b *testing.B) {
 
 		tablePages := storedSectorsPages(db)
 
-		// a cutoff in the future, so the timestamp filter excludes nothing
-		lastAccess := time.Now().Add(time.Hour)
-
 		b.Run(fmt.Sprintf("sectors=%d", sectors), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ReportMetric(float64(tablePages), "tablePages")
 
 			for range b.N {
-				var refs []volumeSectorRef
-				err := db.transaction(func(tx *txn) (err error) {
-					refs, err = updatePruneableVolumeSectors(tx, lastAccess, 0)
+				var n int
+				err := db.writeTransaction(func(tx *txn) (err error) {
+					n, err = pruneSectorBatch(tx, log)
 					return
 				})
 				if err != nil {
 					b.Fatal(err)
-				} else if len(refs) != 0 {
-					b.Fatalf("expected nothing to prune, got %d sectors", len(refs))
+				} else if n != 0 {
+					b.Fatal("expected nothing to prune")
 				}
 			}
 		})


### PR DESCRIPTION
Switches to a reference counter for sector pruning instead of look-ups and removes the last accessed timestamp. This reduces lockups due to the prune loop and reduces IO during sector reads. Only writes now lock the sector location. This is the same system we used before the v2 changes.