### PR TITLE
Remove the sector cache

### DIFF
--- a/.changeset/remove_sector_cache.md
+++ b/.changeset/remove_sector_cache.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Removed the in-memory sector cache, the sectorCacheSize setting is now ignored

--- a/api/api.go
+++ b/api/api.go
@@ -87,7 +87,6 @@ type (
 		ResizeVolume(ctx context.Context, id int64, maxSectors uint64, result chan<- error) error
 		SetReadOnly(id int64, readOnly bool) error
 		RemoveSector(root types.Hash256) error
-		ResizeCache(size uint32)
 		ReadSector(root types.Hash256, offset, length uint64) ([]byte, []types.Hash256, error)
 
 		// SectorReferences returns the references to a sector

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -265,9 +265,6 @@ func (a *api) handlePATCHSettings(jc jape.Context) {
 		return
 	}
 
-	// Resize the cache based on the updated settings
-	a.volumes.ResizeCache(settings.SectorCacheSize)
-
 	jc.Encode(a.settings.Settings())
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/cloudflare/cloudflare-go v0.118.0
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/mattn/go-sqlite3 v1.14.50
 	github.com/shopspring/decimal v1.4.0
 	go.sia.tech/core v0.21.7

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
-github.com/cloudflare/cloudflare-go v0.117.0 h1:y00E0XCvxuZGplL+gkoMRIhWpfNqIgyBFS6UUWC4s0c=
-github.com/cloudflare/cloudflare-go v0.117.0/go.mod h1:Ds6urDwn/TF2uIU24mu7H91xkKP8gSAHxQ44DSZgVmU=
 github.com/cloudflare/cloudflare-go v0.118.0 h1:pPcgYGPq8wegLoILMelVFKhIk5Vp02M5rf7Fjlal1bc=
 github.com/cloudflare/cloudflare-go v0.118.0/go.mod h1:Ds6urDwn/TF2uIU24mu7H91xkKP8gSAHxQ44DSZgVmU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -18,8 +16,6 @@ github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4r
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
-github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
-github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/host/metrics/types.go
+++ b/host/metrics/types.go
@@ -95,6 +95,7 @@ type (
 		ReadBytes  uint64 `json:"readBytes"`
 		WriteBytes uint64 `json:"writeBytes"`
 
+		// Deprecated: the sector cache was removed and the counters are no longer updated.
 		SectorCacheHits   uint64 `json:"sectorCacheHits"`
 		SectorCacheMisses uint64 `json:"sectorCacheMisses"`
 	}

--- a/host/settings/settings.go
+++ b/host/settings/settings.go
@@ -128,6 +128,7 @@ type (
 		// DNS settings
 		DDNS DNSSettings `json:"ddns"`
 
+		// Deprecated: the sector cache was removed and the value is ignored.
 		SectorCacheSize uint32 `json:"sectorCacheSize"`
 
 		Revision uint64 `json:"revision"`

--- a/host/storage/options.go
+++ b/host/storage/options.go
@@ -23,13 +23,6 @@ func WithAlerter(a Alerts) VolumeManagerOption {
 	}
 }
 
-// WithCacheSize sets the sector cache size for the manager.
-func WithCacheSize(cacheSize int) VolumeManagerOption {
-	return func(s *VolumeManager) {
-		s.cacheSize = cacheSize
-	}
-}
-
 // WithPruneInterval sets the time between cleaning up dereferenced
 // sectors.
 func WithPruneInterval(d time.Duration) VolumeManagerOption {

--- a/host/storage/recorder.go
+++ b/host/storage/recorder.go
@@ -17,9 +17,6 @@ type (
 
 		ReadBytes  uint64
 		WriteBytes uint64
-
-		CacheHit  uint64
-		CacheMiss uint64
 	}
 
 	sectorAccessRecorder struct {
@@ -61,18 +58,6 @@ func (sr *sectorAccessRecorder) AddWrite(n uint64) {
 
 	sr.metrics.WriteCount++
 	sr.metrics.WriteBytes += n
-}
-
-func (sr *sectorAccessRecorder) AddCacheHit() {
-	sr.mu.Lock()
-	defer sr.mu.Unlock()
-	sr.metrics.CacheHit++
-}
-
-func (sr *sectorAccessRecorder) AddCacheMiss() {
-	sr.mu.Lock()
-	defer sr.mu.Unlock()
-	sr.metrics.CacheMiss++
 }
 
 // Run starts the recorder, flushing data at regular intervals.

--- a/host/storage/storage.go
+++ b/host/storage/storage.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	proto2 "go.sia.tech/core/rhp/v2"
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -82,10 +80,7 @@ type (
 
 	// A VolumeManager manages storage using local volumes.
 	VolumeManager struct {
-		cacheHits          uint64 // ensure 64-bit alignment on 32-bit systems
-		cacheMisses        uint64
 		merkleCacheEnabled bool
-		cacheSize          int
 		pruneInterval      time.Duration
 
 		vs       VolumeStore
@@ -97,7 +92,6 @@ type (
 
 		mu      sync.Mutex // protects the following fields
 		volumes map[int64]*volume
-		cache   *lru.Cache[types.Hash256, *[proto2.SectorSize]byte] // Added cache
 	}
 )
 
@@ -371,8 +365,6 @@ func (vm *VolumeManager) writeSector(root types.Hash256, data *[proto4.SectorSiz
 		}
 		vm.log.Debug("wrote sector", zap.String("root", root.String()), zap.Int64("volume", loc.Volume), zap.Uint64("index", loc.Index), zap.Duration("elapsed", time.Since(start)))
 
-		// Add newly written sector to cache
-		vm.cache.Add(root, data)
 		return vol.Sync()
 	})
 	if errors.Is(err, ErrNotEnoughStorage) {
@@ -902,15 +894,7 @@ func (vm *VolumeManager) RemoveSector(root types.Hash256) error {
 	} else if err := vol.Sync(); err != nil {
 		return fmt.Errorf("failed to sync volume %v: %w", loc.Volume, err)
 	}
-
-	// eject the sector from the cache
-	vm.cache.Remove(root)
 	return nil
-}
-
-// CacheStats returns the number of cache hits and misses.
-func (vm *VolumeManager) CacheStats() (hits, misses uint64) {
-	return atomic.LoadUint64(&vm.cacheHits), atomic.LoadUint64(&vm.cacheMisses)
 }
 
 func (vm *VolumeManager) readLocation(loc SectorLocation, offset, length uint64) ([]byte, error) {
@@ -938,13 +922,6 @@ func (vm *VolumeManager) readLocation(loc SectorLocation, offset, length uint64)
 			Timestamp: time.Now(),
 		})
 		return nil, fmt.Errorf("failed to read sector data: %w", err)
-	}
-
-	if length == proto4.SectorSize {
-		// only add full sectors to the cache
-		vm.cache.Add(loc.Root, (*[proto4.SectorSize]byte)(sector))
-		atomic.AddUint64(&vm.cacheMisses, 1)
-		vm.recorder.AddCacheMiss()
 	}
 	return sector, nil
 }
@@ -1113,12 +1090,6 @@ func (vm *VolumeManager) StoreSector(root types.Hash256, data *[proto4.SectorSiz
 	return nil
 }
 
-// ResizeCache resizes the cache to the given size.
-func (vm *VolumeManager) ResizeCache(size uint32) {
-	// Resize the underlying cache data structure
-	vm.cache.Resize(int(size))
-}
-
 // ProcessActions processes the actions for the given chain index.
 func (vm *VolumeManager) ProcessActions(index types.ChainIndex) error {
 	done, err := vm.tg.Add()
@@ -1133,7 +1104,6 @@ func (vm *VolumeManager) ProcessActions(index types.ChainIndex) error {
 // NewVolumeManager creates a new VolumeManager.
 func NewVolumeManager(vs VolumeStore, opts ...VolumeManagerOption) (*VolumeManager, error) {
 	vm := &VolumeManager{
-		cacheSize:          32, // 128 MiB
 		pruneInterval:      5 * time.Minute,
 		merkleCacheEnabled: true,
 		vs:                 vs,
@@ -1172,16 +1142,6 @@ func NewVolumeManager(vs VolumeStore, opts ...VolumeManagerOption) (*VolumeManag
 			}
 		}
 	}()
-
-	// Initialize cache with LRU eviction and a max capacity of 64
-	cache, err := lru.New[types.Hash256, *[proto2.SectorSize]byte](64)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize cache: %w", err)
-	}
-	// resize the cache, prevents an error in lru.New when initializing the
-	// cache to 0
-	cache.Resize(int(vm.cacheSize))
-	vm.cache = cache
 
 	vm.recorder = &sectorAccessRecorder{
 		store: vs,

--- a/host/storage/storage_test.go
+++ b/host/storage/storage_test.go
@@ -1362,7 +1362,7 @@ func TestStoragePrune(t *testing.T) {
 	defer db.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, storage.WithLogger(log.Named("volumes")), storage.WithCacheSize(0), storage.WithPruneInterval(500*time.Millisecond))
+	vm, err := storage.NewVolumeManager(db, storage.WithLogger(log.Named("volumes")), storage.WithPruneInterval(500*time.Millisecond))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1447,7 +1447,7 @@ func TestMerkleCacheDisable(t *testing.T) {
 	defer db.Close()
 
 	// initialize the storage manager
-	vm, err := storage.NewVolumeManager(db, storage.WithLogger(log.Named("volumes")), storage.WithCacheSize(0), storage.WithMerkleCacheEnabled(false), storage.WithPruneInterval(500*time.Millisecond))
+	vm, err := storage.NewVolumeManager(db, storage.WithLogger(log.Named("volumes")), storage.WithMerkleCacheEnabled(false), storage.WithPruneInterval(500*time.Millisecond))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1512,7 +1512,6 @@ func TestReadSectorCorrupt(t *testing.T) {
 		am := alerts.NewManager()
 		vm, err := storage.NewVolumeManager(db,
 			storage.WithLogger(log.Named("volumes")),
-			storage.WithCacheSize(0),
 			storage.WithMerkleCacheEnabled(cacheEnabled),
 			storage.WithAlerter(am),
 		)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1401,7 +1401,8 @@ components:
         sectorCacheSize:
           type: integer
           format: int64
-          description: Number of sectors to cache in memory for faster reads.
+          deprecated: true
+          description: Deprecated. The sector cache was removed and the value is ignored.
         revision:
           type: integer
           format: int64
@@ -1656,11 +1657,13 @@ components:
         sectorCacheHits:
           type: integer
           format: int64
-          description: Number of sector reads served from the in-memory cache.
+          deprecated: true
+          description: Deprecated. The sector cache was removed and the counter is no longer updated.
         sectorCacheMisses:
           type: integer
           format: int64
-          description: Number of sector reads that required disk access.
+          deprecated: true
+          description: Deprecated. The sector cache was removed and the counter is no longer updated.
       required:
         - totalSectors
         - physicalSectors

--- a/persist/sqlite/metrics.go
+++ b/persist/sqlite/metrics.go
@@ -295,10 +295,6 @@ func (s *Store) IncrementSectorMetrics(metrics storage.SectorMetrics) error {
 			return fmt.Errorf("failed to track reads: %w", err)
 		} else if err := increment(metricSectorWrites, int(metrics.WriteCount)); err != nil {
 			return fmt.Errorf("failed to track writes: %w", err)
-		} else if err := increment(metricSectorCacheHit, int(metrics.CacheHit)); err != nil {
-			return fmt.Errorf("failed to track cache hits: %w", err)
-		} else if err := increment(metricSectorCacheMiss, int(metrics.CacheMiss)); err != nil {
-			return fmt.Errorf("failed to track cache misses: %w", err)
 		} else if err := increment(metricSectorReadBytes, int(metrics.ReadBytes)); err != nil {
 			return fmt.Errorf("failed to track read bytes: %w", err)
 		} else if err := increment(metricSectorWriteBytes, int(metrics.WriteBytes)); err != nil {


### PR DESCRIPTION
The sector cache was mostly cache misses due to partial reads being the primary way renters read data and added unnecessary memory and db overhead. We may re-add it in the future, but for now we're removing it. The setting is there, but documented as unused.